### PR TITLE
Protect non-release deployments from web crawlers

### DIFF
--- a/web/.eslintignore
+++ b/web/.eslintignore
@@ -7,6 +7,8 @@
 \.ignore
 \.reports
 \.vscode
+config/next/lib/EmitFilePlugin.js
+infra/lambda-at-edge/basicAuth.js
 node_modules
 public
 styles

--- a/web/config/next/lib/EmitFilePlugin.js
+++ b/web/config/next/lib/EmitFilePlugin.js
@@ -5,8 +5,6 @@
  * See LICENSE.md file in root directory for full license.
  */
 
-'use strict'
-
 const { Buffer } = require('buffer')
 const path = require('path')
 const webpack = require('webpack')
@@ -76,7 +74,7 @@ function EmitFilePlugin(options) {
 EmitFilePlugin.prototype.apply = function (compiler) {
   if (version < 4) {
     compiler.plugin('emit', (compilation, callback) => emitFile(this.options, compilation, callback, callback))
-  } else if (version == 4) {
+  } else if (version === 4) {
     compiler.hooks.emit.tapAsync(EmitFilePlugin.name, (compilation, callback) =>
       emitFile(this.options, compilation, callback, callback),
     )

--- a/web/config/next/lib/EmitFilePlugin.js
+++ b/web/config/next/lib/EmitFilePlugin.js
@@ -1,0 +1,143 @@
+// Taken from https://github.com/Kir-Antipov/emit-file-webpack-plugin/blob/a17e94f434c9185d659e18806d49f3c6bc73d706/index.js
+
+/**
+ * @author Kir_Antipov
+ * See LICENSE.md file in root directory for full license.
+ */
+
+'use strict'
+
+const { Buffer } = require('buffer')
+const path = require('path')
+const webpack = require('webpack')
+const version = +webpack.version.split('.')[0]
+// Webpack 5 exposes the sources property to ensure the right version of webpack-sources is used.
+// require('webpack-sources') approach may result in the "Cannot find module 'webpack-sources'" error.
+const { Source, RawSource } = webpack.sources || require('webpack-sources')
+
+/**
+ * @typedef {object} EmitFilePluginOptions
+ *
+ * @property {string} [path]
+ * OPTIONAL: defaults to the Webpack output path.
+ * Output path.
+ * Can be relative (to Webpack output path) or absolute.
+ *
+ * @property {string} filename
+ * REQUIRED.
+ * Name of the file to add to assets.
+ *
+ * @property {boolean} [hash]
+ * OPTIONAL: defaults to false.
+ * Adds the compilation hash to the filename. You can either choose within the filename
+ * where the hash is inserted by adding `[hash]` i.e. `test.[hash].js` or the hash will be
+ * appended to the end of the file i.e. `test.js?hash`.
+ *
+ * @property {number} [stage]
+ * OPTIONAL: defaults to the webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL.
+ * Asset processing stage.
+ *
+ * @property {string|Buffer|Source|((assets: Record<string, Source>) => (string|Buffer|Source))|((assets: Record<string, Source>) => (Promise<string|Buffer|Source>))} content
+ * REQUIRED.
+ * File content. Can be either a string, a buffer, or a (asynchronous) function.
+ * If the resulting object is not a string or a buffer, it will be converted to JSON.
+ */
+
+/**
+ * Webpack plugin to emit files.
+ *
+ * @param {EmitFilePluginOptions} options The EmitFilePlugin config.
+ */
+function EmitFilePlugin(options) {
+  if (!options) {
+    throw new Error(`${EmitFilePlugin.name}: Please provide 'options' for the ${EmitFilePlugin.name} config.`)
+  }
+
+  if (!options.filename) {
+    throw new Error(`${EmitFilePlugin.name}: Please provide 'options.filename' in the ${EmitFilePlugin.name} config.`)
+  }
+
+  if (!options.content && options.content !== '') {
+    throw new Error(`${EmitFilePlugin.name}: Please provide 'options.content' in the ${EmitFilePlugin.name} config.`)
+  }
+
+  if (typeof options.stage == 'number' && version < 5) {
+    console.warn(`${EmitFilePlugin.name}: 'options.stage' is only available for Webpack version 5 and higher.`)
+  }
+
+  this.options = options
+}
+
+/**
+ * Plugin entry point.
+ *
+ * @param {webpack.Compiler} compiler The compiler.
+ */
+EmitFilePlugin.prototype.apply = function (compiler) {
+  if (version < 4) {
+    compiler.plugin('emit', (compilation, callback) => emitFile(this.options, compilation, callback, callback))
+  } else if (version == 4) {
+    compiler.hooks.emit.tapAsync(EmitFilePlugin.name, (compilation, callback) =>
+      emitFile(this.options, compilation, callback, callback),
+    )
+  } else {
+    compiler.hooks.thisCompilation.tap(EmitFilePlugin.name, (compilation) => {
+      compilation.hooks.processAssets.tapPromise(
+        {
+          name: EmitFilePlugin.name,
+          stage:
+            typeof this.options.stage == 'number'
+              ? this.options.stage
+              : webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
+        },
+        () => new Promise((resolve, reject) => emitFile(this.options, compilation, resolve, reject)),
+      )
+    })
+  }
+}
+
+/**
+ * @param {EmitFilePluginOptions} options
+ * @param {webpack.Compilation} compilation
+ * @param {() => void} resolve
+ */
+function emitFile(options, compilation, resolve) {
+  const outputPath = options.path || compilation.options.output.path
+
+  let filename = options.filename
+
+  if (options.hash) {
+    const hash = compilation.hash || ''
+    if (filename.includes('[hash]')) {
+      filename = filename.replace('[hash]', hash)
+    } else if (hash) {
+      filename = `${filename}?${hash}`
+    }
+  }
+
+  const outputPathAndFilename = path.resolve(compilation.options.output.path, outputPath, filename)
+
+  const relativeOutputPath = path.relative(compilation.options.output.path, outputPathAndFilename)
+
+  const contentOrPromise = typeof options.content == 'function' ? options.content(compilation.assets) : options.content
+
+  const contentPromise =
+    contentOrPromise instanceof Promise ? contentOrPromise : new Promise((resolve) => resolve(contentOrPromise))
+
+  contentPromise.then((content) => {
+    const source =
+      content instanceof Source
+        ? content
+        : new RawSource(typeof content == 'string' || content instanceof Buffer ? content : JSON.stringify(content))
+
+    if (version < 5) {
+      compilation.assets[relativeOutputPath] = source
+    } else {
+      compilation.emitAsset(relativeOutputPath, source)
+    }
+
+    resolve()
+  })
+}
+
+module.exports = EmitFilePlugin

--- a/web/config/next/withRobotsTxt.ts
+++ b/web/config/next/withRobotsTxt.ts
@@ -1,0 +1,15 @@
+import { NextConfig } from 'next'
+import { addWebpackPlugin } from './lib/addWebpackPlugin'
+import EmitFilePlugin from './lib/EmitFilePlugin'
+
+export const getWithRobotsTxt = (content: string) => (nextConfig: NextConfig) => {
+  return addWebpackPlugin(
+    nextConfig,
+    new EmitFilePlugin({
+      path: '.',
+      filename: 'robots.txt',
+      content,
+      hash: false,
+    }),
+  )
+}

--- a/web/infra/lambda-at-edge/basicAuth.js
+++ b/web/infra/lambda-at-edge/basicAuth.js
@@ -1,0 +1,30 @@
+// Implements basic authentication using AWS Lambda@Edge
+// This is insecure due to hardcoded credentials and is only suited for blocking crawlers
+//
+// Usage: Create an AWS Lambda function and attach this to "Viewer Request" event of a Cloudfront distribution
+
+const USERNAME = 'nextstrain'
+const PASSWORD = 'nextstrain'
+const BASIC_AUTH_STRING = `Basic ${Buffer.from(`${USERNAME}:${PASSWORD}`).toString('base64')}`
+
+exports.handler = (event, context, callback) => {
+  // Get request and request headers
+  const request = event.Records[0].cf.request
+  const headers = request.headers
+
+  // Require Basic authentication
+  if (typeof headers.authorization == 'undefined' || headers.authorization[0].value != BASIC_AUTH_STRING) {
+    const body = 'Unauthorized'
+    const response = {
+      status: '401',
+      statusDescription: 'Unauthorized',
+      body,
+      headers: {
+        'www-authenticate': [{ key: 'WWW-Authenticate', value: 'Basic' }],
+      },
+    }
+    callback(null, response)
+  }
+
+  callback(null, request)
+}

--- a/web/infra/lambda-at-edge/modifyOutgoingHeaders.lambda.js
+++ b/web/infra/lambda-at-edge/modifyOutgoingHeaders.lambda.js
@@ -1,3 +1,8 @@
+// Adds some of the security headers to requests using AWS Lambda@Edge
+// See https://securityheaders.com/
+//
+// Usage: Create an AWS Lambda function and attach this to "Viewer Response" event of a Cloudfront distribution
+
 const FEATURE_POLICY = {
   'accelerometer': `'none'`,
   'autoplay': `'none'`,

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,7 @@
     "prod:build:vercel": "cp .env.vercel .env && yarn install && yarn prod:build && cp .build/production/tmp/routes-manifest.json .build/production/web/",
     "prod:_build": "yarn run next:build && yarn run next:export",
     "next:build": "cross-env NODE_ENV=production BABEL_ENV=production NODE_OPTIONS=--max_old_space_size=8192 babel-node --extensions \".js,.ts\" -- node_modules/.bin/next build",
-    "next:export": "cross-env NODE_ENV=production BABEL_ENV=production NODE_OPTIONS=--max_old_space_size=8192 babel-node --extensions \".js,.ts\" -- node_modules/.bin/next export -o \".build/production/web\"",
+    "next:export": "cross-env NODE_ENV=production BABEL_ENV=production NODE_OPTIONS=--max_old_space_size=8192 babel-node --extensions \".js,.ts\" -- node_modules/.bin/next export -o \".build/production/web\" && cp .build/production/tmp/robots.txt .build/production/web/robots.txt",
     "next:build:profile": "PROFILE=1 yarn next:build --profile",
     "prod:clean": "rimraf '.build/production/{*,.*}' 'node_modules/.cache'",
     "prod:serve:nowatch": "babel-node --extensions \".ts\" ./tools/server/server.ts",

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow:


### PR DESCRIPTION
This adds:
 - dynamically generated `robots.txt`
 - basic auth via Lambda@Edge
