### PR TITLE
place external-link icon after link

### DIFF
--- a/web/src/components/Link/LinkExternal.tsx
+++ b/web/src/components/Link/LinkExternal.tsx
@@ -44,8 +44,8 @@ export function LinkExternal({
   return (
     <>
       <A target="_blank" rel="noopener noreferrer" href={href} $color={$color} {...restProps}>
+        <ContentWrapper>{children}</ContentWrapper>{' '}
         {Icon && <LinkExternalIconWrapper $color={$iconColor}>{Icon}</LinkExternalIconWrapper>}
-        <ContentWrapper>{children}</ContentWrapper>
       </A>
     </>
   )

--- a/web/src/components/Link/LinkExternal.tsx
+++ b/web/src/components/Link/LinkExternal.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components'
 import { GoLinkExternal } from 'react-icons/go'
 
 const LinkExternalIconWrapper = styled.span<{ $color?: string }>`
-  margin-right: 0.25rem;
   color: ${(props) => props.$color ?? props.theme.link.dim.iconColor};
 `
 


### PR DESCRIPTION
The external-link icon conventionally appears *after* the link text (e.g, see [these](https://en.wikipedia.org/wiki/COVID-19_pandemic#References), [examples](https://designnotes.blog.gov.uk/2016/11/28/removing-the-external-link-icon-from-gov-uk/)).

Covariants.org currently places the icons *before* the link text, which looks unusual; this PR reverses this.