### PR TITLE
Use monospace font for variants, prettify name table

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -111,8 +111,8 @@
     "reselect": "4.0.0",
     "serialize-javascript": "5.0.1",
     "styled-components": "5.1.1",
-    "typeface-open-sans": "1.1.13",
-    "typeface-source-code-pro": "1.1.13",
+    "typeface-droid-sans-mono": "0.0.44",
+    "typeface-open-sans": "0.0.75",
     "url-join": "4.0.1"
   },
   "devDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -111,7 +111,8 @@
     "reselect": "4.0.0",
     "serialize-javascript": "5.0.1",
     "styled-components": "5.1.1",
-    "typeface-open-sans": "0.0.75",
+    "typeface-open-sans": "1.1.13",
+    "typeface-source-code-pro": "1.1.13",
     "url-join": "4.0.1"
   },
   "devDependencies": {

--- a/web/src/components/ClusterButtonPanel/ClusterButton.tsx
+++ b/web/src/components/ClusterButtonPanel/ClusterButton.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable camelcase */
 import React from 'react'
-import { ClusterNameText } from 'src/components/CountryDistribution/CountryDistributionPlotTooltip'
 
 import { ClusterDatum } from 'src/io/getClusters'
 import styled from 'styled-components'
@@ -73,7 +72,6 @@ const ClusterButtonComponent = styled(Link)<{ $isCurrent: boolean; $color: strin
 const ClusterTitle = styled.h2<{ $isCurrent: boolean }>`
   font-family: ${(props) => props.theme.font.monospace};
   font-size: 1.2rem;
-  font-weight: ${(props) => props.$isCurrent && 600};
 
   @media (min-width: 992px) {
     margin-left: 1rem;

--- a/web/src/components/ClusterButtonPanel/ClusterButton.tsx
+++ b/web/src/components/ClusterButtonPanel/ClusterButton.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import React from 'react'
+import { ClusterNameText } from 'src/components/CountryDistribution/CountryDistributionPlotTooltip'
 
 import { ClusterDatum } from 'src/io/getClusters'
 import styled from 'styled-components'
@@ -69,18 +70,20 @@ const ClusterButtonComponent = styled(Link)<{ $isCurrent: boolean; $color: strin
   }
 `
 
-const ClusterTitle = styled.h1<{ $isCurrent: boolean }>`
+const ClusterTitle = styled.h2<{ $isCurrent: boolean }>`
+  font-family: ${(props) => props.theme.font.monospace};
+  font-size: 1.2rem;
+  font-weight: ${(props) => props.$isCurrent && 600};
+
   @media (min-width: 992px) {
     margin-left: 1rem;
   }
 
   @media (max-width: 991.98px) {
-    font-size: 1rem;
+    font-size: 0.8rem;
     margin: auto 3px;
   }
 
-  font-weight: ${(props) => props.$isCurrent && 600};
-  font-size: ${(props) => (props.$isCurrent ? '1.5rem' : '1.33rem')};
   margin: auto 5px;
 
   color: ${({ $isCurrent, theme }) => ($isCurrent ? theme.gray700 : theme.gray600)};

--- a/web/src/components/Common/NameTable.tsx
+++ b/web/src/components/Common/NameTable.tsx
@@ -29,12 +29,19 @@ const Table = styled(TableBase)`
   }
 
   & > thead > tr > th {
+    font-size: 0.9rem;
     text-align: center;
     height: 3rem;
+    border: #aaa solid 1px;
   }
 
   & > tbody > tr > td {
-    text-align: center;
+    font-family: ${(props) => props.theme.font.monospace};
+    font-size: 0.8rem;
+    text-align: left;
+    border: #aaa solid 1px;
+    min-width: 150px;
+    padding: 2px;
   }
 `
 

--- a/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
@@ -38,6 +38,10 @@ const TooltipTable = styled.table`
 
 const TooltipTableBody = styled.tbody``
 
+export const ClusterNameText = styled.span`
+  font-family: ${(props) => props.theme.font.monospace};
+`
+
 export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps<number, string>) {
   const { payload } = props
   if (!payload || payload.length === 0) {
@@ -73,7 +77,7 @@ export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps
             <tr key={name}>
               <td className="px-2 text-left">
                 <ColoredBox $color={getClusterColor(name ?? '')} $size={10} $aspect={1.66} />
-                <span>{name}</span>
+                <ClusterNameText>{name}</ClusterNameText>
               </td>
               <td className="px-2 text-right">{value !== undefined && value > EPSILON ? formatInteger(value) : '-'}</td>
               <td className="px-2 text-right">

--- a/web/src/components/DistributionSidebar/ClusterFilters.tsx
+++ b/web/src/components/DistributionSidebar/ClusterFilters.tsx
@@ -27,6 +27,10 @@ export const Form = styled(FormBase)`
   flex-wrap: wrap;
 `
 
+export const ClusterNameText = styled.span`
+  font-family: ${(props) => props.theme.font.monospace};
+`
+
 export interface ClusterFilterCheckboxProps {
   cluster: string
   enabled: boolean
@@ -41,7 +45,7 @@ export function ClusterFilterCheckbox({ cluster, enabled, onFilterChange }: Clus
       <Label htmlFor={CSS.escape(cluster)} check>
         <Input id={CSS.escape(cluster)} type="checkbox" checked={enabled} onChange={onChange} />
         <ColoredBox $color={getClusterColor(cluster)} $size={14} $aspect={16 / 9} />
-        <span>{cluster}</span>
+        <ClusterNameText>{cluster}</ClusterNameText>
       </Label>
     </FormGroup>
   )

--- a/web/src/styles/_variables.scss
+++ b/web/src/styles/_variables.scss
@@ -31,7 +31,7 @@ $width-xxl: map.get($grid-breakpoints, 'xxl');
 
 $font-family-sans-serif: 'Open Sans', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Helvetica Neue', 'Arial',
   'system-ui', 'system-sans', 'sans-serif';
-$font-family-monospace: 'Roboto Mono', 'system-mono';
+$font-family-monospace: 'Droid Sans Mono', 'system-mono';
 $font-family-default: $font-family-sans-serif;
 $font-family-base: $font-family-default;
 $font-size-base: 1rem;

--- a/web/src/styles/global.scss
+++ b/web/src/styles/global.scss
@@ -1,7 +1,7 @@
 @use "sass:map";
 
 @import '~typeface-open-sans/index.css';
-@import '~typeface-source-code-pro/index.css';
+@import '~typeface-droid-sans-mono/index.css';
 @import '~bootstrap-icons/font/bootstrap-icons.css';
 @import './font-family-system';
 
@@ -9,8 +9,8 @@
 @import './bootstrap';
 @import './theme';
 
-@import 'react-aspect-ratio/aspect-ratio.css';
-@import 'react-gif-player/src/GifPlayer.scss';
+@import '~react-aspect-ratio/aspect-ratio.css';
+@import '~react-gif-player/src/GifPlayer.scss';
 @import '~react-super-responsive-table/dist/SuperResponsiveTableStyle.css';
 
 .gif_player {

--- a/web/src/styles/global.scss
+++ b/web/src/styles/global.scss
@@ -1,6 +1,7 @@
 @use "sass:map";
 
 @import '~typeface-open-sans/index.css';
+@import '~typeface-source-code-pro/index.css';
 @import '~bootstrap-icons/font/bootstrap-icons.css';
 @import './font-family-system';
 

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -94,7 +94,7 @@ export const themeColors = {
 
 export const font = {
   sansSerif: `'Open Sans', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Helvetica Neue', 'Arial', 'system-ui', 'system-sans', 'sans-serif'`,
-  monospace: `'Source Code Pro', 'Roboto Mono', 'system-mono'`,
+  monospace: `'Droid Sans Mono', 'system-mono'`,
   default: 'sans-serif',
 }
 

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -94,7 +94,7 @@ export const themeColors = {
 
 export const font = {
   sansSerif: `'Open Sans', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Helvetica Neue', 'Arial', 'system-ui', 'system-sans', 'sans-serif'`,
-  monospace: `'Roboto Mono', 'system-mono'`,
+  monospace: `'Source Code Pro', 'Roboto Mono', 'system-mono'`,
   default: 'sans-serif',
 }
 

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -13133,15 +13133,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typeface-open-sans@1.1.13:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/typeface-open-sans/-/typeface-open-sans-1.1.13.tgz#32a09ebd7df59601e01ad81216f98ce641eeafd1"
-  integrity sha512-lVGVHvYl7UJDFB9vN8r7NHw3sVm7Rjeow6b9AeABc/J+2mDaCkmcdVtw3QZnsJW39P+xm5zeggIj9gLHYGn9Iw==
+typeface-droid-sans-mono@0.0.44:
+  version "0.0.44"
+  resolved "https://registry.yarnpkg.com/typeface-droid-sans-mono/-/typeface-droid-sans-mono-0.0.44.tgz#186d544e3d59c55efc6e66979e5e2d22ee54e414"
+  integrity sha512-Mx5mDCSKlgL3SzTCVcqk0w3C4g53hmpONbwSqtwfa/U2QLFUw/bPGUgFXCnsFCBQm5OMbaKyvwXWZ0E0gQ5Gdg==
 
-typeface-source-code-pro@1.1.13:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/typeface-source-code-pro/-/typeface-source-code-pro-1.1.13.tgz#88c8787f90294d00c3b05c35adc096a2d07d922f"
-  integrity sha512-TX3c89uW9uc5SJNFWY8HBFkZqcxcNY7nJz0rw+0Pk2ZVsog/v2d04yKRsPU+jJI4wFegOvWXbOWt927i/xUdIw==
+typeface-open-sans@0.0.75:
+  version "0.0.75"
+  resolved "https://registry.yarnpkg.com/typeface-open-sans/-/typeface-open-sans-0.0.75.tgz#20d0c330f14c0c40463c334adbedd6005389abe4"
+  integrity sha512-0lLmB7pfj113OP4T78SbpSmC4OCdFQ0vUxdSXQccsSb6qF76F92iEuC/DghFgmPswTyidk8+Hwf+PS/htiJoRQ==
 
 typescript-compare@^0.0.2:
   version "0.0.2"

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -13133,10 +13133,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typeface-open-sans@0.0.75:
-  version "0.0.75"
-  resolved "https://registry.yarnpkg.com/typeface-open-sans/-/typeface-open-sans-0.0.75.tgz#20d0c330f14c0c40463c334adbedd6005389abe4"
-  integrity sha512-0lLmB7pfj113OP4T78SbpSmC4OCdFQ0vUxdSXQccsSb6qF76F92iEuC/DghFgmPswTyidk8+Hwf+PS/htiJoRQ==
+typeface-open-sans@1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/typeface-open-sans/-/typeface-open-sans-1.1.13.tgz#32a09ebd7df59601e01ad81216f98ce641eeafd1"
+  integrity sha512-lVGVHvYl7UJDFB9vN8r7NHw3sVm7Rjeow6b9AeABc/J+2mDaCkmcdVtw3QZnsJW39P+xm5zeggIj9gLHYGn9Iw==
+
+typeface-source-code-pro@1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/typeface-source-code-pro/-/typeface-source-code-pro-1.1.13.tgz#88c8787f90294d00c3b05c35adc096a2d07d922f"
+  integrity sha512-TX3c89uW9uc5SJNFWY8HBFkZqcxcNY7nJz0rw+0Pk2ZVsog/v2d04yKRsPU+jJI4wFegOvWXbOWt927i/xUdIw==
 
 typescript-compare@^0.0.2:
   version "0.0.2"


### PR DESCRIPTION
Switched the font for variant names in some places to monospace. This way the sections in new variant names are nicely aligned.

Current font is "Source Code Pro"

We might try other, prettier fonts too. I would think that a monospace sans serif font would do the best here. Serif fonts jump out immediately, because the rest of the page is sans. Here are some random font viewers:

https://fonts.google.com/?category=Sans+Serif,Monospace
https://www.1001fonts.com/monospaced-fonts.html
https://www.fontsquirrel.com/fonts/list/classification/monospaced
https://fontsarena.com/monospace/
https://en.wikipedia.org/wiki/List_of_monospaced_typefaces


Screenshots:
---

![00](https://user-images.githubusercontent.com/9403403/122441940-5737f700-cf9e-11eb-9355-c131e828099f.png)

---

![01](https://user-images.githubusercontent.com/9403403/122441903-4edfbc00-cf9e-11eb-8550-907e6f802833.png)

---

![02](https://user-images.githubusercontent.com/9403403/122442135-86e6ff00-cf9e-11eb-8830-68e84eb3ede6.png)
