### PR TITLE
Make cluster button sidebar width fixed

### DIFF
--- a/content/VariantsPageIntro.md
+++ b/content/VariantsPageIntro.md
@@ -1,3 +1,5 @@
+import { NameTable } from 'src/components/Common/NameTable'
+
 Click one of the colored buttons to look at a particular [Variant](/variants) - to read information, see graphs and the protein structure, and link out to focused Nextstrain builds.
 
 To look at many variants at once, check out the [Per Variant](/per-variant) and [Per Country](/per-country) pages, where you can view a lot of data in the same place, and compare variants and countries!
@@ -5,3 +7,6 @@ To look at many variants at once, check out the [Per Variant](/per-variant) and 
 Variants included on CoVariants include internationally recognised Variants of Concern (VoC) and many Variants of Interest (VoI), as well as other variants which have expanded rapidly, dominated in countries or regions, or feature mutations of interest.
 
 Mutations included on CoVariants are mutations associated with VoCs or other variants, which have an association with observed or hypothetical changes in viral transmission, immune escape, or clinical outcome. 
+
+
+<NameTable />

--- a/web/src/components/ClusterButtonPanel/ClusterButton.tsx
+++ b/web/src/components/ClusterButtonPanel/ClusterButton.tsx
@@ -5,53 +5,11 @@ import { ClusterDatum } from 'src/io/getClusters'
 import styled from 'styled-components'
 import { Link } from '../Link/Link'
 
-const ClusterButtonRow = styled.span`
-  flex: 1 0 150px;
-  display: flex;
-
-  @media (min-width: 992px) {
-    flex: 1 0 170px;
-    flex-grow: 1;
-    height: 50px;
-    margin: 3px auto;
-  }
-
-  @media (max-width: 991.98px) {
-    flex: 1 0 170px;
-    flex-grow: 0;
-    height: 50px;
-    margin: 3px 5px;
-  }
-
-  @media (max-width: 767.98px) {
-    flex: 1 0 170px;
-    flex-grow: 0;
-    height: 50px;
-    margin: 3px 5px;
-  }
-
-  @media (max-width: 575.98px) {
-    flex: 1 0 170px;
-    flex-grow: 0;
-    height: 42px;
-    margin: 3px 3px;
-  }
-`
-
 const ClusterButtonComponent = styled(Link)<{ $isCurrent: boolean; $color: string }>`
   display: flex;
-  flex: 1 0 170px;
-
-  @media (min-width: 992px) {
-    justify-content: left;
-    margin: 0 5px;
-  }
-
-  @media (max-width: 991.98px) {
-    justify-content: left;
-    padding: 0 5px;
-    //justify-content: center;
-  }
+  width: 200px;
+  height: 55px;
+  margin: 3px;
 
   border: none;
   border-left: 30px solid ${(props) => props.$color};
@@ -59,9 +17,7 @@ const ClusterButtonComponent = styled(Link)<{ $isCurrent: boolean; $color: strin
   cursor: pointer;
 
   box-shadow: ${({ $isCurrent, theme }) => ($isCurrent ? theme.shadows.normal : theme.shadows.light)};
-
   background-color: ${({ $isCurrent, theme }) => ($isCurrent ? theme.white : theme.gray100)};
-
   text-decoration: none;
 
   &:active,
@@ -69,25 +25,43 @@ const ClusterButtonComponent = styled(Link)<{ $isCurrent: boolean; $color: strin
   &:hover {
     text-decoration: none;
   }
+
+  @media (min-width: 992px) {
+  }
+
+  @media (max-width: 991.98px) {
+    width: 180px;
+    height: 45px;
+  }
+
+  @media (max-width: 767.98px) {
+    width: 160px;
+    height: 40px;
+  }
+
+  @media (max-width: 575.98px) {
+    width: 150px;
+    height: 32px;
+  }
 `
 
 const ClusterTitle = styled.h2<{ $isCurrent: boolean }>`
   font-family: ${(props) => props.theme.font.monospace};
   font-size: 1rem;
 
-  @media (min-width: 992px) {
-    font-size: 0.9rem;
-    margin-left: 1rem;
-  }
-
-  @media (min-width: 768px) {
+  @media (max-width: 991.98px) {
     font-size: 0.8rem;
-    margin: auto 5px;
+    margin: auto 7px;
   }
 
   @media (max-width: 767.98px) {
-    font-size: 0.8rem;
-    margin: auto 3px;
+    font-size: 0.75rem;
+    margin: auto 5px;
+  }
+
+  @media (max-width: 575.98px) {
+    font-size: 0.7rem;
+    margin: auto 4px;
   }
 
   margin: auto 5px;
@@ -112,10 +86,8 @@ export function ClusterButton({ cluster, isCurrent }: ClusterButtonProps) {
   const { display_name, col } = cluster
 
   return (
-    <ClusterButtonRow>
-      <ClusterButtonComponent href={`/variants/${cluster.build_name}`} $isCurrent={isCurrent} $color={col}>
-        <ClusterTitle $isCurrent={isCurrent}>{display_name}</ClusterTitle>
-      </ClusterButtonComponent>
-    </ClusterButtonRow>
+    <ClusterButtonComponent href={`/variants/${cluster.build_name}`} $isCurrent={isCurrent} $color={col}>
+      <ClusterTitle $isCurrent={isCurrent}>{display_name}</ClusterTitle>
+    </ClusterButtonComponent>
   )
 }

--- a/web/src/components/ClusterButtonPanel/ClusterButtonGroup.tsx
+++ b/web/src/components/ClusterButtonPanel/ClusterButtonGroup.tsx
@@ -1,16 +1,28 @@
 import React, { useMemo, useState } from 'react'
 
 import styled from 'styled-components'
-import { Button, Col, Container, Row } from 'reactstrap'
+import { Button } from 'reactstrap'
 
 import type { ClusterDatum } from 'src/io/getClusters'
 import { ClusterButton } from 'src/components/ClusterButtonPanel/ClusterButton'
 
 const ClusterGroupContainer = styled.div`
   display: flex;
