### PR TITLE
Add basic windows dev support

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -15,8 +15,18 @@ Navigate to `covariants/web` and type the folowing commands:
 ```
 cp .env.example .env
 nvm use
-yarn dev
 ```
+
+then start the development server with:
+```
+yarn dev
+``
+
+for Windows, (without Linux Subsystem), try:
+```
+yarn dev:start_win
+```
+
 This may take a while to build. Once finished, open a browser and navigate to `localhost:3000`. Note that navigating between pages may be slow: your computer is building each page as it needs them.
 
 ## To add links, information, and resources:

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,8 @@
     "dev": "nodemon --config config/nodemon/dev.json",
     "dev:start": "yarn install && yarn run monkey-patch && yarn dev:nowatch || cd .",
     "dev:nowatch": "cross-env NODE_ENV=development BABEL_ENV=development NODE_OPTIONS=--max_old_space_size=8192 babel-node --extensions \".js,.ts\" -- node_modules/.bin/next dev --hostname 0.0.0.0 --port 3000",
+    "dev:start_win": "yarn install && yarn run monkey-patch && yarn dev:nowatch_win || cd .",
+    "dev:nowatch_win": "cross-env NODE_ENV=development BABEL_ENV=development NODE_OPTIONS=--max_old_space_size=8192 babel-node --extensions \".js,.ts\" -- ./node_modules/next/dist/bin/next dev --hostname 0.0.0.0 --port 3000",
     "dev:clean": "rimraf '.build/development/{*,.*}' 'node_modules/.cache'",
     "prod:build": "yarn run monkey-patch && yarn run next:build && yarn run next:export",
     "prod:build:ci": "yarn run prod:build",


### PR DESCRIPTION
This adds hardcoding to a path that seems to work in Windows. (See discussion in https://github.com/nextstrain/nextclade/issues/313 and https://github.com/hodcroftlab/covariants/issues/18).

It's a bit hacky, I don't have a good understanding of structuring node commands. Improvements welcome.