### PR TITLE
Document copying .env.example

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -13,7 +13,7 @@ If you can't build the repository - that's ok. By creating a PR an automatic bui
 To build locally:
 Navigate to `covariants/web` and type the folowing commands:
 ```
-cp ./.env.example .env
+cp .env.example .env
 nvm use
 yarn dev
 ```

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -13,6 +13,7 @@ If you can't build the repository - that's ok. By creating a PR an automatic bui
 To build locally:
 Navigate to `covariants/web` and type the folowing commands:
 ```
+cp ./.env.example .env
 nvm use
 yarn dev
 ```


### PR DESCRIPTION
Documents the need to run `cp .env.example .env` before general dev.

I'm not sure exactly how you'll want to do this, perhaps in a different "set-up" section? (Do make any edits) But I think that despite the relatively helpful error message, it would be worth documenting this need because it isn't clear exactly where the error message is being surfaced from and I initially assumed it was some unhappy node package rather than relating to this package itself.