+  flex-direction: column;
+`
+
+const ClusterGroupWrapper = styled.div`
+  display: flex;
   flex-wrap: wrap;
+  flex: 1 1;
+`
+
+const ClusterGroup = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  flex: 1 0;
+  margin: auto;
   justify-content: center;
-  padding: 0;
 `
 
 const ShowMoreButton = styled(Button)`
@@ -47,29 +59,23 @@ export function ClusterButtonGroup({ clusterGroup, currentCluster }: ClusterButt
   const toggleShowNonImportant = useMemo(() => (_: unknown) => setShowNonImportant(!showNonImportant), [showNonImportant]) // prettier-ignore
 
   return (
-    <Container>
-      <Row noGutters>
-        <Col>
-          <ClusterGroupContainer>
-            {clusterGroup.map((cluster) => (
-              <ClusterButtonOptional
-                key={cluster.build_name}
-                cluster={cluster}
-                isCurrent={cluster.display_name === currentCluster?.display_name}
-                showNonImportant={showNonImportant}
-              />
-            ))}
-          </ClusterGroupContainer>
-        </Col>
-      </Row>
+    <ClusterGroupContainer>
+      <ClusterGroupWrapper>
+        <ClusterGroup>
+          {clusterGroup.map((cluster) => (
+            <ClusterButtonOptional
+              key={cluster.build_name}
+              cluster={cluster}
+              isCurrent={cluster.display_name === currentCluster?.display_name}
+              showNonImportant={showNonImportant}
+            />
+          ))}
+        </ClusterGroup>
+      </ClusterGroupWrapper>
 
-      <Row noGutters>
-        <Col className="d-flex">
-          <ShowMoreButton type="button" color="link" onClick={toggleShowNonImportant}>
-            {showNonImportant ? 'Show less' : 'Show more'}
-          </ShowMoreButton>
-        </Col>
-      </Row>
-    </Container>
+      <ShowMoreButton type="button" color="link" onClick={toggleShowNonImportant}>
+        {showNonImportant ? 'Show less' : 'Show more'}
+      </ShowMoreButton>
+    </ClusterGroupContainer>
   )
 }

--- a/web/src/components/ClusterButtonPanel/ClusterButtonPanel.tsx
+++ b/web/src/components/ClusterButtonPanel/ClusterButtonPanel.tsx
@@ -19,7 +19,6 @@ const ClusterGroupCard = styled(Card)`
   flex-wrap: wrap;
   border: 0;
   box-shadow: none;
