### PR TITLE
feat: add ability to select and deselect all country or variant filters

### DIFF
--- a/web/src/components/ClusterDistribution/ClusterDistributionPage.tsx
+++ b/web/src/components/ClusterDistribution/ClusterDistributionPage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react'
 
 import copy from 'fast-copy'
-import { pickBy } from 'lodash'
+import { mapValues, pickBy } from 'lodash'
 import { useDispatch, useSelector } from 'react-redux'
 import { Card, CardBody, Col, Form, FormGroup, Input, Label, Row } from 'reactstrap'
 import styled from 'styled-components'
@@ -177,11 +177,31 @@ export function ClusterDistributionPage() {
     [],
   )
 
+  const handleClusterSelectAll = useCallback(
+    () => setClusters((oldClusters) => mapValues(oldClusters, (cluster) => ({ ...cluster, enabled: true }))),
+    [],
+  )
+
+  const handleClusterDeselectAll = useCallback(
+    () => setClusters((oldClusters) => mapValues(oldClusters, (cluster) => ({ ...cluster, enabled: false }))),
+    [],
+  )
+
   const handleCountryCheckedChange = useCallback(
     (country: string) =>
       setCountries((oldCountries) => {
         return { ...oldCountries, [country]: { ...oldCountries[country], enabled: !oldCountries[country].enabled } }
       }),
+    [],
+  )
+
+  const handleCountrySelectAll = useCallback(
+    () => setCountries((oldCountries) => mapValues(oldCountries, (country) => ({ ...country, enabled: true }))),
+    [],
+  )
+
+  const handleCountryDeselectAll = useCallback(
+    () => setCountries((oldCountries) => mapValues(oldCountries, (country) => ({ ...country, enabled: false }))),
     [],
   )
 
