### PR TITLE
Avoid content blinking on variants pages

### DIFF
--- a/web/src/components/Variants/VariantsPage.tsx
+++ b/web/src/components/Variants/VariantsPage.tsx
@@ -6,10 +6,10 @@ import { ClusterButtonPanel } from 'src/components/ClusterButtonPanel/ClusterBut
 import { DefiningMutations, hasDefiningMutations } from 'src/components/Variants/DefiningMutations'
 import styled from 'styled-components'
 import { Col, Row } from 'reactstrap'
-import dynamic from 'next/dynamic'
 
 import { theme } from 'src/theme'
 import { ClusterDatum, getClusters } from 'src/io/getClusters'
+import { getClusterContent } from 'src/io/getClusterContent'
 import { LinkExternal } from 'src/components/Link/LinkExternal'
 import { Layout } from 'src/components/Layout/Layout'
 import { Editable } from 'src/components/Common/Editable'
@@ -19,7 +19,6 @@ import { ReactComponent as NextstrainIconBase } from 'src/assets/images/nextstra
 
 import { PlotCard } from './PlotCard'
 import { ProteinCard } from './ProteinCard'
-import { ClusterContentLoading } from './ClusterContentLoading'
 
 const EditableClusterContent = styled(Editable)``
 
@@ -37,9 +36,6 @@ const NextstrainIcon = styled(NextstrainIconBase)`
   width: 25px;
   height: 25px;
 `
-
-const getClusterContent = (cluster: string) =>
-  dynamic(() => import(`../../../../content/clusters/${cluster}.md`), { ssr: true, loading: ClusterContentLoading })
 
 const clusters = getClusters()
 

--- a/web/src/io/getClusterContent.ts
+++ b/web/src/io/getClusterContent.ts
@@ -1,0 +1,6 @@
+import type { ComponentType } from 'react'
+
+export function getClusterContent(cluster: string) {
+  // eslint-disable-next-line global-require,import/no-dynamic-require,security/detect-non-literal-require,@typescript-eslint/no-var-requires,@typescript-eslint/no-unsafe-member-access
+  return require(`src/../../../content/clusters/${cluster}.md`).default as ComponentType
+}


### PR DESCRIPTION
This turns Next.js `dynamic()` `import`s into static `require`s. This way, the markdown content on variants pages is rendered statically, and there is no blink of empty content and no page reflow when switching variants.

The variants pages should feel more responsive and seamless.

