### PR TITLE
Warn about missing acknowledgements on data update

### DIFF
--- a/web/src/components/Acknowledgements/AcknowledgementsPage.tsx
+++ b/web/src/components/Acknowledgements/AcknowledgementsPage.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { Col, Container, Row } from 'reactstrap'
 
 import { getClusters } from 'src/io/getClusters'
+import { getAcknowledgementsKeys } from 'src/io/getClusterEpiIslsNumChunks'
 import { Layout } from 'src/components/Layout/Layout'
 import { AcknowledgementsCard } from 'src/components/Acknowledgements/AcknowledgementsCard'
 
@@ -16,7 +17,11 @@ export const AcknowledgementsPageContainer = styled(Container)`
 
 const clusters = getClusters()
 
+const acknowledgementsKeys = getAcknowledgementsKeys()
+
 export function AcknowledgementsPage() {
+  const clustersWithAcks = clusters.filter((cluster) => acknowledgementsKeys.has(cluster.build_name))
+
   return (
     <Layout>
       <AcknowledgementsPageContainer>
@@ -34,7 +39,7 @@ export function AcknowledgementsPage() {
 
         <Row>
           <Col>
-            {clusters.map((cluster) => (
+            {clustersWithAcks.map((cluster) => (
               <AcknowledgementsCard key={cluster.build_name} cluster={cluster} />
             ))}
           </Col>

--- a/web/src/io/getClusterEpiIslsNumChunks.ts
+++ b/web/src/io/getClusterEpiIslsNumChunks.ts
@@ -2,6 +2,16 @@ import { get } from 'lodash'
 
 import acknowledgements from 'src/../data/acknowledgements/acknowledgements_keys.json'
 
+export function getAcknowledgementsKeys(): Set<string> {
+  const acks = get(acknowledgements, 'acknowledgements')
+  if (!acks) {
+    console.warn(`Acknowledgements not found`)
+    return new Set()
+  }
+
+  return new Set(Object.keys(acknowledgements.acknowledgements))
+}
+
 export function getClusterEpiIslsNumChunks(clusterBuildName: string): number {
   const acks = get(acknowledgements, 'acknowledgements')
   if (!acks) {


### PR DESCRIPTION
This PR

 - Adds warning messages if acknowledgements data is missing when running web data update script. The script now checks for:
    - `acknowledgements_keys.json` to contain all clusters present in `clusters.json` (that are not of `type: do_not_display`)
    - presence of acknowledgements directory (with JSON chunks) for each cluster
    - number and names of chunk files consistency with `numChunks` in `acknowledgements_keys.json` for each cluster

 - Prevents "Acknowledgements" page from crashing the whole application when acknowledgements data is incomplete (by filtering clusters displayed on "Acknowledgements" to the ones present in `acknowledgements_keys.json`)
