### PR TITLE
Improve mutation badges

### DIFF
--- a/web/src/components/Common/MdxComponents.tsx
+++ b/web/src/components/Common/MdxComponents.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 
+import { AaMut, NucMut, Var } from 'src/components/Common/MutationBadge'
 import { LinkSmart } from 'src/components/Link/LinkSmart'
 
 export const Pre = styled.pre`
@@ -19,4 +20,7 @@ export const Pre = styled.pre`
 export const mdxComponents = {
   a: LinkSmart,
   pre: Pre,
+  AaMut,
+  NucMut,
+  Var,
 }

--- a/web/src/components/Common/MutationBadge.tsx
+++ b/web/src/components/Common/MutationBadge.tsx
@@ -202,7 +202,7 @@ export function VariantLinkBadge({ name, href }: VariantLinkBadgeProps) {
   }
 
   return (
-    <LinkUnstyled href={url ?? ''} icon={null}>
+    <LinkUnstyled href={url} icon={null}>
       <MutationBadge mutation={mutationObj} colors={AMINOACID_COLORS} />
     </LinkUnstyled>
   )

--- a/web/src/components/Common/MutationBadge.tsx
+++ b/web/src/components/Common/MutationBadge.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+/* eslint-disable camelcase */
+import React, { useMemo } from 'react'
 
 import { get } from 'lodash'
 import styled from 'styled-components'
@@ -6,8 +7,14 @@ import styled from 'styled-components'
 import type { Mutation, MutationColors } from 'src/types'
 import { theme } from 'src/theme'
 import { AMINOACID_COLORS, GENE_COLORS, NUCLEOTIDE_COLORS } from 'src/colors'
+import { getClusterNames, getClusters } from 'src/io/getClusters'
+import { LinkSmart } from 'src/components/Link/LinkSmart'
 import { parseAminoacidMutation } from 'src/components/Common/parseAminoacidMutation'
 import { parseNucleotideMutation } from 'src/components/Common/parseNucleotideMutation'
+import { formatMutation } from 'src/components/Common/formatMutation'
+
+const clusters = getClusters()
+const clusterNames = getClusterNames()
 
 const DEFAULT_COLOR = theme.gray700
 
@@ -67,6 +74,38 @@ export function aminoacidMutationFromStringMaybe(mutation: Mutation | string): M
   return mutation
 }
 