-  background: transparent;
   margin-bottom: 0.5rem;
 `
 
@@ -36,8 +35,8 @@ const ClusterGroupHeader = styled(CardHeader)`
 
 const ClusterGroupBody = styled(CardBody)`
   display: flex;
-  flex-wrap: wrap;
   padding: 0;
+  margin: auto;
 `
 
 export interface ClusterPanelProps {

--- a/web/src/components/ClusterButtonPanel/ClusterButtonPanelLayout.tsx
+++ b/web/src/components/ClusterButtonPanel/ClusterButtonPanelLayout.tsx
@@ -1,0 +1,45 @@
+import React, { PropsWithChildren } from 'react'
+
+import styled from 'styled-components'
+
+import type { ClusterDatum } from 'src/io/getClusters'
+import { ClusterButtonPanel } from './ClusterButtonPanel'
+
+const FlexContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+
+  @media (max-width: 767.98px) {
+    flex-direction: column;
+  }
+`
+
+const FlexFixed = styled.div`
+  flex: 0 0 180px;
+  display: flex;
+  flex-wrap: wrap;
+`
+
+const FlexGrowing = styled.div`
+  display: flex;
+  flex: 1 0;
+`
+
+export interface ClusterButtonPanelLayoutProps {
+  currentCluster?: ClusterDatum
+}
+
+export function ClusterButtonPanelLayout({
+  children,
+  currentCluster,
+}: PropsWithChildren<ClusterButtonPanelLayoutProps>) {
+  return (
+    <FlexContainer>
+      <FlexFixed>
+        <ClusterButtonPanel currentCluster={currentCluster} />
+      </FlexFixed>
+
+      <FlexGrowing>{children}</FlexGrowing>
+    </FlexContainer>
+  )
+}

--- a/web/src/components/Common/ClusterSidebarLayout.tsx
+++ b/web/src/components/Common/ClusterSidebarLayout.tsx
@@ -1,37 +1,8 @@
-import { Container } from 'reactstrap'
 import styled from 'styled-components'
 
-export const VariantsPageContainer = styled(Container)`
+export const NarrowPageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
   max-width: 1500px;
-  margin-bottom: 50px;
-`
-
-export const WrapperFlex = styled.section`
-  display: flex;
-  flex-wrap: wrap;
-`
-
-export const SidebarFlex = styled.aside`
-  @media (max-width: 991.98px) {
-    flex: 1;
-  }
-
-  @media (min-width: 992px) {
-    flex: 0 0 150px;
-  }
-`
-
-export const MainFlex = styled.section`
-  flex: 1;
-`
-
-export const ChartContainerOuter = styled.div`
-  display: flex;
-  justify-content: space-evenly;
-  width: 100%;
-`
-
-export const ChartContainerInner = styled.div`
-  flex: 0 1 100%;
-  width: 0;
+  margin: auto;
 `

--- a/web/src/components/Common/NameTable.tsx
+++ b/web/src/components/Common/NameTable.tsx
@@ -40,7 +40,7 @@ const Table = styled(TableBase)`
     font-size: 0.8rem;
     text-align: left;
     border: #aaa solid 1px;
-    min-width: 120px;
+    min-width: 100px;
     padding: 2px;
   }
 `

--- a/web/src/components/Home/HomePage.tsx
+++ b/web/src/components/Home/HomePage.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 
 import { Col, Row } from 'reactstrap'
+import { ClusterButtonPanelLayout } from 'src/components/ClusterButtonPanel/ClusterButtonPanelLayout'
 
-import { ClusterButtonPanel } from 'src/components/ClusterButtonPanel/ClusterButtonPanel'
-import { VariantsPageContainer } from 'src/components/Common/ClusterSidebarLayout'
+import { NarrowPageContainer } from 'src/components/Common/ClusterSidebarLayout'
 import { Editable } from 'src/components/Common/Editable'
 import { Layout } from 'src/components/Layout/Layout'
 
@@ -12,7 +12,7 @@ import HomeContent from '../../../../content/Home.md'
 export function HomePage() {
   return (
     <Layout>
-      <VariantsPageContainer fluid>
+      <NarrowPageContainer>
         <Row noGutters>
           <Col>
             <h1 className="text-center">{'CoVariants'}</h1>
@@ -20,17 +20,15 @@ export function HomePage() {
         </Row>
 
         <Row noGutters>
-          <Col lg={3} xl={2}>
-            <ClusterButtonPanel />
-          </Col>
-
-          <Col lg={9} xl={10}>
-            <Editable githubUrl="blob/master/content/Home.md">
-              <HomeContent />
-            </Editable>
+          <Col>
+            <ClusterButtonPanelLayout>
+              <Editable>
+                <HomeContent />
+              </Editable>
+            </ClusterButtonPanelLayout>
           </Col>
         </Row>
-      </VariantsPageContainer>
+      </NarrowPageContainer>
     </Layout>
   )
 }

--- a/web/src/components/Layout/Layout.tsx
+++ b/web/src/components/Layout/Layout.tsx
@@ -12,6 +12,7 @@ import { LastUpdated } from '../Common/LastUpdated'
 
 const Container = styled(ContainerBase)`
   min-height: 100%;
