### PR TITLE
Travis CI: Lint Python code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
   - cp .env.example .env
 
 script:
-  - flake8 . --count --select=E9,F63,F7 --show-source --statistics  # ,F82
+  - flake8 $HOME --count --select=E9,F63,F7 --show-source --statistics  # ,F82
   - yarn lint:ci
   - yarn test:coverage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
   - cp .env.example .env
 
 script:
-  - flake8 $HOME --count --select=E9,F63,F7 --show-source --statistics  # ,F82
+  - flake8 .. --count --select=E9,F63,F7 --show-source --statistics  # ,F82
   - yarn lint:ci
   - yarn test:coverage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 version: ~> 1.0
 
 os: linux
-dist: bionic
+dist: focal
 
 branches:
   only:
@@ -18,7 +18,7 @@ cache:
   - "./web/.cache"
 
 before_install:
-  - pip install awscli
+  - pip install awscli flake8
   - cd web
 
 install:
@@ -28,6 +28,7 @@ before_script:
   - cp .env.example .env
 
 script:
+  - flake8 . --count --select=E9,F63,F7 --show-source --statistics  # ,F82
   - yarn lint:ci
   - yarn test:coverage
 

--- a/scripts/allClusterDynamics.py
+++ b/scripts/allClusterDynamics.py
@@ -364,7 +364,7 @@ for clus in clus_to_run:
             temp_meta = meta[meta['division'].isin([coun])]
         else:
             temp_meta = meta[meta['country'].isin([coun])]
-        all_dates = [datetime.datetime.strptime(x, '%Y-%m-%d') for x in temp_meta["date"] if len(x) is 10 and "-XX" not in x and datetime.datetime.strptime(x, '%Y-%m-%d') >= cutoffDate]
+        all_dates = [datetime.datetime.strptime(x, '%Y-%m-%d') for x in temp_meta["date"] if len(x) == 10 and "-XX" not in x and datetime.datetime.strptime(x, '%Y-%m-%d') >= cutoffDate]
         if len(all_dates) == 0:
             country_info.loc[coun].sept_oct_freq = 0
         else:
@@ -400,13 +400,13 @@ for clus in clus_to_run:
         if 'url_params' in clusters[clus]:
             url_params = clusters[clus]['url_params']
 
-#        if clus is "S501":
+#        if clus == "S501":
 #        #    col = "c=gt-S_501&"
 #            filt = ""
-#        if clus is "S69":
+#        if clus == "S69":
 #            col = "c=gt-S_69,501,453&"
 #            filt = ""
-#        if clus is "S453":
+#        if clus == "S453":
 #            col = "c=gt-S_453&"
 
         # don't print DanishCluster in 'all tables'
@@ -415,7 +415,7 @@ for clus in clus_to_run:
             with open(f"{tables_path}all_tables.md", 'a') as fh:
                 fh.write(f'\n\n## {clus_display}\n')
                 fh.write(f"[Focal Build](https://nextstrain.org/groups/neherlab/ncov/{clus_display}?{url_params})\n\n")
-                if clus is "S501":
+                if clus == "S501":
                     fh.write(f"Note any pre-2020 Chinese sequences are from SARS-like viruses in bats (not SARS-CoV-2).\n")
                     fh.write(f"Note that this mutation has multiple amino-acid mutants - these numbers "
                             "refer to _all_ these mutations (Y, S, T).\n")
@@ -426,7 +426,7 @@ for clus in clus_to_run:
         with open(f"{tables_path}{clus_display}_table.md", 'w') as fh:
             fh.write(f'\n\n## {clus_display}\n')
             fh.write(f"[Focal Build](https://nextstrain.org/groups/neherlab/ncov/{clus_display}?{url_params})\n\n")
-            if clus is "S501":
+            if clus == "S501":
                 fh.write(f"Note any pre-2020 Chinese sequences are from SARS-like viruses in bats (not SARS-CoV-2).\n")
                 fh.write(f"Note that this mutation has multiple amino-acid mutants - these numbers "
                           "refer to _all_ these mutations (Y, S, T).\n")
@@ -465,7 +465,7 @@ for clus in clus_to_run:
         #week 20
         for ri, row in temp_meta.iterrows():
             dat = row.date
