### PR TITLE
Acknowledge contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -6,8 +6,80 @@
   ],
   "imageSize": 100,
   "contributorsSortAlphabetically": true,
-  "skipCi": true,
-  "contributors": [],
+  "skipCi": false,
+  "contributors": [
+    {
+      "login": "ivan-aksamentov",
+      "name": "Ivan Aksamentov",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/9403403?v=4",
+      "profile": "https://github.com/ivan-aksamentov",
+      "contributions": [
+        "code",
+        "infra",
+        "doc",
+        "design"
+      ]
+    },
+    {
+      "login": "rneher",
+      "name": "Richard Neher",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/8379168?v=4",
+      "profile": "https://github.com/rneher",
+      "contributions": [
+        "code",
+        "data",
+        "content"
+      ]
+    },
+    {
+      "login": "jameshadfield",
+      "name": "james hadfield",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/8350992?v=4",
+      "profile": "https://twitter.com/hamesjadfield",
+      "contributions": [
+        "code",
+        "design",
+        "doc"
+      ]
+    },
+    {
+      "login": "moirazuber",
+      "name": "Moira Zuber",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/48066606?v=4",
+      "profile": "https://github.com/MoiraZuber",
+      "contributions": [
+        "code",
+        "data"
+      ]
+    },
+    {
+      "login": "jbloom",
+      "name": "Jesse Bloom",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/1906801?v=4",
+      "profile": "https://research.fhcrc.org/bloom/en.html",
+      "contributions": [
+        "content"
+      ]
+    },
+    {
+      "login": "corneliusroemer",
+      "name": "Cornelius Roemer",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/25161793?v=4",
+      "profile": "https://github.com/corneliusroemer",
+      "contributions": [
+        "content"
+      ]
+    },
+    {
+      "login": "theosanderson",
+      "name": "Theo Sanderson",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/19732295?v=4",
+      "profile": "http://theo.io/",
+      "contributions": [
+        "content"
+      ]
+    }
+  ],
   "repoType": "github",
   "contributorsPerLine": 4,
   "repoHost": "https://github.com",

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,15 @@
+{
+  "projectName": "covariants",
+  "projectOwner": "hodcroftlab",
+  "files": [
+    "new-readme.md"
+  ],
+  "imageSize": 100,
+  "contributorsSortAlphabetically": true,
+  "skipCi": true,
+  "contributors": [],
+  "repoType": "github",
+  "contributorsPerLine": 4,
+  "repoHost": "https://github.com",
+  "commitConvention": "angular"
+}

--- a/web/config/next/next.config.ts
+++ b/web/config/next/next.config.ts
@@ -22,6 +22,7 @@ import getWithLodash from './withLodash'
 // import getWithStaticComprression from './webpackCompression'
 import getWithTypeChecking from './withTypeChecking'
 import withRaw from './withRaw'
+import withJson from './withJson'
 import withSvg from './withSvg'
 import withImages from './withImages'
 import withIgnore from './withIgnore'
