### PR TITLE
fix: replace handmade routing with link navigation between variant pages

### DIFF
--- a/web/src/components/ClusterButtonPanel/ClusterButton.tsx
+++ b/web/src/components/ClusterButtonPanel/ClusterButton.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable camelcase */
-import React, { useMemo } from 'react'
+import React from 'react'
 
-import { Button, Col } from 'reactstrap'
+import { Col } from 'reactstrap'
 import { ClusterDatum } from 'src/io/getClusters'
 import styled from 'styled-components'
+import { Link } from '../Link/Link'
 
 const ClusterCol = styled(Col)`
   display: flex;
@@ -30,7 +31,7 @@ const ClusterCol = styled(Col)`
   }
 `
 
-const ClusterButtonComponent = styled(Button)<{ $isCurrent: boolean; $color: string }>`
+const ClusterButtonComponent = styled(Link)<{ $isCurrent: boolean; $color: string }>`
   width: 100%;
 
   display: flex;
@@ -57,10 +58,12 @@ const ClusterButtonComponent = styled(Button)<{ $isCurrent: boolean; $color: str
 
   background-color: ${({ $isCurrent, theme }) => ($isCurrent ? theme.white : theme.gray100)};
 
+  text-decoration: none;
+
   &:active,
   &:focus,
   &:hover {
-    background-color: ${({ $isCurrent, theme }) => ($isCurrent ? theme.white : theme.gray100)};
+    text-decoration: none;
   }
 `
 
