### PR TITLE
add new WHO Labels to variant table

### DIFF
--- a/scripts/name_table.py
+++ b/scripts/name_table.py
@@ -4,6 +4,7 @@ import urllib.error
 name_table = [
     {
         "clade": "20E (EU1)",
+        "who": None,
         "lineages": [
             {"name": "B.1.177", "url": None},
         ],
@@ -13,6 +14,7 @@ name_table = [
     },
     {
         "clade": "20A.EU2",
+        "who": None,
         "lineages": [
             {"name": "B.1.160", "url": None}
         ],
@@ -20,6 +22,7 @@ name_table = [
     },
     {
         "clade": "20I/501Y.V1",
+        "who": "Alpha",
         "lineages": [
             {"name": "B.1.1.7", "url": None}
         ],
@@ -29,6 +32,7 @@ name_table = [
     },
     {
         "clade": "20H/501Y.V2",
+        "who": "Beta",
         "lineages": [
             {"name": "B.1.351", "url": None}
         ],
@@ -38,6 +42,7 @@ name_table = [
     },
     {
         "clade": "20J/501Y.V3",
+        "who": "Gamma",
         "lineages": [
             {"name": "P.1", "url": None}
         ],
@@ -45,6 +50,7 @@ name_table = [
     },
     {
         "clade": "20C/S:452R",
+        "who": "Epsilon",
         "lineages": [
             {"name": "B.1.427", "url": None},
             {"name": "B.1.429", "url": None}
@@ -55,6 +61,7 @@ name_table = [
     },
     {
         "clade": "20A/S:484K",
+        "who": "Eta",
         "lineages": [
             {"name": "B.1.525", "url": None}
         ],
@@ -62,6 +69,7 @@ name_table = [
     },
     {
         "clade": "20C/S:484K",
+        "who": "Iota",
         "lineages": [
             {"name": "B.1.526", "url": None}
         ],
@@ -71,6 +79,7 @@ name_table = [
     },
     {
         "clade": "21A/S:154K",
+        "who": "Kappa",
         "lineages": [
             {"name": "B.1.617.1", "url": "https://cov-lineages.org/lineages/lineage_B.1.617.1.html"}
         ],
@@ -78,6 +87,7 @@ name_table = [
     },
     {
         "clade": "21A/S:478K",
+        "who": "Delta",
         "lineages": [
             {"name": "B.1.617.2", "url": "https://cov-lineages.org/lineages/lineage_B.1.617.2.html"}
         ],
@@ -85,6 +95,7 @@ name_table = [
     },
     {
         "clade": "20A/S:439K",
+        "who": None,
         "lineages": [
             {"name": "B.1.258", "url": None}
         ],
@@ -92,6 +103,7 @@ name_table = [
     },
     {
         "clade": "20A/S:98F",
+        "who": None,
         "lineages": [
             {"name": "B.1.221", "url": None}
         ],
@@ -99,6 +111,7 @@ name_table = [
     },
     {
         "clade": "20C/S:80Y",
+        "who": None,
         "lineages": [
             {"name": "B.1.367", "url": None}
         ],
@@ -106,6 +119,7 @@ name_table = [
     },
     {
         "clade": "20B/S:626S",
+        "who": None,
         "lineages": [
             {"name": "B.1.1.277", "url": None}
         ],
@@ -113,6 +127,7 @@ name_table = [
     },
     {
         "clade": "20B/S:1122L",
+        "who": None,
         "lineages": [
             {"name": "B.1.1.302", "url": None}
         ],

--- a/web/data/nameTable.json
+++ b/web/data/nameTable.json
@@ -2,6 +2,7 @@
   "nameTable": [
     {
       "clade": "20E (EU1)",
+      "who": null,
       "lineages": [
         {
           "name": "B.1.177",
@@ -17,6 +18,7 @@
     },
     {
       "clade": "20A.EU2",
+      "who": null,
       "lineages": [
         {
           "name": "B.1.160",
@@ -27,6 +29,7 @@
     },
     {
       "clade": "20I/501Y.V1",
+      "who": "Alpha",
       "lineages": [
         {
           "name": "B.1.1.7",
@@ -42,6 +45,7 @@
     },
     {
       "clade": "20H/501Y.V2",
+      "who": "Beta",
       "lineages": [
         {
           "name": "B.1.351",
@@ -57,6 +61,7 @@
     },
     {
       "clade": "20J/501Y.V3",
+      "who": "Gamma",
       "lineages": [
         {
           "name": "P.1",
@@ -67,6 +72,7 @@
     },
     {
       "clade": "20C/S:452R",
+      "who": "Epsilon",
       "lineages": [
         {
           "name": "B.1.427",
@@ -86,6 +92,7 @@
     },
     {
       "clade": "20A/S:484K",
+      "who": "Eta",
       "lineages": [
         {
           "name": "B.1.525",
@@ -96,6 +103,7 @@
     },
     {
       "clade": "20C/S:484K",
+      "who": "Iota",
       "lineages": [
         {
           "name": "B.1.526",
@@ -111,6 +119,7 @@
     },
     {
       "clade": "21A/S:154K",
+      "who": "Kappa",
       "lineages": [
         {
           "name": "B.1.617.1",
@@ -121,6 +130,7 @@
     },
     {
       "clade": "21A/S:478K",
+      "who": "Delta",
       "lineages": [
         {
           "name": "B.1.617.2",
@@ -131,6 +141,7 @@
     },
     {
       "clade": "20A/S:439K",
+      "who": null,
       "lineages": [
         {
           "name": "B.1.258",
@@ -141,6 +152,7 @@
     },
     {
       "clade": "20A/S:98F",
+      "who": null,
       "lineages": [
         {
           "name": "B.1.221",
@@ -151,6 +163,7 @@
     },
     {
       "clade": "20C/S:80Y",
+      "who": null,
       "lineages": [
         {
           "name": "B.1.367",
@@ -161,6 +174,7 @@
     },
     {
       "clade": "20B/S:626S",
+      "who": null,
       "lineages": [
         {
           "name": "B.1.1.277",
@@ -171,6 +185,7 @@
     },
     {
       "clade": "20B/S:1122L",
+      "who": null,
       "lineages": [
         {
           "name": "B.1.1.302",

--- a/web/src/components/Common/NameTable.tsx
+++ b/web/src/components/Common/NameTable.tsx
@@ -65,7 +65,7 @@ export interface NameTableRowProps {
 }
 
 export function NameTableRow({ datum }: NameTableRowProps) {
-  const { clade, lineages, others } = datum
+  const { clade, lineages, who, others } = datum
 
   const lineageEntries = useMemo(
     () =>
@@ -89,6 +89,7 @@ export function NameTableRow({ datum }: NameTableRowProps) {
         <Var name={clade} prefix="" />
       </Td>
       <Td>{lineageEntries}</Td>
+      <Td>{who}</Td>
       <Td>{otherEntries}</Td>
     </Tr>
   )
@@ -101,6 +102,11 @@ export function NameTable() {
         <Tr>
           <Th>{'Nextstrain Clade'}</Th>
           <Th>{'Pango Lineage'}</Th>
+          <Th>
+            <LinkExternal href="https://www.who.int/en/activities/tracking-SARS-CoV-2-variants/">
+              {'WHO Label'}
+            </LinkExternal>
+          </Th>
           <Th>{'Other Names'}</Th>
         </Tr>
       </Thead>

--- a/web/src/io/getNameTable.ts
+++ b/web/src/io/getNameTable.ts
@@ -7,6 +7,7 @@ export interface NameTableEntry {
 
 export interface NameTableDatum {
   clade: string
+  who: string | null
   lineages: NameTableEntry[]
   others: NameTableEntry[]
 }


### PR DESCRIPTION
This adds the new [Greek letter variant names](https://www.who.int/en/activities/tracking-SARS-CoV-2-variants/) to the table of variants:

![who-labels](https://user-images.githubusercontent.com/338833/120451775-9e609e00-c389-11eb-826d-eb19701b7cb5.png)