@@ -212,7 +232,11 @@ export function ClusterDistributionPage() {
                   coutriesCollapsedByDefault={false}
                   enabledFilters={enabledFilters}
                   onClusterFilterChange={handleClusterCheckedChange}
+                  onClusterFilterSelectAll={handleClusterSelectAll}
+                  onClusterFilterDeselectAll={handleClusterDeselectAll}
                   onCountryFilterChange={handleCountryCheckedChange}
+                  onCountryFilterSelectAll={handleCountrySelectAll}
+                  onCountryFilterDeselectAll={handleCountryDeselectAll}
                 />
               </SidebarFlex>
 

--- a/web/src/components/CountryDistribution/CountryDistributionPage.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPage.tsx
@@ -1,6 +1,6 @@
 import copy from 'fast-copy'
 
-import { pickBy } from 'lodash'
+import { mapValues, pickBy } from 'lodash'
 import React, { useCallback, useMemo, useState } from 'react'
 import { Col, Row } from 'reactstrap'
 
@@ -101,11 +101,37 @@ export function CountryDistributionPage() {
     [],
   )
 
+  const handleClusterSelectAll = useCallback(
+    () => setClusters((oldClusters) => mapValues(oldClusters, (cluster) => ({ ...cluster, enabled: true }))),
+    [],
+  )
+
+  const handleClusterDeselectAll = useCallback(
+    () => setClusters((oldClusters) => mapValues(oldClusters, (cluster) => ({ ...cluster, enabled: false }))),
+    [],
+  )
+
   const handleCountryCheckedChange = useCallback(
     (country: string) =>
       setCountries((oldCountries) => {
         return { ...oldCountries, [country]: { ...oldCountries[country], enabled: !oldCountries[country].enabled } }
       }),
+    [],
+  )
+
+  const handleCountrySelectAll = useCallback(
+    () =>
+      setCountries((oldCountries: CountryState) =>
+        mapValues(oldCountries, (country) => ({ ...country, enabled: true })),
+      ),
+    [],
+  )
+
+  const handleCountryDeselectAll = useCallback(
+    () =>
+      setCountries((oldCountries: CountryState) =>
+        mapValues(oldCountries, (country) => ({ ...country, enabled: false })),
+      ),
     [],
   )
 
@@ -136,7 +162,11 @@ export function CountryDistributionPage() {
                   enabledFilters={enabledFilters}
                   clustersCollapsedByDefault={false}
                   onClusterFilterChange={handleClusterCheckedChange}
+                  onClusterFilterSelectAll={handleClusterSelectAll}
+                  onClusterFilterDeselectAll={handleClusterDeselectAll}
                   onCountryFilterChange={handleCountryCheckedChange}
+                  onCountryFilterSelectAll={handleCountrySelectAll}
+                  onCountryFilterDeselectAll={handleCountryDeselectAll}
                 />
               </SidebarFlex>
 

--- a/web/src/components/DistributionSidebar/ClusterFilters.tsx
+++ b/web/src/components/DistributionSidebar/ClusterFilters.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from 'react'
 
-import { CardBody, Form, FormGroup, Input, Label } from 'reactstrap'
+import { Button, CardBody, Col, Container, Form, FormGroup, Input, Label, Row } from 'reactstrap'
 
 import { getClusterColor } from 'src/io/getClusters'
 import { ColoredBox } from 'src/components/Common/ColoredBox'
@@ -31,20 +31,53 @@ export interface ClusterFiltersProps {
   clusters: ClusterState
   collapsed: boolean
   onFilterChange(cluster: string): void
+  onFilterSelectAll(): void
+  onFilterDeselectAll(): void
   setCollapsed(collapsed: boolean): void
 }
 
-export function ClusterFilters({ clusters, collapsed, onFilterChange, setCollapsed }: ClusterFiltersProps) {
+export function ClusterFilters({
+  clusters,
+  collapsed,
+  onFilterSelectAll,
+  onFilterDeselectAll,
+  onFilterChange,
+  setCollapsed,
+}: ClusterFiltersProps) {
   const filters = useMemo(() => Object.entries(clusters), [clusters])
 
   return (
     <CardCollapsible className="m-2" title={'Variants'} collapsed={collapsed} setCollapsed={setCollapsed}>
       <CardBody>
-        <Form>
-          {filters.map(([cluster, { enabled }]) => (
-            <ClusterFilterCheckbox key={cluster} cluster={cluster} enabled={enabled} onFilterChange={onFilterChange} />
-          ))}
-        </Form>
+        <Container fluid>
+          <Row noGutters>
+            <Col className="d-flex">
+              <FormGroup className="flex-grow-0 mx-auto">
+                <Button type="button" color="link" onClick={onFilterSelectAll}>
+                  {'Select all'}
+                </Button>
+                <Button type="button" color="link" onClick={onFilterDeselectAll}>
+                  {'Deselect all'}
+                </Button>
+              </FormGroup>
+            </Col>
+          </Row>
+
+          <Row noGutters>
+            <Col>
+              <Form>
+                {filters.map(([cluster, { enabled }]) => (
+                  <ClusterFilterCheckbox
+                    key={cluster}
+                    cluster={cluster}
+                    enabled={enabled}
+                    onFilterChange={onFilterChange}
+                  />
+                ))}
+              </Form>
+            </Col>
+          </Row>
+        </Container>
       </CardBody>
     </CardCollapsible>
   )

--- a/web/src/components/DistributionSidebar/CountryFilters.tsx
+++ b/web/src/components/DistributionSidebar/CountryFilters.tsx
@@ -1,6 +1,16 @@
 import React, { useCallback, useMemo } from 'react'
 
-import { CardBody as CardBodyBase, Form as FormBase, FormGroup as FormGroupBase, Input, Label } from 'reactstrap'
+import {
+  Button,
+  CardBody as CardBodyBase,
+  Col,
+  Container,
+  Form as FormBase,
+  FormGroup as FormGroupBase,
+  Input,
+  Label,
+  Row,
+} from 'reactstrap'
 import { ColoredCircle } from 'src/components/Common/ColoredCircle'
 import styled from 'styled-components'
 
@@ -57,26 +67,55 @@ export interface CountryFiltersProps {
   collapsed: boolean
   withIcons?: boolean
   onFilterChange(country: string): void
+  onFilterSelectAll(): void
+  onFilterDeselectAll(): void
   setCollapsed(collapsed: boolean): void
 }
 
-export function CountryFilters({ countries, collapsed, withIcons, onFilterChange, setCollapsed }: CountryFiltersProps) {
+export function CountryFilters({
+  countries,
+  collapsed,
+  withIcons,
+  onFilterSelectAll,
+  onFilterDeselectAll,
+  onFilterChange,
+  setCollapsed,
+}: CountryFiltersProps) {
   const filters = useMemo(() => Object.entries(countries), [countries])
 
   return (
     <CardCollapsible className="m-2" title={'Countries'} collapsed={collapsed} setCollapsed={setCollapsed}>
       <CardBody>
-        <Form>
-          {filters.map(([country, { enabled }]) => (
-            <CountryFilterCheckbox
-              key={country}
-              country={country}
-              enabled={enabled}
-              withIcons={withIcons}
-              onFilterChange={onFilterChange}
-            />
-          ))}
-        </Form>
+        <Container fluid>
+          <Row noGutters>
+            <Col className="d-flex">
+              <FormGroup className="flex-grow-0 mx-auto">
+                <Button type="button" color="link" onClick={onFilterSelectAll}>
+                  {'Select all'}
+                </Button>
+                <Button type="button" color="link" onClick={onFilterDeselectAll}>
+                  {'Deselect all'}
+                </Button>
+              </FormGroup>
+            </Col>
+          </Row>
+
+          <Row noGutters>
+            <Col>
+              <Form>
+                {filters.map(([country, { enabled }]) => (
+                  <CountryFilterCheckbox
+                    key={country}
+                    country={country}
+                    enabled={enabled}
+                    withIcons={withIcons}
+                    onFilterChange={onFilterChange}
+                  />
+                ))}
+              </Form>
+            </Col>
+          </Row>
+        </Container>
       </CardBody>
     </CardCollapsible>
   )

--- a/web/src/components/DistributionSidebar/DistributionSidebar.tsx
+++ b/web/src/components/DistributionSidebar/DistributionSidebar.tsx
@@ -14,7 +14,11 @@ export interface DistributionSidebarProps {
   coutriesCollapsedByDefault?: boolean
   enabledFilters: string[]
   onClusterFilterChange(cluster: string): void
+  onClusterFilterSelectAll(): void
+  onClusterFilterDeselectAll(): void
   onCountryFilterChange(country: string): void
+  onCountryFilterSelectAll(): void
+  onCountryFilterDeselectAll(): void
 }
 
 export function DistributionSidebar({
@@ -24,7 +28,11 @@ export function DistributionSidebar({
   coutriesCollapsedByDefault = true,
   enabledFilters,
   onClusterFilterChange,
+  onClusterFilterSelectAll,
+  onClusterFilterDeselectAll,
   onCountryFilterChange,
+  onCountryFilterSelectAll,
+  onCountryFilterDeselectAll,
 }: DistributionSidebarProps) {
   const [clustersColapsed, setClustersCollapsed] = useState(clustersCollapsedByDefault)
   const [countriesCollapsed, setCountriesCollapsed] = useState(coutriesCollapsedByDefault)
@@ -36,6 +44,8 @@ export function DistributionSidebar({
           key="country-filters"
           countries={countries}
           onFilterChange={onCountryFilterChange}
+          onFilterSelectAll={onCountryFilterSelectAll}
+          onFilterDeselectAll={onCountryFilterDeselectAll}
           collapsed={countriesCollapsed}
           setCollapsed={setCountriesCollapsed}
         />
@@ -46,6 +56,8 @@ export function DistributionSidebar({
           withIcons
           countries={countries}
           onFilterChange={onCountryFilterChange}
+          onFilterSelectAll={onCountryFilterSelectAll}
+          onFilterDeselectAll={onCountryFilterDeselectAll}
           collapsed={countriesCollapsed}
           setCollapsed={setCountriesCollapsed}
         />
@@ -55,12 +67,25 @@ export function DistributionSidebar({
           key="cluster-filters"
           clusters={clusters}
           onFilterChange={onClusterFilterChange}
+          onFilterSelectAll={onClusterFilterSelectAll}
+          onFilterDeselectAll={onClusterFilterDeselectAll}
           collapsed={clustersColapsed}
           setCollapsed={setClustersCollapsed}
         />
       ),
     }),
-    [clusters, clustersColapsed, countries, countriesCollapsed, onClusterFilterChange, onCountryFilterChange],
+    [
+      clusters,
+      clustersColapsed,
+      countries,
+      countriesCollapsed,
+      onClusterFilterChange,
+      onClusterFilterDeselectAll,
+      onClusterFilterSelectAll,
+      onCountryFilterChange,
+      onCountryFilterDeselectAll,
+      onCountryFilterSelectAll,
+    ],
   )
 
   return (


### PR DESCRIPTION
Resolves #96

Adds "Select all" and "Deselect all" links to the filtering sidebar panels, which allow toggling all countries or variants

![01](https://user-images.githubusercontent.com/9403403/108304847-2a6b0300-71a9-11eb-9732-4be941f65ac6.png)

![02](https://user-images.githubusercontent.com/9403403/108304852-2c34c680-71a9-11eb-942d-67fbe6ab8036.png)

