### PR TITLE
don't add so many labels to new issues by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_report_bug.md
+++ b/.github/ISSUE_TEMPLATE/01_report_bug.md
@@ -1,5 +1,5 @@
 ---
 name: 🐛 Report a bug
 about: If something is broken
-labels: bug, help wanted, good first issue, needs triage
+labels: bug, needs triage
 ---

--- a/.github/ISSUE_TEMPLATE/02_request_feature.md
+++ b/.github/ISSUE_TEMPLATE/02_request_feature.md
@@ -1,5 +1,5 @@
 ---
 name: 🙋 Request a feature
 about: Suggest an improvement, propose changes 
-labels: enhancement, help wanted, good first issue, needs triage
+labels: enhancement, needs triage
 ---


### PR DESCRIPTION
The `help wanted` and `good first issue` tags should probably be added (if appropriate) when an issue is triaged, rather than being added immediately by default. 