### PR TITLE
feat: add color to "others" variant on per-country plots

### DIFF
--- a/content/PerCountryIntro.md
+++ b/content/PerCountryIntro.md
@@ -1,6 +1,6 @@
 Graphs show for each country, the proportion of total number of **sequences** (*not cases*), over time, that fall into defined variant groups. Countries are displayed if they have at least 40 sequences in any variant being tracked. Countries are ordered by total number of sequences in tracked variants.
 
-The 'blank space' between the top of the coloured curve and '1' on the Y-axis is composed of variants, lineages, and mutations that we don't currently track (often a collection of many small ones).
+The grey colour between the top of the coloured curve and '1' on the Y-axis is composed of variants, lineages, and mutations that we don't currently track.
 
 Sequences with the 69 deletion or a mutation at <AaMut mut={'S:E484'}/> in Spike are not shown on these plots as they commonly are found in other varaints (<Var name="S:N439K"/>, <Var name="S:Y453F"/>, and <Var name="S:N501"/> for <AaMut mut={'S:H69-'}/>; <Var name="S:N501"/> for <AaMut mut={'S:E484'}/>), so they would be 'double-plotted'.
 

--- a/web/src/components/CountryDistribution/CountryDistributionPlot.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlot.tsx
@@ -7,7 +7,7 @@ import { DateTime } from 'luxon'
 
 import { theme } from 'src/theme'
 import { timeDomain } from 'src/io/getParams'
-import { getClusterColor } from 'src/io/getClusters'
+import { CLUSTER_NAME_OTHERS, getClusterColor } from 'src/io/getClusters'
 import { formatDate, formatProportion } from 'src/helpers/format'
 
 import { PlotPlaceholder } from 'src/components/Common/PlotPlaceholder'
@@ -63,7 +63,7 @@ export function CountryDistributionPlotComponent({ cluster_names, distribution }
               allowEscapeViewBox={{ x: false, y: true }}
               offset={50}
             />
-            {cluster_names.map((cluster, i) => (
+            {cluster_names.map((cluster) => (
               <Area
                 key={cluster}
                 type="monotone"
@@ -75,9 +75,16 @@ export function CountryDistributionPlotComponent({ cluster_names, distribution }
               />
             ))}
 
-            <Area type="monotone" dataKey="others" stackId="1" stroke="none" fill="none" isAnimationActive={false} />
+            <Area
+              type="monotone"
+              dataKey={CLUSTER_NAME_OTHERS}
+              stackId="1"
+              stroke="none"
+              fill={theme.clusters.color.others}
+              isAnimationActive={false}
+            />
 
-            <CartesianGrid stroke="#2222" />
+            <CartesianGrid stroke={theme.plot.cartesianGrid.stroke} />
           </AreaChart>
         </ResponsiveContainer>
       </ChartContainerInner>

--- a/web/src/io/getClusters.ts
+++ b/web/src/io/getClusters.ts
@@ -1,9 +1,10 @@
 /* eslint-disable camelcase */
 import type { Mutation } from 'src/types'
+import { theme } from 'src/theme'
 
 import clustersJson from 'src/../data/clusters.json'
 
-const CLUSTER_COLOR_UNKNOWN = '#555555' as const
+export const CLUSTER_NAME_OTHERS = 'others' as const
 
 export type ClusterDatum = {
   build_name: string
@@ -37,7 +38,11 @@ export function getClusterBuildNames() {
 }
 
 export function getClusterColor(clusterName: string) {
+  if (clusterName === CLUSTER_NAME_OTHERS) {
+    return theme.clusters.color.others
+  }
+
   const clusters = getClusters()
   const found = clusters.find(({ display_name }) => display_name === clusterName)
-  return found ? found.col : CLUSTER_COLOR_UNKNOWN
+  return found ? found.col : theme.clusters.color.unknown
 }

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -116,6 +116,9 @@ export const plot = {
   aspectRatio: 1.88,
   margin: { left: -20, top: 5, bottom: 5, right: 10 },
   tickStyle: { fontSize: 12 },
+  cartesianGrid: {
+    stroke: '#2222',
+  },
 }
 
 export const link = {
@@ -140,6 +143,13 @@ export const code = {
   },
 }
 
+export const clusters = {
+  color: {
+    unknown: '#aaaaaa',
+    others: '#aaaaaa',
+  },
+}
+
 export const theme = {
   ...basicColors,
   ...themeColors,
@@ -151,6 +161,7 @@ export const theme = {
   plot,
   iframe,
   code,
+  clusters,
 }
 
 export type Theme = typeof theme

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -146,7 +146,7 @@ export const code = {
 export const clusters = {
   color: {
     unknown: '#aaaaaa',
-    others: '#aaaaaa',
+    others: '#cccccc',
   },
 }
 


### PR DESCRIPTION
Resolves #85

This adds fill color to "others" entry on the per-country plots. The color is reused in the plot tooltip, to fill the rectangle near the "others" entry as well.

The color can be adjusted here: 
https://github.com/hodcroftlab/covariants/blob/2f6483d978a500f8302bdd55a9a1758252a69a66/web/src/theme.ts#L149

![001](https://user-images.githubusercontent.com/9403403/107179101-f25c0700-69d5-11eb-8261-db766dded2be.png)
