### PR TITLE
feat: add frequency column for per-country plot tooltips

### DIFF
--- a/web/src/components/CountryDistribution/CountryDistributionPlot.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlot.tsx
@@ -34,7 +34,7 @@ export function CountryDistributionPlotComponent({ cluster_names, distribution }
 
     const others = total_sequences - total_cluster_sequences
     const weekSec = DateTime.fromFormat(week, 'yyyy-MM-dd').toSeconds()
-    return { week: weekSec, ...cluster_counts, others }
+    return { week: weekSec, ...cluster_counts, others, total: total_sequences }
   })
 
   return (

--- a/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
@@ -49,7 +49,12 @@ export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   const week = formatDate(payload[0]?.payload.week)
 
-  const payloadSorted = reverse(sortBy(payload, 'value')).filter(({ name }) => name !== 'others')
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  const total: number = formatInteger(payload[0]?.payload.total)
+
+  const payloadSorted = reverse(sortBy(payload, 'value'))
 
   return (
     <Tooltip>
@@ -63,7 +68,7 @@ export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps
           </tr>
         </thead>
         <TooltipTableBody>
-          {payloadSorted.map(({ color, name, value }, index) => (
+          {payloadSorted.map(({ name, value }) => (
             <tr key={name}>
               <td className="px-2 text-left">
                 <ColoredBox $color={getClusterColor(name ?? '')} $size={10} $aspect={1.66} />
@@ -72,6 +77,15 @@ export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps
               <td className="px-2 text-right">{value !== undefined && value > EPSILON ? formatInteger(value) : '-'}</td>
             </tr>
           ))}
+
+          <tr>
+            <td className="px-2 text-left">
+              <span>
+                <b>{'Total'}</b>
+              </span>
+            </td>
+            <td className="px-2 text-right">{total}</td>
+          </tr>
         </TooltipTableBody>
       </TooltipTable>
     </Tooltip>

--- a/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
@@ -4,7 +4,7 @@ import { sortBy, reverse } from 'lodash'
 import styled from 'styled-components'
 import { Props as DefaultTooltipContentProps } from 'recharts/types/component/DefaultTooltipContent'
 
-import { formatDate, formatInteger } from 'src/helpers/format'
+import { formatDate, formatInteger, formatProportion } from 'src/helpers/format'
 import { getClusterColor } from 'src/io/getClusters'
 import { ColoredBox } from '../Common/ColoredBox'
 
@@ -65,6 +65,7 @@ export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps
           <tr className="w-100">
             <th className="px-2 text-left">{'Variant'}</th>
             <th className="px-2 text-right">{'Num seq'}</th>
+            <th className="px-2 text-right">{'Freq'}</th>
           </tr>
         </thead>
         <TooltipTableBody>
@@ -75,6 +76,9 @@ export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps
                 <span>{name}</span>
               </td>
               <td className="px-2 text-right">{value !== undefined && value > EPSILON ? formatInteger(value) : '-'}</td>
+              <td className="px-2 text-right">
+                {value !== undefined && value > EPSILON ? formatProportion(value / total) : '-'}
+              </td>
             </tr>
           ))}
 
@@ -85,6 +89,7 @@ export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps
               </span>
             </td>
             <td className="px-2 text-right">{total}</td>
+            <td className="px-2 text-right">{'1.00'}</td>
           </tr>
         </TooltipTableBody>
       </TooltipTable>

--- a/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
@@ -52,7 +52,7 @@ export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  const total: number = formatInteger(payload[0]?.payload.total)
+  const total: number = formatInteger(payload[0]?.payload.total ?? 0)
 
   const payloadSorted = reverse(sortBy(payload, 'value'))
 


### PR DESCRIPTION
Extends and depends on #75

Note: This PR is done, but is marked as draft, to avoid out-of order merges, because it requires #75 to be merged first. Safe to unmark (click "Ready for review") and merge when #75  is on master.

This adds another column "Freq", which value is `number_of_sequences / total_sequences`


![01](https://user-images.githubusercontent.com/9403403/106404595-7d1b8f80-6433-11eb-9897-c6e2fa22e4a0.png)
