### PR TITLE
color code in link to match rest of link

### DIFF
--- a/web/src/styles/global.scss
+++ b/web/src/styles/global.scss
@@ -137,3 +137,10 @@ p {
 .recharts-tooltip-wrapper {
   z-index: 1000 !important;
 }
+
+/* bootstrap/scss/code sets "color: inherit" for only *direct( descendants of an anchor element */
+code {
+  a & {
+    color: inherit;
+  }
+}


### PR DESCRIPTION
Currently the links to specific nextstrain builds look like two links, because the names formatted with `<code>` are in black rather than blue:

Currently:
![old](https://user-images.githubusercontent.com/338833/110049608-0fbc9080-7d4a-11eb-8584-ec53b0b63290.png)

After this PR:
![new](https://user-images.githubusercontent.com/338833/110049605-0f23fa00-7d4a-11eb-8c4b-d986826f12ff.png)

