### PR TITLE
Allow clusters to not have a nextstrain link

### DIFF
--- a/web/src/components/Variants/VariantsPage.tsx
+++ b/web/src/components/Variants/VariantsPage.tsx
@@ -81,7 +81,7 @@ export function VariantsPageDisconnected({ currentCluster }: VariantsPageProps) 
             <EditableClusterContent githubUrl={`blob/master/content/clusters/${currentCluster.build_name}.md`}>
               <Row noGutters className="mb-3">
                 <Col className="d-flex w-100">
-                  {currentCluster.nextstrain_url && (
+                  {currentCluster.nextstrain_url ? (
                     <LinkExternal
                       href={currentCluster.nextstrain_url}
                       icon={<NextstrainIcon />}
@@ -89,6 +89,8 @@ export function VariantsPageDisconnected({ currentCluster }: VariantsPageProps) 
                     >
                       {`Dedicated ${currentCluster.display_name} Nextstrain build`}
                     </LinkExternal>
+                  ) : (
+                    <span>{'No dedicated Nextstrain build is available'}</span>
                   )}
                 </Col>
               </Row>

--- a/web/src/components/Variants/VariantsPage.tsx
+++ b/web/src/components/Variants/VariantsPage.tsx
@@ -81,13 +81,15 @@ export function VariantsPageDisconnected({ currentCluster }: VariantsPageProps) 
             <EditableClusterContent githubUrl={`blob/master/content/clusters/${currentCluster.build_name}.md`}>
               <Row noGutters className="mb-3">
                 <Col className="d-flex w-100">
-                  <LinkExternal
-                    href={currentCluster.nextstrain_url}
-                    icon={<NextstrainIcon />}
-                    color={theme.link.dim.color}
-                  >
-                    {`Dedicated ${currentCluster.display_name} Nextstrain build`}
-                  </LinkExternal>
+                  {currentCluster.nextstrain_url && (
+                    <LinkExternal
+                      href={currentCluster.nextstrain_url}
+                      icon={<NextstrainIcon />}
+                      color={theme.link.dim.color}
+                    >
+                      {`Dedicated ${currentCluster.display_name} Nextstrain build`}
+                    </LinkExternal>
+                  )}
                 </Col>
               </Row>
 

--- a/web/src/io/getClusters.ts
+++ b/web/src/io/getClusters.ts
@@ -10,7 +10,7 @@ export const CLUSTER_NAME_OTHERS = 'others' as const
 
 export type ClusterDatum = {
   build_name: string
-  nextstrain_url: string
+  nextstrain_url?: string
   cluster_data: unknown[]
   col: string
   country_info: unknown[]


### PR DESCRIPTION
If a cluster entry in `clusters.py` does not have a `nextstrain_url` field, then Nextstrain link will not be shown on cluster's page. The text "No dedicated Nextstrain build is available" will be show instead.

Resolves #119 