-            if len(dat) is 10 and "-XX" not in dat: # only take those that have real dates
+            if len(dat) == 10 and "-XX" not in dat: # only take those that have real dates
                 dt = datetime.datetime.strptime(dat, '%Y-%m-%d')
                 #exclude sequences with identical dates & underdiverged
                 if coun == "Ireland" and dat == "2020-09-22":

--- a/scripts/clusterDynamics.py
+++ b/scripts/clusterDynamics.py
@@ -239,7 +239,7 @@ for clus in clus_to_run:
             temp_meta = meta[meta['division'].isin([coun])]
         else:
             temp_meta = meta[meta['country'].isin([coun])]
-        all_dates = [datetime.datetime.strptime(x, '%Y-%m-%d') for x in temp_meta["date"] if len(x) is 10 and "-XX" not in x and datetime.datetime.strptime(x, '%Y-%m-%d') >= cutoffDate]
+        all_dates = [datetime.datetime.strptime(x, '%Y-%m-%d') for x in temp_meta["date"] if len(x) == 10 and "-XX" not in x and datetime.datetime.strptime(x, '%Y-%m-%d') >= cutoffDate]
         if len(all_dates) == 0:
             country_info.loc[coun].sept_oct_freq = 0
         else:
@@ -289,7 +289,7 @@ for clus in clus_to_run:
         #week 20
         for ri, row in temp_meta.iterrows():
             dat = row.date
-            if len(dat) is 10 and "-XX" not in dat: # only take those that have real dates
+            if len(dat) == 10 and "-XX" not in dat: # only take those that have real dates
                 dt = datetime.datetime.strptime(dat, '%Y-%m-%d')
                 #exclude sequences with identical dates & underdiverged
                 if coun == "Ireland" and dat == "2020-09-22":
@@ -532,7 +532,7 @@ for clus in clus_to_run:
                 counts_by_week = defaultdict(int)
                 temp_meta = meta[meta['country'].isin([coun])]
                 for dat in temp_meta['date']:
-                    if len(dat) is 10 and "-XX" not in dat: # only take those that have real dates
+                    if len(dat) == 10 and "-XX" not in dat: # only take those that have real dates
                         dt = datetime.datetime.strptime(dat, '%Y-%m-%d')
                         wk = dt.isocalendar()[1] #returns ISO calendar week
                         counts_by_week[wk]+=1
@@ -554,7 +554,7 @@ for clus in clus_to_run:
                 color='tab:blue'
                 ax1.set_ylabel('New Cases', color=color)
                 lines.append(ax1.plot(case_week_as_date[:-1] , case_data.cases[:-1], color=color, label='cases per week')[0])
-                #if coun is not 'Norway':
+                #if coun != 'Norway':
                 #    lines.append(ax1.plot(case_week_as_date , case_data.cases*(1 - logistic(days, rates[coun]['center'], rates[coun]['t50']) ), color=color, ls='--', label='cases per week w/o cluster')[0])
                 ax1.tick_params(axis='y', labelcolor=color)
                 ax1.set_yscale("log")
@@ -570,7 +570,7 @@ for clus in clus_to_run:
                 ax2.set_yscale("log")
 
                 fig.autofmt_xdate(rotation=30)
