### PR TITLE
Fix typo in 20A.EU1.md

### DIFF
--- a/content/clusters/20A.EU1.md
+++ b/content/clusters/20A.EU1.md
@@ -1,7 +1,7 @@
 
 20A.EU1 initially expanded in Spain and spread widely across Europe via holiday travel ([Hodcroft et al., medRXiv](https://www.medrxiv.org/content/10.1101/2020.10.25.20219063v2)). In the summer of 2020, it became the most prevalent SARS-CoV-2 variant in western Europe.
 
-- <AaMut mut={'S:A222V'}/> is a mutation in the non-terminal domain (NTD), which is not known to play a direct role in receptor binding or membrane fusion.
+- <AaMut mut={'S:A222V'}/> is a mutation in the N-terminal domain (NTD), which is not known to play a direct role in receptor binding or membrane fusion.
 
 - Pseudotyped lentivirus with the <AaMut mut={'S:A222V'}/> mutation did not have a measurably different viral titer than without the mutation ([Hodcroft et al., medRXiv](https://www.medrxiv.org/content/10.1101/2020.10.25.20219063v2)).
 


### PR DESCRIPTION
Believe this should read 'N-terminal domain' (pertaining to the 'N-terminus') instead of 'non-terminal domain'.