+  width: 100%;
 `
 
 const HeaderRow = styled(Row)`
@@ -68,39 +69,37 @@ export interface LayoutProps {
 
 export function Layout({ children }: PropsWithChildren<LayoutProps>) {
   return (
-    <>
-      <Container fluid>
-        <HeaderRow noGutters>
-          <HeaderCol>
-            <NavigationBar />
-          </HeaderCol>
-        </HeaderRow>
+    <Container fluid>
+      <HeaderRow noGutters>
+        <HeaderCol>
+          <NavigationBar />
+        </HeaderCol>
+      </HeaderRow>
 
-        <Row noGutters className="ml-3 mt-n1 d-none d-md-block">
-          <Col className="d-flex">
-            <GisaidText className="d-flex mr-auto">
-              <span className="mr-1">{'Enabled by data from '}</span>
-              <LinkExternal href="https://www.gisaid.org/" icon={null}>
-                <GisaidLogo height={20} />
-              </LinkExternal>
-            </GisaidText>
+      <Row noGutters className="ml-3 mt-n1 d-none d-md-block">
+        <Col className="d-flex">
+          <GisaidText className="d-flex mr-auto">
+            <span className="mr-1">{'Enabled by data from '}</span>
+            <LinkExternal href="https://www.gisaid.org/" icon={null}>
+              <GisaidLogo height={20} />
+            </LinkExternal>
+          </GisaidText>
 
-            <LastUpdated className="d-flex ml-auto" />
-          </Col>
-        </Row>
+          <LastUpdated className="d-flex ml-auto" />
+        </Col>
+      </Row>
 
-        <MainContainer fluid>
-          <MainRow noGutters>
-            <MainCol>{children}</MainCol>
-          </MainRow>
-        </MainContainer>
+      <MainContainer fluid>
+        <MainRow noGutters>
+          <MainCol>{children}</MainCol>
+        </MainRow>
+      </MainContainer>
 
-        <FooterRow noGutters>
-          <FooterCol>
-            <FooterContent />
-          </FooterCol>
-        </FooterRow>
-      </Container>
-    </>
+      <FooterRow noGutters>
+        <FooterCol>
+          <FooterContent />
+        </FooterCol>
+      </FooterRow>
+    </Container>
   )
 }

--- a/web/src/components/Variants/DefiningMutations.tsx
+++ b/web/src/components/Variants/DefiningMutations.tsx
@@ -7,6 +7,7 @@ import { AminoacidMutationBadge, NucleotideMutationBadge } from 'src/components/
 import { Row, Col } from 'reactstrap'
 
 const Container = styled.div`
+  width: 100%;
   margin: 10px 5px;
   padding: 0.65rem 1rem;
   box-shadow: ${(props) => props.theme.shadows.light};

--- a/web/src/components/Variants/VariantsPage.tsx
+++ b/web/src/components/Variants/VariantsPage.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 
 import { useRouter } from 'next/router'
+import { ClusterButtonPanelLayout } from 'src/components/ClusterButtonPanel/ClusterButtonPanelLayout'
 import styled from 'styled-components'
 import { Col, Row } from 'reactstrap'
 
@@ -11,8 +12,7 @@ import { getClusterRedirects, getClusters } from 'src/io/getClusters'
 import { LinkExternal } from 'src/components/Link/LinkExternal'
 import { Layout } from 'src/components/Layout/Layout'
 import { Editable } from 'src/components/Common/Editable'
-import { VariantsPageContainer } from 'src/components/Common/ClusterSidebarLayout'
-import { ClusterButtonPanel } from 'src/components/ClusterButtonPanel/ClusterButtonPanel'
+import { NarrowPageContainer } from 'src/components/Common/ClusterSidebarLayout'
 import { DefiningMutations, hasDefiningMutations } from 'src/components/Variants/DefiningMutations'
 import { VariantTitle } from 'src/components/Variants/VariantTitle'
 
@@ -23,6 +23,29 @@ import { ProteinCard } from './ProteinCard'
 
 const clusters = getClusters()
 const clusterRedirects = getClusterRedirects()
+
+const FlexContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+
+  @media (max-width: 991.98px) {
+    flex-direction: column;
+  }
+`
+
+const FlexFixed = styled.div`
+  flex: 0 0 180px;
+  display: flex;
+
+  @media (max-width: 991.98px) {
+    flex: 1 0;
+  }
+`
+
+const FlexGrowing = styled.div`
+  display: flex;
+  flex: 1 0;
+`
 
 const EditableClusterContent = styled(Editable)``
 
@@ -57,21 +80,13 @@ export function VariantsPage({ clusterName: clusterNameUnsafe }: VariantsPagePro
 
   return (
     <Layout>
-      <VariantsPageContainer fluid>
-        <Row noGutters>
-          <Col>
-            <VariantTitle cluster={currentCluster} />
-          </Col>
-        </Row>
+      <NarrowPageContainer>
+        <VariantTitle cluster={currentCluster} />
 
-        <Row noGutters>
-          <Col lg={3} xl={2}>
-            <ClusterButtonPanel currentCluster={currentCluster} />
-          </Col>
-
+        <ClusterButtonPanelLayout currentCluster={currentCluster}>
           {currentCluster && <VariantsPageContent currentCluster={currentCluster} />}
-        </Row>
-      </VariantsPageContainer>
+        </ClusterButtonPanelLayout>
+      </NarrowPageContainer>
     </Layout>
   )
 }
@@ -81,8 +96,8 @@ export function VariantsPageContent({ currentCluster }: { currentCluster: Cluste
   const showDefiningMutations = useMemo(() => hasDefiningMutations(currentCluster), [currentCluster])
 
   return (
-    <>
-      <Col lg={showDefiningMutations ? 7 : 9} xl={showDefiningMutations ? 8 : 10}>
+    <FlexContainer>
+      <FlexGrowing>
         <EditableClusterContent githubUrl={`blob/master/content/clusters/${currentCluster.build_name}.md`}>
           <Row noGutters className="mb-3">
             <Col className="d-flex w-100">
@@ -118,13 +133,13 @@ export function VariantsPageContent({ currentCluster }: { currentCluster: Cluste
             </Col>
           </Row>
         </EditableClusterContent>
-      </Col>
+      </FlexGrowing>
 
       {showDefiningMutations && (
-        <Col lg={2} xl={2}>
+        <FlexFixed>
           <DefiningMutations cluster={currentCluster} />
-        </Col>
+        </FlexFixed>
       )}
-    </>
+    </FlexContainer>
   )
 }

--- a/web/src/components/Variants/VariantsPageIndex.tsx
+++ b/web/src/components/Variants/VariantsPageIndex.tsx
@@ -1,19 +1,19 @@
 import React from 'react'
 
-import { Col, Row } from 'reactstrap'
-import { ClusterButtonPanel } from 'src/components/ClusterButtonPanel/ClusterButtonPanel'
+import { Col, Container, Row } from 'reactstrap'
 
-import { VariantsPageContainer } from 'src/components/Common/ClusterSidebarLayout'
+import { NarrowPageContainer } from 'src/components/Common/ClusterSidebarLayout'
 import { Editable } from 'src/components/Common/Editable'
 import { NameTable } from 'src/components/Common/NameTable'
 import { Layout } from 'src/components/Layout/Layout'
 
 import VariantsPageIntro from '../../../../content/VariantsPageIntro.md'
+import { ClusterButtonPanelLayout } from '../ClusterButtonPanel/ClusterButtonPanelLayout'
 
 export function VariantsPageIndex() {
   return (
     <Layout>
-      <VariantsPageContainer fluid>
+      <NarrowPageContainer>
         <Row noGutters>
           <Col>
             <h1 className="text-center">{'Overview of Variants/Mutations'}</h1>
@@ -21,24 +21,15 @@ export function VariantsPageIndex() {
         </Row>
 
         <Row noGutters>
-          <Col lg={3} xl={2}>
-            <ClusterButtonPanel currentCluster={undefined} />
-          </Col>
-
-          <Col lg={8} xl={10}>
-            <Row noGutters>
-              <Col>
-                <Editable githubUrl="blob/master/content/VariantsPageIntro.md">
-                  <VariantsPageIntro />
-                </Editable>
-                <Editable>
-                  <NameTable />
-                </Editable>
-              </Col>
-            </Row>
+          <Col>
+            <ClusterButtonPanelLayout>
+              <Editable githubUrl="blob/master/content/VariantsPageIntro.md">
+                <VariantsPageIntro />
+              </Editable>
+            </ClusterButtonPanelLayout>
           </Col>
         </Row>
-      </VariantsPageContainer>
+      </NarrowPageContainer>
     </Layout>
   )
 }

--- a/web/src/components/Variants/VariantsPageIndex.tsx
+++ b/web/src/components/Variants/VariantsPageIndex.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
 
-import { Col, Container, Row } from 'reactstrap'
+import { Col, Row } from 'reactstrap'
 
 import { NarrowPageContainer } from 'src/components/Common/ClusterSidebarLayout'
 import { Editable } from 'src/components/Common/Editable'
-import { NameTable } from 'src/components/Common/NameTable'
 import { Layout } from 'src/components/Layout/Layout'
 
 import VariantsPageIntro from '../../../../content/VariantsPageIntro.md'


### PR DESCRIPTION
This makes button sidebar width fixed, such that it is easier to find an appropriate width for all screen sizes. The layout of variants and home pages had to be revamped for that.

Now only the central text content section is responsible. Both sidebars are of fixed width. 

For smaller screens we tweak the button width slightly, along with height and font size.


