### PR TITLE
Ensure variant badges work for named variants

### DIFF
--- a/content/Home.md
+++ b/content/Home.md
@@ -19,7 +19,7 @@ CoVariants uses the Nextstrain naming system for variants ([read more here](http
 
 | Nextstrain Clade      |&#124; Pango Lineage | &#124;Other Name(s) |
 | ----------- | ----------- |--------|
-| <Link href="/variants/20A.EU1">20E (EU1)</Link> | &#124; B.1.177 | &#124; 20A.EU1 |
+| <Var name="20E (EU1)" prefix=""/>     | &#124; B.1.177 | &#124; 20A.EU1 |
 | <Var name="20A.EU2" prefix=""/>       | &#124; B.1.160           | &#124;  |
 | <Var name="20I/501Y.V1" prefix=""/>   | &#124; <LinkExternal href="https://cov-lineages.org/global_report_B.1.1.7.html">B.1.1.7</LinkExternal>           | &#124; VOC 202012/01 |
 | <Var name="20H/501Y.V2" prefix=""/>   | &#124; <LinkExternal href="https://cov-lineages.org/global_report_B.1.351.html">B.1.351</LinkExternal>           | &#124; 501Y.V2 |

--- a/web/src/components/Common/MutationBadge.tsx
+++ b/web/src/components/Common/MutationBadge.tsx
@@ -122,18 +122,20 @@ export interface MutationBadgeProps {
 }
 
 export function MutationBadge({ prefix, mutation, colors, tooltip }: MutationBadgeProps) {
-  const { parent, gene, left, pos, right, version, note } = mutation
+  const { parent, parentDelimiter, gene, left, pos, right, version, note } = mutation
 
   const parentColor = get(CLADE_COLORS, parent ?? '', DEFAULT_COLOR)
   const geneColor = get(GENE_COLORS, gene ?? '', DEFAULT_COLOR)
   const leftColor = get(colors, left ?? '', DEFAULT_COLOR)
   const rightColor = get(colors, right ?? '', DEFAULT_COLOR)
 
+  const parentDelimiterStr = parentDelimiter ?? ''
+
   return (
     <MutationBadgeBox title={tooltip}>
       <MutationWrapper>
         {prefix && <PrefixText>{prefix}</PrefixText>}
-        {parent && <ParentText $color={parentColor}>{`${parent}/`}</ParentText>}
+        {parent && <ParentText $color={parentColor}>{`${parent}${parentDelimiterStr}`}</ParentText>}
         {gene && (
           <>
             <GeneText $color={geneColor}>
@@ -143,9 +145,9 @@ export function MutationBadge({ prefix, mutation, colors, tooltip }: MutationBad
           </>
         )}
         {left && <ColoredText $color={leftColor}>{left}</ColoredText>}
-        <PositionText>{pos}</PositionText>
+        {pos && <PositionText>{pos}</PositionText>}
         {right && <ColoredText $color={rightColor}>{right}</ColoredText>}
-        {version && <VersionText>{`.${version}`}</VersionText>}
+        {version && <VersionText>{version}</VersionText>}
       </MutationWrapper>
       {note && <span>{note}</span>}
     </MutationBadgeBox>
@@ -165,7 +167,8 @@ export function NucleotideMutationBadge({ mutation }: NucleotideMutationBadgePro
   const { left, right, pos } = mutationObj
   const wildTypeBase = get(NUCELOTIDE_NAMES, left ?? '', '')
   const variantBase = get(NUCELOTIDE_NAMES, right ?? '', '')
-  const tooltip = `Mutation of nucleotide ${pos} from ${wildTypeBase} to ${variantBase}`
+  const posStr = pos ?? ''
+  const tooltip = `Mutation of nucleotide ${posStr} from ${wildTypeBase} to ${variantBase}`
 
   return <MutationBadge mutation={mutationObj} colors={NUCLEOTIDE_COLORS} tooltip={tooltip} />
 }
@@ -183,10 +186,9 @@ export function AminoacidMutationBadge({ mutation }: AminoacidMutationBadgeProps
   const { gene, left, pos, right } = mutationObj
   const wildTypeAA = get(AMINOACID_NAMES, left ?? '', '')
   const variantAA = right ? get(AMINOACID_NAMES, right, '') : 'one of several alternatives'
-
   const geneName = gene ? get(GENE_NAMES, gene, gene) : ''
-
-  const tooltip = `Mutation of amino acid ${pos} in ${geneName} from ${wildTypeAA} to ${variantAA}`
+  const posStr = pos ?? ''
+  const tooltip = `Mutation of amino acid ${posStr} in ${geneName} from ${wildTypeAA} to ${variantAA}`
 
   return <MutationBadge mutation={mutationObj} colors={AMINOACID_COLORS} tooltip={tooltip} />
 }

--- a/web/src/components/Common/__tests__/parseVariant.test.ts
+++ b/web/src/components/Common/__tests__/parseVariant.test.ts
@@ -1,0 +1,51 @@
+import { parseVariant } from 'src/components/Common/parseVariant'
+
+describe('parseVariant', () => {
+  it('should accept "20A.EU2"', async () => {
+    expect(parseVariant('20A.EU2')).toEqual({
+      parent: '20A',
+      parentDelimiter: undefined,
+      gene: undefined,
+      left: undefined,
+      pos: undefined,
+      right: undefined,
+      version: '.EU2',
+    })
+  })
+
+  it('should accept "20E (EU1)"', async () => {
+    expect(parseVariant('20E (EU1)')).toEqual({
+      parent: '20E',
+      parentDelimiter: undefined,
+      gene: undefined,
+      left: undefined,
+      pos: undefined,
+      right: undefined,
+      version: ' (EU1)',
+    })
+  })
+
+  it('should accept "20I/501Y.V1"', async () => {
+    expect(parseVariant('20I/501Y.V1')).toEqual({
+      parent: '20I',
+      parentDelimiter: '/',
+      gene: undefined,
+      left: undefined,
+      pos: 501,
+      right: 'Y',
+      version: '.V1',
+    })
+  })
+
+  it('should accept "20C/S:452R"', async () => {
+    expect(parseVariant('20C/S:452R')).toEqual({
+      parent: '20C',
+      parentDelimiter: '/',
+      gene: 'S',
+      left: undefined,
+      pos: 452,
+      right: 'R',
+      version: undefined,
+    })
+  })
+})

--- a/web/src/components/Common/formatMutation.ts
+++ b/web/src/components/Common/formatMutation.ts
@@ -3,7 +3,8 @@ import type { Mutation } from 'src/types'
 export function formatMutation({ gene, left, pos, right }: Mutation) {
   const geneStr = gene ? `${gene}:` : ''
   const leftStr = left ?? ''
+  const posStr = pos ?? ''
   const rightStr = right ?? ''
 
-  return `${geneStr}${leftStr}${pos}${rightStr}`
+  return `${geneStr}${leftStr}${posStr}${rightStr}`
 }

--- a/web/src/components/Common/parseVariant.ts
+++ b/web/src/components/Common/parseVariant.ts
@@ -10,6 +10,14 @@ export function parseNonEmpty(raw: string | undefined | null) {
 }
 
 export function parseVariant(formatted: string): Mutation | undefined {
+  if (formatted === '20A.EU2') {
+    return { parent: '20A', version: '.EU2' }
+  }
+
+  if (formatted === '20E (EU1)') {
+    return { parent: '20E', version: ' (EU1)' }
+  }
+
   const match = /^(?<parent>.*\/)?(?<gene>.*:)?(?<left>[*.a-z-]{0,1})(?<pos>(\d)*)(?<right>[*.a-z-]{0,1})(?<version>\..*)?$/i.exec(formatted) // prettier-ignore
 
   if (!match?.groups) {
@@ -20,16 +28,21 @@ export function parseVariant(formatted: string): Mutation | undefined {
     return undefined
   }
 
-  const parent = parseNonEmpty(match.groups?.parent)?.replace('/', '')
+  let parent = parseNonEmpty(match.groups?.parent)
+  let parentDelimiter: string | undefined
+  if (parent?.endsWith('/')) {
+    parent = parent.replace('/', '')
+    parentDelimiter = '/'
+  }
   const gene = parseNonEmpty(match.groups?.gene)?.replace(':', '')
   const left = parseNonEmpty(match.groups?.left)?.toUpperCase()
   const pos = parsePosition(match.groups?.pos)
   const right = parseNonEmpty(match.groups?.right)?.toUpperCase()
-  const version = parseNonEmpty(match.groups?.version)?.replace('.', '')
+  const version = parseNonEmpty(match.groups?.version)
 
   if (!pos) {
     return undefined
   }
 
-  return { parent, gene, left, pos, right, version }
+  return { parent, parentDelimiter, gene, left, pos, right, version }
 }

--- a/web/src/components/Variants/DefiningMutations.tsx
+++ b/web/src/components/Variants/DefiningMutations.tsx
@@ -57,7 +57,7 @@ export function DefiningMutations({ cluster }: DefiningMutationsProps) {
         {hasNonsynonymous ? (
           <Ul>
             {cluster.mutations?.nonsynonymous?.map((mutation) => (
-              <Li key={`${mutation?.gene ?? ''}:${mutation.left ?? ''}${mutation.pos}${mutation.right ?? ''}`}>
+              <Li key={`${mutation?.gene ?? ''}:${mutation.left ?? ''}${mutation.pos ?? ''}${mutation.right ?? ''}`}>
                 <AminoacidMutationBadge mutation={mutation} />
               </Li>
             ))}
@@ -72,7 +72,7 @@ export function DefiningMutations({ cluster }: DefiningMutationsProps) {
         {hasSynonymous ? (
           <Ul>
             {cluster.mutations?.synonymous?.map((mutation) => (
-              <Li key={`${mutation.left ?? ''}${mutation.pos}${mutation.right ?? ''}`}>
+              <Li key={`${mutation.left ?? ''}${mutation.pos ?? ''}${mutation.right ?? ''}`}>
                 <NucleotideMutationBadge mutation={mutation} />
               </Li>
             ))}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,8 +1,9 @@
 export interface Mutation {
   parent?: string
+  parentDelimiter?: string
   gene?: string
   left?: string
-  pos: number
+  pos?: number
   right?: string
   version?: string
   note?: string


### PR DESCRIPTION
This:
 - makes sure that badges for variants "20E (EU1)" and "20A.EU2" are rendered correctly
 - adds unit tests for variant string parser for some of the variants
![Screenshot from 2021-03-11 16-24-15](https://user-images.githubusercontent.com/9403403/110810620-42084980-8286-11eb-916d-ab98c3bd8972.png)