-                if coun is 'Norway':
+                if coun == 'Norway':
                     plt.legend(lines, ['cases per week', 'total sequences', 'sequences in cluster'], loc=3)
                 else:
                     plt.legend(lines, ['cases per week', #'cases per week w/o cluster',

--- a/scripts/compare_S222_S477.py
+++ b/scripts/compare_S222_S477.py
@@ -89,7 +89,7 @@ for clus in clusters.keys():
             temp_meta = meta[meta['division'].isin([coun])]
         else:
             temp_meta = meta[meta['country'].isin([coun])]
-        all_dates = [datetime.datetime.strptime(x, '%Y-%m-%d') for x in temp_meta["date"] if len(x) is 10 and "-XX" not in x and datetime.datetime.strptime(x, '%Y-%m-%d') >= cutoffDate]
+        all_dates = [datetime.datetime.strptime(x, '%Y-%m-%d') for x in temp_meta["date"] if len(x) == 10 and "-XX" not in x and datetime.datetime.strptime(x, '%Y-%m-%d') >= cutoffDate]
         country_info.loc[coun].sept_aug_freq = round(len(herbst_dates)/len(all_dates),2)
 
     print(f"\nCluster {clus}")
@@ -117,7 +117,7 @@ for clus in clusters.keys():
         #week 20
         for ri, row in temp_meta.iterrows():
             dat = row.date
-            if len(dat) is 10 and "-XX" not in dat: # only take those that have real dates
+            if len(dat) == 10 and "-XX" not in dat: # only take those that have real dates
                 dt = datetime.datetime.strptime(dat, '%Y-%m-%d')
                 #exclude sequences with identical dates & underdiverged
                 if coun == "Ireland" and dat == "2020-09-22":
@@ -230,7 +230,7 @@ for coun, ax in zip(countries_to_plot, axs[1:]):
         patch = mpatches.Patch(color=clusters[clus]['col'], label=lab)
 
         #exclude 501 for now (not present)
-        if clus is not "S501":
+        if clus == not "S501":
             ptchs.append(patch)
         if i == len(clusters)-1 :
             ax.fill_between(week_as_date, cluster_count/total_count, 1, facecolor=grey_color)

--- a/scripts/compare_S222_S477.py
+++ b/scripts/compare_S222_S477.py
@@ -230,7 +230,7 @@ for coun, ax in zip(countries_to_plot, axs[1:]):
         patch = mpatches.Patch(color=clusters[clus]['col'], label=lab)
 
         #exclude 501 for now (not present)
-        if clus == not "S501":
+        if clus != "S501":
             ptchs.append(patch)
         if i == len(clusters)-1 :
             ax.fill_between(week_as_date, cluster_count/total_count, 1, facecolor=grey_color)

--- a/scripts/compare_country_lineages.py
+++ b/scripts/compare_country_lineages.py
@@ -135,7 +135,7 @@ for clus in clusters:
             temp_meta = meta[meta['division'].isin([coun])]
         else:
             temp_meta = meta[meta['country'].isin([coun])]
-        all_dates = [datetime.datetime.strptime(x, '%Y-%m-%d') for x in temp_meta["date"] if len(x) is 10 and "-XX" not in x and datetime.datetime.strptime(x, '%Y-%m-%d') >= cutoffDate]
+        all_dates = [datetime.datetime.strptime(x, '%Y-%m-%d') for x in temp_meta["date"] if len(x) == 10 and "-XX" not in x and datetime.datetime.strptime(x, '%Y-%m-%d') >= cutoffDate]
         #country_info.loc[coun].sept_aug_freq = round(len(herbst_dates)/len(all_dates),2)
 
     print(f"\nCluster {clus}")
@@ -167,7 +167,7 @@ for clus in clusters:
         #week 20
         for ri, row in temp_meta.iterrows():
             dat = row.date
-            if len(dat) is 10 and "-XX" not in dat: # only take those that have real dates
+            if len(dat) == 10 and "-XX" not in dat: # only take those that have real dates
                 dt = datetime.datetime.strptime(dat, '%Y-%m-%d')
                 #exclude sequences with identical dates & underdiverged
                 if coun == "Ireland" and dat == "2020-09-22":

--- a/scripts/tree_pie_plot.py
+++ b/scripts/tree_pie_plot.py
@@ -295,7 +295,7 @@ def list_parent_countries(wanted_country, second_country):
 fs = 16
 fig = plt.figure(figsize=(12,18))
 ax = fig.add_subplot(1,1,1)
-Phylo.draw(cluster2, label_func=lambda x:'', axes=ax),
+Phylo.draw(cluster2, label_func=lambda x:'', axes=ax,
            branch_labels=lambda x: ",".join([f"{a}{p+1}{d}" for a,p,d in x.mutations]))
 
 for node in cluster2.find_clades(order="preorder"):


### PR DESCRIPTION
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.

---

Avoid [SyntaxWarnings on Python >= 3.8](https://docs.python.org/3/whatsnew/3.8.html#porting-to-python-3-8).

% `python3.8` or `python3.9`
```
>>> 10 is 10
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```

