### PR TITLE
feat: add 'total' and 'others' to per-country plot tooltips

### DIFF
--- a/web/src/components/CountryDistribution/CountryDistributionPlot.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlot.tsx
@@ -34,7 +34,7 @@ export function CountryDistributionPlotComponent({ cluster_names, distribution }
 
     const others = total_sequences - total_cluster_sequences
     const weekSec = DateTime.fromFormat(week, 'yyyy-MM-dd').toSeconds()
-    return { week: weekSec, ...cluster_counts, others }
+    return { week: weekSec, ...cluster_counts, others, total: total_sequences }
   })
 
   return (

--- a/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
@@ -49,7 +49,12 @@ export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   const week = formatDate(payload[0]?.payload.week)
 
-  const payloadSorted = reverse(sortBy(payload, 'value')).filter(({ name }) => name !== 'others')
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  const total: number = formatInteger(payload[0]?.payload.total)
+
+  const payloadSorted = reverse(sortBy(payload, 'value'))
 
   return (
     <Tooltip>
@@ -63,7 +68,7 @@ export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps
           </tr>
         </thead>
         <TooltipTableBody>
-          {payloadSorted.map(({ color, name, value }, index) => (
+          {payloadSorted.map(({ name, value }) => (
             <tr key={name}>
               <td className="px-2 text-left">
                 <ColoredBox $color={getClusterColor(name ?? '')} $size={10} $aspect={1.66} />
@@ -72,6 +77,15 @@ export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps
               <td className="px-2 text-right">{value !== undefined && value > EPSILON ? formatInteger(value) : '-'}</td>
             </tr>
           ))}
+
+          <tr>
+            <td className="px-2 text-left">
+              <span>
+                <b>{'Total'}</b>
+              </span>
+            </td>
+            <td className="px-2 text-right">{total}</td>
+          </tr>
         </TooltipTableBody>
       </TooltipTable>
     </Tooltip>

--- a/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
@@ -52,7 +52,7 @@ export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  const total: number = formatInteger(payload[0]?.payload.total)
+  const total: number = formatInteger(payload[0]?.payload.total ?? 0)
 
   const payloadSorted = reverse(sortBy(payload, 'value'))
 


### PR DESCRIPTION
Resolves #72 

Adds 2 rows:
 - "total" number of sequences at the bottom
 - "others" as a difference of total and sum of number of sequences for all variants (variants which are not filtered out with checkboxes)


![02](https://user-images.githubusercontent.com/9403403/106404371-dafba780-6432-11eb-85b9-62d8d310a7d3.png)

Related: #76 