+export function formatMutationMaybe(mutation: Mutation | string) {
+  if (typeof mutation === 'string') {
+    return mutation
+  }
+  return formatMutation(mutation)
+}
+
+export function aminoacidMutationToObjectAndString(mutation: Mutation | string) {
+  let mutationObj: Mutation | undefined
+  let mutationStr: string | undefined
+
+  if (typeof mutation === 'string') {
+    mutationObj = aminoacidMutationFromStringMaybe(mutation)
+    mutationStr = mutation
+  } else {
+    mutationObj = mutation
+    mutationStr = formatMutation(mutation)
+  }
+
+  return { mutationObj, mutationStr }
+}
+
+export function formatVariantUrl(mutation: string) {
+  const cluster = clusters.find(({ display_name }) => display_name === mutation)
+  if (!cluster) {
+    console.warn(`Variant not recognized: ${mutation}. Known variants: ${clusterNames.join(', ')}`)
+    return undefined
+  }
+
+  return `/variants/${cluster.build_name}`
+}
+
 export interface MutationBadgeProps {
   mutation: Mutation
   colors: MutationColors
@@ -76,8 +115,8 @@ export function MutationBadge({ mutation, colors }: MutationBadgeProps) {
   const { gene, left, pos, right, note } = mutation
 
   const geneColor = get(GENE_COLORS, gene ?? '', DEFAULT_COLOR)
-  const leftColor = get(colors, left, DEFAULT_COLOR)
-  const rightColor = get(colors, right, DEFAULT_COLOR)
+  const leftColor = get(colors, left ?? '', DEFAULT_COLOR)
+  const rightColor = get(colors, right ?? '', DEFAULT_COLOR)
 
   return (
     <MutationBadgeBox>
@@ -90,9 +129,9 @@ export function MutationBadge({ mutation, colors }: MutationBadgeProps) {
             </GeneText>
           </>
         )}
-        <ColoredText $color={leftColor}>{left}</ColoredText>
+        {left && <ColoredText $color={leftColor}>{left}</ColoredText>}
         <PositionText>{pos}</PositionText>
-        <ColoredText $color={rightColor}>{right}</ColoredText>
+        {right && <ColoredText $color={rightColor}>{right}</ColoredText>}
       </MutationWrapper>
       {note && <span>{note}</span>}
     </MutationBadgeBox>
@@ -123,4 +162,63 @@ export function AminoacidMutationBadge({ mutation }: AminoacidMutationBadgeProps
   }
 
   return <MutationBadge mutation={mutationObj} colors={AMINOACID_COLORS} />
+}
+
+export const LinkUnstyled = styled(LinkSmart)`
+  color: unset;
+  text-decoration: none;
+
+  &:active,
+  &:focus,
+  &:hover {
+    color: unset;
+    text-decoration: none;
+  }
+`
+
+export interface VariantLinkBadgeProps {
+  name: Mutation | string
+  href?: string
+}
+
+export function VariantLinkBadge({ name, href }: VariantLinkBadgeProps) {
+  const { mutationObj, mutationStr } = useMemo(() => aminoacidMutationToObjectAndString(name), [name])
+  const url = useMemo(() => href ?? formatVariantUrl(mutationStr), [href, mutationStr])
+
+  if (!mutationObj) {
+    return <span className="text-danger">{`VariantLinkBadge: Invalid mutation: ${JSON.stringify(name)}`}</span>
+  }
+
+  if (!url) {
+    return (
+      <span className="text-danger">
+        {
+          // prettier-ignore
+          `VariantLinkBadge: Variant not recognized: ${JSON.stringify(name)}.` +
+        `Known variants: ${clusterNames.join(', ')}`
+        }
+      </span>
+    )
+  }
+
+  return (
+    <LinkUnstyled href={url ?? ''} icon={null}>
+      <MutationBadge mutation={mutationObj} colors={AMINOACID_COLORS} />
+    </LinkUnstyled>
+  )
+}
+
+/** Shorter convenience alias for NucleotideMutationBadge */
+export function NucMut({ mut }: { mut: string }) {
+  return <NucleotideMutationBadge mutation={mut} />
+}
+
+/** Shorter convenience alias for AminoacidMutationBadge */
+export function AaMut({ mut }: { mut: string }) {
+  return <AminoacidMutationBadge mutation={mut} />
+}
+
+/** Shorter convenience alias for VariantLinkBadge */
+export function Var({ name, href }: { name: string; href?: string }) {
+  return <VariantLinkBadge name={name} href={href} />
 }

--- a/web/src/components/Common/__tests__/parseAminoacidMutation.test.ts
+++ b/web/src/components/Common/__tests__/parseAminoacidMutation.test.ts
@@ -1,0 +1,83 @@
+import { parseAminoacidMutation } from 'src/components/Common/parseAminoacidMutation'
+
+describe('parseAminoacidMutation', () => {
+  it('should parse gene, ref, position, right', () => {
+    expect(parseAminoacidMutation('Gene1:V123S')).toStrictEqual({ gene: 'Gene1', left: 'V', pos: 123, right: 'S' })
+  })
+
+  it('should parse different gene, ref, position, right', () => {
+    expect(parseAminoacidMutation('ORF1a:T2153I')).toStrictEqual({
+      gene: 'ORF1a',
+      left: 'T',
+      pos: 2153,
+      right: 'I',
+    })
+  })
+
+  it('should parse position', () => {
+    expect(parseAminoacidMutation('123')).toStrictEqual({
+      gene: undefined,
+      left: undefined,
+      pos: 123,
+      right: undefined,
+    })
+  })
+
+  it('should parse gene, position, right', () => {
+    expect(parseAminoacidMutation('S:123V')).toStrictEqual({
+      gene: 'S',
+      left: undefined,
+      pos: 123,
+      right: 'V',
+    })
+  })
+
+  it('should parse position, right', () => {
+    expect(parseAminoacidMutation('123V')).toStrictEqual({
+      gene: undefined,
+      left: undefined,
+      pos: 123,
+      right: 'V',
+    })
+  })
+
+  it('should parse gene, left, position', () => {
+    expect(parseAminoacidMutation('S:V123')).toStrictEqual({
+      gene: 'S',
+      left: 'V',
+      pos: 123,
+      right: undefined,
+    })
+  })
+
+  it('should parse left, position', () => {
+    expect(parseAminoacidMutation('V123')).toStrictEqual({
+      gene: undefined,
+      left: 'V',
+      pos: 123,
+      right: undefined,
+    })
+  })
+})
+
+describe('parseAminoacidMutation ', () => {
+  it('should reject one letter', () => {
+    expect(parseAminoacidMutation('V')).toBeUndefined()
+  })
+
+  it('should reject multiple letters', () => {
+    expect(parseAminoacidMutation(':VS')).toBeUndefined()
+  })
+
+  it('should reject empty input', () => {
+    expect(parseAminoacidMutation('')).toBeUndefined()
+  })
+
+  it('should reject non-mutation-like input', () => {
+    expect(parseAminoacidMutation('hello!')).toBeUndefined()
+  })
+
+  it('should reject letters in position', () => {
+    expect(parseAminoacidMutation(':G1X3T')).toBeUndefined()
+  })
+})

--- a/web/src/components/Common/__tests__/parseNucleotideMutation.test.ts
+++ b/web/src/components/Common/__tests__/parseNucleotideMutation.test.ts
@@ -1,0 +1,61 @@
+import { parseNucleotideMutation } from 'src/components/Common/parseNucleotideMutation'
+
+describe('parseNucleotideMutation', () => {
+  it('should parse left, position, right', () => {
+    expect(parseNucleotideMutation('A123C')).toStrictEqual({ left: 'A', pos: 123, right: 'C' })
+  })
+
+  it('should parse position', () => {
+    expect(parseNucleotideMutation('123')).toStrictEqual({ left: undefined, pos: 123, right: undefined })
+  })
+
+  it('should parse position, right', () => {
+    expect(parseNucleotideMutation('123C')).toStrictEqual({ left: undefined, pos: 123, right: 'C' })
+  })
+
+  it('should parse left, position', () => {
+    expect(parseNucleotideMutation('A123')).toStrictEqual({ left: 'A', pos: 123, right: undefined })
+  })
+
+  it('should parse different left, position, right', () => {
+    expect(parseNucleotideMutation('T43516N')).toStrictEqual({ left: 'T', pos: 43516, right: 'N' })
+  })
+
+  it('should parse left "-", position, right', () => {
+    expect(parseNucleotideMutation('-123C')).toStrictEqual({ left: '-', pos: 123, right: 'C' })
+  })
+
+  it('should parse left, position, right "-"', () => {
+    expect(parseNucleotideMutation('A123-')).toStrictEqual({ left: 'A', pos: 123, right: '-' })
+  })
+
+  it('should parse left "-", position and right "-"', () => {
+    expect(parseNucleotideMutation('-123-')).toStrictEqual({ left: '-', pos: 123, right: '-' })
+  })
+})
+
+describe('parseNucleotideMutation ', () => {
+  it('should reject empty', () => {
+    expect(parseNucleotideMutation('')).toBeUndefined()
+  })
+
+  it('should reject non-mutation-like input', () => {
+    expect(parseNucleotideMutation('hello!')).toBeUndefined()
+  })
+
+  it('should reject when no position', () => {
+    expect(parseNucleotideMutation('AC')).toBeUndefined()
+  })
+
+  it('should reject "-"', () => {
+    expect(parseNucleotideMutation('-')).toBeUndefined()
+  })
+
+  it('should reject one letter', () => {
+    expect(parseNucleotideMutation('A')).toBeUndefined()
+  })
+
+  it('should reject letters in position', () => {
+    expect(parseNucleotideMutation('G1X3T')).toBeUndefined()
+  })
+})

--- a/web/src/components/Common/formatMutation.ts
+++ b/web/src/components/Common/formatMutation.ts
@@ -1,0 +1,9 @@
+import type { Mutation } from 'src/types'
+
+export function formatMutation({ gene, left, pos, right }: Mutation) {
+  const geneStr = gene ? `${gene}:` : ''
+  const leftStr = left ?? ''
+  const rightStr = right ?? ''
+
+  return `${geneStr}${leftStr}${pos}${rightStr}`
+}

--- a/web/src/components/Common/parseAminoacidMutation.ts
+++ b/web/src/components/Common/parseAminoacidMutation.ts
@@ -17,22 +17,22 @@ export function parseGene(raw: string | undefined | null) {
 }
 
 export function parseAminoacidMutation(formatted: string): Mutation | undefined {
-  const match = /^(?<gene>.*):(?<left>[*.a-z-]{0,1})(?<pos>(\d)*)(?<right>[*.a-z-]{0,1})$/i.exec(formatted)
+  const match = /^(?<gene>.*:)?(?<left>[*.a-z-]{0,1})(?<pos>(\d)*)(?<right>[*.a-z-]{0,1})$/i.exec(formatted)
 
   if (!match?.groups) {
     return undefined
   }
 
-  if (Object.values(match?.groups).every((s) => s.length === 0)) {
+  if (Object.values(match?.groups).every((s) => !s || s.length === 0)) {
     return undefined
   }
 
-  const gene = parseGene(match.groups?.gene)
+  const gene = parseGene(match.groups?.gene)?.replace(':', '')
   const left = parseAminoacid(match.groups?.left)
   const pos = parsePosition(match.groups?.pos)
   const right = parseAminoacid(match.groups?.right)
 
-  if (!left || !right || !pos) {
+  if (!pos) {
     return undefined
   }
 

--- a/web/src/components/Common/parseNucleotideMutation.ts
+++ b/web/src/components/Common/parseNucleotideMutation.ts
@@ -24,7 +24,7 @@ export function parseNucleotideMutation(formatted: string): Mutation | undefined
   const pos = parsePosition(match.groups?.pos)
   const right = parseNucleotide(match.groups?.right)
 
-  if (!left || !right || !pos) {
+  if (!pos) {
     return undefined
   }
 

--- a/web/src/components/Variants/DefiningMutations.tsx
+++ b/web/src/components/Variants/DefiningMutations.tsx
@@ -57,7 +57,7 @@ export function DefiningMutations({ cluster }: DefiningMutationsProps) {
         {hasNonsynonymous ? (
           <Ul>
             {cluster.mutations?.nonsynonymous?.map((mutation) => (
-              <Li key={`${mutation?.gene ?? ''}:${mutation.left}${mutation.pos}${mutation.right}`}>
+              <Li key={`${mutation?.gene ?? ''}:${mutation.left ?? ''}${mutation.pos}${mutation.right ?? ''}`}>
                 <AminoacidMutationBadge mutation={mutation} />
               </Li>
             ))}
@@ -72,7 +72,7 @@ export function DefiningMutations({ cluster }: DefiningMutationsProps) {
         {hasSynonymous ? (
           <Ul>
             {cluster.mutations?.synonymous?.map((mutation) => (
-              <Li key={`${mutation.left}${mutation.pos}${mutation.right}`}>
+              <Li key={`${mutation.left ?? ''}${mutation.pos}${mutation.right ?? ''}`}>
                 <NucleotideMutationBadge mutation={mutation} />
               </Li>
             ))}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,8 +1,8 @@
 export interface Mutation {
   gene?: string
-  left: string
+  left?: string
   pos: number
-  right: string
+  right?: string
   note?: string
 }
 


### PR DESCRIPTION
This:
 - adds shorter aliases for existing aminoacid and nucleotide badges (for convenience, when using in markdown)
 - adds variant badges which link to variant pages
 - imports these new components explicitly to markdown, so that explicit import statements are no longer needed


Examples:

```jsx
<!-- Just a shorter version of NucleotideMutationBadge -->
<NucMut mut="C123T" />

<!-- Just a shorter version of AminoacidMutationBadge -->
<AaMut mut="S:N501" />

<!-- Clickable variant badge. -->
<!-- Tries to find a known cluster by name and link to /variants/${cluster.build_name} page -->
<Var name="S:N501" />

<!-- i.e. it is same as -->
<Var name="S:N501" href="/variant/S.N501" />

<!-- With custom internal link -->
<Var name="S:N501" href="/foo/bar" />

<!-- With custom external link -->
<Var name="S:N501" href="https://example/com/foo/bar" />
```