@@ -87,17 +90,15 @@ const ClusterTitle = styled.h1<{ $isCurrent: boolean }>`
 
 export interface ClusterButtonProps {
   cluster: ClusterDatum
-  onClick(cluster: string): void
   isCurrent: boolean
 }
 
-export function ClusterButton({ cluster, onClick, isCurrent }: ClusterButtonProps) {
+export function ClusterButton({ cluster, isCurrent }: ClusterButtonProps) {
   const { display_name, col } = cluster
-  const handleClick = useMemo(() => () => onClick(display_name), [display_name, onClick])
 
   return (
-    <ClusterCol>
-      <ClusterButtonComponent color="transparent" onClick={handleClick} $isCurrent={isCurrent} $color={col}>
+    <ClusterCol tag="span">
+      <ClusterButtonComponent href={`/variants/${cluster.build_name}`} $isCurrent={isCurrent} $color={col}>
         <ClusterTitle $isCurrent={isCurrent}>{display_name}</ClusterTitle>
       </ClusterButtonComponent>
     </ClusterCol>

--- a/web/src/components/ClusterButtonPanel/ClusterButtonPanel.tsx
+++ b/web/src/components/ClusterButtonPanel/ClusterButtonPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React from 'react'
 
 import { Row } from 'reactstrap'
 import { ClusterDatum } from 'src/io/getClusters'
@@ -14,19 +14,15 @@ export interface ClusterPanelProps {
   clusters: ClusterDatum[]
   currentCluster?: ClusterDatum
   className?: string
-  switchCluster?(cluster: ClusterDatum): void
 }
 
-export function ClusterButtonPanel({ clusters, currentCluster, switchCluster, className }: ClusterPanelProps) {
-  const handleSwitchCluster = useCallback((cluster: ClusterDatum) => () => switchCluster?.(cluster), [switchCluster])
-
+export function ClusterButtonPanel({ clusters, currentCluster, className }: ClusterPanelProps) {
   return (
     <ClustersRow noGutters className={className}>
-      {clusters.map((cluster, index) => (
+      {clusters.map((cluster) => (
         <ClusterButton
           key={cluster.display_name}
           cluster={cluster}
-          onClick={handleSwitchCluster(cluster)}
           isCurrent={cluster.display_name === currentCluster?.display_name}
         />
       ))}

--- a/web/src/components/Home/HomePage.tsx
+++ b/web/src/components/Home/HomePage.tsx
@@ -1,11 +1,9 @@
-import React, { useCallback } from 'react'
+import React from 'react'
 
-import { replace } from 'connected-next-router'
-import { connect } from 'react-redux'
 import { Col, Row } from 'reactstrap'
 import { VariantsPageContainer } from 'src/components/Common/ClusterSidebarLayout'
 
-import { ClusterDatum, getClusters } from 'src/io/getClusters'
+import { getClusters } from 'src/io/getClusters'
 
 import { ClusterButtonPanel } from 'src/components/ClusterButtonPanel/ClusterButtonPanel'
 import { Editable } from 'src/components/Common/Editable'
@@ -15,26 +13,7 @@ import HomeContent from '../../../../content/Home.md'
 
 const clusters = getClusters()
 
-const mapStateToProps = null
-
-const mapDispatchToProps = {
-  routerReplace: replace,
-}
-
-export const HomePage = connect(mapStateToProps, mapDispatchToProps)(HomePageDisconnected)
-
-export interface HomePagePageProps {
-  routerReplace(url: string): void
-}
-
-export function HomePageDisconnected({ routerReplace }: HomePagePageProps) {
-  const switchCluster = useCallback(
-    (cluster: ClusterDatum) => {
-      routerReplace(`/variants/${cluster.build_name}`)
-    },
-    [routerReplace],
-  )
-
+export function HomePage() {
   return (
     <Layout>
       <VariantsPageContainer fluid>
@@ -46,7 +25,7 @@ export function HomePageDisconnected({ routerReplace }: HomePagePageProps) {
 
         <Row noGutters>
           <Col lg={3} xl={2}>
-            <ClusterButtonPanel clusters={clusters} switchCluster={switchCluster} />
+            <ClusterButtonPanel clusters={clusters} />
           </Col>
 
           <Col lg={9} xl={10}>

--- a/web/src/components/Variants/VariantsPage.tsx
+++ b/web/src/components/Variants/VariantsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React from 'react'
 
 import { connect } from 'react-redux'
 import { replace } from 'connected-next-router'
@@ -20,7 +20,6 @@ import { ReactComponent as NextstrainIconBase } from 'src/assets/images/nextstra
 import { PlotCard } from './PlotCard'
 import { ProteinCard } from './ProteinCard'
 import { ClusterContentLoading } from './ClusterContentLoading'
-import { Link } from '../Link/Link'
 
 const EditableClusterContent = styled(Editable)``
 

--- a/web/src/components/Variants/VariantsPage.tsx
+++ b/web/src/components/Variants/VariantsPage.tsx
@@ -20,6 +20,7 @@ import { ReactComponent as NextstrainIconBase } from 'src/assets/images/nextstra
 import { PlotCard } from './PlotCard'
 import { ProteinCard } from './ProteinCard'
 import { ClusterContentLoading } from './ClusterContentLoading'
+import { Link } from '../Link/Link'
 
 const EditableClusterContent = styled(Editable)``
 
@@ -52,28 +53,14 @@ const mapDispatchToProps = {
 export const VariantsPage = connect(mapStateToProps, mapDispatchToProps)(VariantsPageDisconnected)
 
 export interface VariantsPageBaseProps {
-  defaultCluster: ClusterDatum
+  currentCluster: ClusterDatum
 }
 
 export interface VariantsPageProps extends VariantsPageBaseProps {
   routerReplace(url: string): void
 }
 
-export function VariantsPageDisconnected({ defaultCluster, routerReplace }: VariantsPageProps) {
-  const [currentCluster, setCurrentCluster] = useState(defaultCluster)
-
-  const switchCluster = useCallback(
-    (cluster: ClusterDatum) => {
-      routerReplace(`/variants/${cluster.build_name}`)
-      setCurrentCluster(cluster)
-    },
-    [routerReplace],
-  )
-
-  useEffect(() => {
-    routerReplace(`/variants/${defaultCluster.build_name}`)
-  }, [defaultCluster.build_name, routerReplace])
-
+export function VariantsPageDisconnected({ currentCluster }: VariantsPageProps) {
   const ClusterContent = getClusterContent(currentCluster.build_name)
 
   return (
@@ -94,7 +81,7 @@ export function VariantsPageDisconnected({ defaultCluster, routerReplace }: Vari
 
         <Row noGutters>
           <Col lg={3} xl={2}>
-            <ClusterButtonPanel clusters={clusters} currentCluster={currentCluster} switchCluster={switchCluster} />
+            <ClusterButtonPanel clusters={clusters} currentCluster={currentCluster} />
           </Col>
 
           <Col lg={9} xl={10}>

--- a/web/src/pages/variants/[clusterName].tsx
+++ b/web/src/pages/variants/[clusterName].tsx
@@ -15,10 +15,9 @@ export async function getStaticProps(
 ): Promise<GetStaticPropsResult<VariantsPageBaseProps>> {
   const clusterName = takeFirstMaybe(get(context?.params, 'clusterName'))
   const defaultCluster = clusters.find(({ build_name }) => clusterName === build_name) ?? DEFAULT_CLUSTER
-
   return {
     props: {
-      defaultCluster,
+      currentCluster: defaultCluster,
     },
   }
 }

--- a/web/src/pages/variants/index.tsx
+++ b/web/src/pages/variants/index.tsx
@@ -6,5 +6,5 @@ import { VariantsPage } from 'src/components/Variants/VariantsPage'
 const defaultCluster = getDefaultCluster()
 
 export default function Impl() {
-  return <VariantsPage defaultCluster={defaultCluster} />
+  return <VariantsPage currentCluster={defaultCluster} />
 }


### PR DESCRIPTION
This simplifies code and fixes broken navigation to `/variant/<name>` pages