@@ -66,7 +67,7 @@ console.info(`Client-side Environment:\n${JSON.stringify(clientEnv, null, 2)}`)
 
 const nextConfig: NextConfig = {
   distDir: `.build/${process.env.NODE_ENV}/tmp`,
-  pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],
+  pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx', 'all-contributorsrc'],
   onDemandEntries: {
     maxInactiveAge: 60 * 1000,
     pagesBufferLength: 2,
@@ -190,6 +191,7 @@ const config = withPlugins(
     [withSvg],
     [withImages],
     [withRaw],
+    [withJson],
     // ANALYZE && [withBundleAnalyzer],
     [withFriendlyConsole],
     [withMDX],

--- a/web/config/next/withJson.ts
+++ b/web/config/next/withJson.ts
@@ -1,0 +1,14 @@
+import type { NextConfig } from 'next'
+
+import { addWebpackLoader } from './lib/addWebpackLoader'
+
+export default function withJson(nextConfig: NextConfig) {
+  return addWebpackLoader(nextConfig, (webpackConfig, { dev }) => ({
+    test: /\.(all-contributorsrc)$/i,
+    use: [
+      {
+        loader: 'json-loader',
+      },
+    ],
+  }))
+}

--- a/web/package.json
+++ b/web/package.json
@@ -244,6 +244,7 @@
     "jest-transformer-mdx": "2.2.0",
     "jest-watch-typeahead": "0.6.0",
     "js-yaml": "3.14.0",
+    "json-loader": "0.5.7",
     "lodash-webpack-plugin": "0.11.5",
     "map.prototype.tojson": "0.1.3",
     "next-transpile-modules": "4.1.0",

--- a/web/src/components/Common/TeamCredits.tsx
+++ b/web/src/components/Common/TeamCredits.tsx
@@ -2,9 +2,13 @@ import React from 'react'
 
 import { Col, Row } from 'reactstrap'
 import styled from 'styled-components'
+import { FaGithub, FaTwitter } from 'react-icons/fa'
 
 import { LinkExternal } from 'src/components/Link/LinkExternal'
-import { FaGithub, FaTwitter } from 'react-icons/fa'
+import { TeamCreditsContributor } from 'src/components/Common/TeamCreditsContributor'
+import { getContributors } from 'src/io/getContributors'
+
+const contributors = getContributors()
 
 const Flex = styled.section`
   display: flex;
@@ -35,7 +39,7 @@ const NameText = styled.h2`
   font-size: 1.1rem;
 `
 
-const AfilliationText = styled.small`
+const AffiliationText = styled.small`
   font-size: 0.8rem;
 `
 
@@ -43,6 +47,16 @@ const Portrait = styled.img`
   margin: 0 auto;
   width: 100px;
   border-radius: 100px;
+`
+
+const FlexContributors = styled.section`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
+
+  width: 100%;
+  margin: 10px auto;
 `
 
 const mainLinks = [
@@ -75,8 +89,8 @@ export function TeamCredits() {
             <Flex>
               <Portrait src="https://avatars3.githubusercontent.com/u/14290674?s=400&u=e074280fd3dd9a9b0e583af5f17d3a69f3068f8b&v=4" />
               <NameText>{'Emma Hodcroft, PhD'}</NameText>
-              <AfilliationText>{'Institute of Social and Preventive Medicine'}</AfilliationText>
-              <AfilliationText>{'University of Bern, Bern, Switzerland'}</AfilliationText>
+              <AffiliationText>{'Institute of Social and Preventive Medicine'}</AffiliationText>
+              <AffiliationText>{'University of Bern, Bern, Switzerland'}</AffiliationText>
 
               <Ul>
                 {mainLinks.map(({ title, url, alt, icon }) => (
@@ -88,6 +102,16 @@ export function TeamCredits() {
                 ))}
               </Ul>
             </Flex>
+          </Col>
+        </Row>
+
+        <Row noGutters>
+          <Col>
+            <FlexContributors>
+              {contributors.map((contributor) => (
+                <TeamCreditsContributor key={contributor.login} contributor={contributor} />
+              ))}
+            </FlexContributors>
           </Col>
         </Row>
       </Col>

--- a/web/src/components/Common/TeamCreditsContributor.tsx
+++ b/web/src/components/Common/TeamCreditsContributor.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 
+import type { ContributorData } from 'src/../../.all-contributorsrc'
 import { LinkExternal as LinkExternalBase } from 'src/components/Link/LinkExternal'
 
-import type { ContributorData } from 'src/io/getContributors'
 import styled from 'styled-components'
 
 const FlexOuter = styled.section`

--- a/web/src/components/Common/TeamCreditsContributor.tsx
+++ b/web/src/components/Common/TeamCreditsContributor.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+
+import { LinkExternal as LinkExternalBase } from 'src/components/Link/LinkExternal'
+
+import type { ContributorData } from 'src/io/getContributors'
+import styled from 'styled-components'
+
+const FlexOuter = styled.section`
+  display: flex;
+  flex-direction: column;
+  padding: 10px;
+`
+
+const FlexInner = styled.section`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  flex: 1 0 60px;
+  padding: 10px;
+`
+
+const LinkExternal = styled(LinkExternalBase)`
+  margin: 0 auto;
+
+  text-align: center;
+  color: ${(props) => props.theme.gray650};
+
+  &:hover {
+    color: ${(props) => props.theme.gray650};
+    text-decoration: none;
+  }
+`
+
+const Portrait = styled.img`
+  margin: auto;
+  width: 50px;
+  border-radius: 50px;
+`
+
+const NameText = styled.h2`
+  font-size: 0.8rem;
+`
+
+export interface ContributorProps {
+  contributor: ContributorData
+}
+
+export function TeamCreditsContributor({ contributor }: ContributorProps) {
+  return (
+    <FlexOuter>
+      <FlexInner>
+        <LinkExternal title={contributor.name} href={contributor.profile} alt={contributor.profile} icon={null}>
+          <Portrait src={contributor.avatar_url} />
+          <NameText>{contributor.name}</NameText>
+        </LinkExternal>
+      </FlexInner>
+    </FlexOuter>
+  )
+}

--- a/web/src/io/getContributors.ts
+++ b/web/src/io/getContributors.ts
@@ -1,0 +1,16 @@
+/* eslint-disable camelcase */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { contributors } from 'src/../../.all-contributorsrc'
+
+export interface ContributorData {
+  login: string
+  name: string
+  avatar_url: string
+  profile: string
+  contributions: string[]
+}
+
+export function getContributors(): ContributorData[] {
+  return contributors
+}

--- a/web/src/io/getContributors.ts
+++ b/web/src/io/getContributors.ts
@@ -1,16 +1,5 @@
-/* eslint-disable camelcase */
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import { contributors } from 'src/../../.all-contributorsrc'
-
-export interface ContributorData {
-  login: string
-  name: string
-  avatar_url: string
-  profile: string
-  contributions: string[]
-}
+import allContributors, { ContributorData } from 'src/../../.all-contributorsrc'
 
 export function getContributors(): ContributorData[] {
-  return contributors
+  return allContributors.contributors
 }

--- a/web/src/types/all-contributorsrc.d.ts
+++ b/web/src/types/all-contributorsrc.d.ts
@@ -1,0 +1,13 @@
+/* eslint-disable camelcase */
+declare module '*.all-contributorsrc' {
+  export interface ContributorData {
+    login: string
+    name: string
+    avatar_url: string
+    profile: string
+    contributions: string[]
+  }
+
+  const json: { contributors: ContributorData[] }
+  export default json
+}

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -8196,6 +8196,11 @@ json-buffer@3.0.0:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
   integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
 
+json-loader@0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
+  integrity sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==
+
 json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"


### PR DESCRIPTION
This adds avatars of contributors to the footer of the app.


Uses all-contributors to automate the process.
When readme is finalized we could also add those to the readme.

The list is stored here:
https://github.com/hodcroftlab/covariants/blob/feat/contribs/.all-contributorsrc


## Maintenance

### Install all-contributors

```
npm install -g all-contributors-cli
```

### Show committers that are not in the list
```
all-contributors check
```

### Add new contributors:

```
all-contributors add <github_username> <contribution1>,<contribution2>,...
```
For example:

```
all-contributors add ivan-aksamentov code,design,infra,doc
```

### Update the table in readme
(in the future, the readme does not contain the contributors section yet)

```
all-contributors generate
```

List of types of contributions:
https://allcontributors.org/docs/en/emoji-key

