### PR TITLE
Use consistent cluster colors

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -61,12 +61,14 @@
     "stills": "yarn run:node tools/generateStillImages.ts"
   },
   "dependencies": {
+    "@types/color": "3.0.1",
     "animate.css": "4.1.0",
     "autoprefixer": "9.8.6",
     "axios": "0.21.1",
     "bootstrap": "4.5.2",
     "bootstrap-icons": "1.2.2",
     "classnames": "2.2.6",
+    "color": "3.1.3",
     "connected-next-router": "3.1.0",
     "core-js": "3.6.5",
     "css.escape": "1.5.1",

--- a/web/src/components/CountryDistribution/CountryDistributionPlot.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlot.tsx
@@ -79,7 +79,7 @@ export function CountryDistributionPlotComponent({ cluster_names, distribution }
                       stackId="1"
                       stroke="none"
                       fill={getClusterColor(cluster)}
-                      fillOpacity={1 - theme.plot.country.area.transparency}
+                      fillOpacity={theme.plot.country.area.opacity}
                       isAnimationActive={false}
                     />
                   ))}

--- a/web/src/components/CountryDistribution/CountryDistributionPlot.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlot.tsx
@@ -79,6 +79,7 @@ export function CountryDistributionPlotComponent({ cluster_names, distribution }
                       stackId="1"
                       stroke="none"
                       fill={getClusterColor(cluster)}
+                      fillOpacity={1 - theme.plot.country.area.transparency}
                       isAnimationActive={false}
                     />
                   ))}

--- a/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback } from 'react'
 
 import { sortBy, reverse } from 'lodash'
 import styled, { useTheme } from 'styled-components'
@@ -45,11 +45,9 @@ export const ClusterNameText = styled.span`
 export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps<number, string>) {
   const theme = useTheme()
 
-  const getColor = useCallback(
-    (name?: string) =>
-      getClusterPlotColor(name ?? '', theme.clusters.color.others, theme.plot.country.area.transparency),
-    [theme.clusters.color.others, theme.plot.country.area.transparency],
-  )
+  const getColor = useCallback((name?: string) => getClusterPlotColor(name ?? '', theme.plot.country.area.opacity), [
+    theme.plot.country.area.opacity,
+  ])
 
   const { payload } = props
   if (!payload || payload.length === 0) {

--- a/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
@@ -1,11 +1,11 @@
-import React from 'react'
+import React, { useCallback, useMemo } from 'react'
 
 import { sortBy, reverse } from 'lodash'
-import styled from 'styled-components'
+import styled, { useTheme } from 'styled-components'
 import { Props as DefaultTooltipContentProps } from 'recharts/types/component/DefaultTooltipContent'
 
 import { formatDateBiweekly, formatInteger, formatProportion } from 'src/helpers/format'
-import { getClusterColor } from 'src/io/getClusters'
+import { getClusterPlotColor } from 'src/io/getClusters'
 import { ColoredBox } from '../Common/ColoredBox'
 
 const EPSILON = 1e-2
@@ -43,6 +43,14 @@ export const ClusterNameText = styled.span`
 `
 
 export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps<number, string>) {
+  const theme = useTheme()
+
+  const getColor = useCallback(
+    (name?: string) =>
+      getClusterPlotColor(name ?? '', theme.clusters.color.others, theme.plot.country.area.transparency),
+    [theme.clusters.color.others, theme.plot.country.area.transparency],
+  )
+
   const { payload } = props
   if (!payload || payload.length === 0) {
     return null
@@ -76,7 +84,7 @@ export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps
           {payloadSorted.map(({ name, value }) => (
             <tr key={name}>
               <td className="px-2 text-left">
-                <ColoredBox $color={getClusterColor(name ?? '')} $size={10} $aspect={1.66} />
+                <ColoredBox $color={getColor(name)} $size={10} $aspect={1.66} />
                 <ClusterNameText>{name}</ClusterNameText>
               </td>
               <td className="px-2 text-right">{value !== undefined && value > EPSILON ? formatInteger(value) : '-'}</td>

--- a/web/src/components/DistributionSidebar/ClusterFilters.tsx
+++ b/web/src/components/DistributionSidebar/ClusterFilters.tsx
@@ -40,10 +40,10 @@ export interface ClusterFilterCheckboxProps {
 export function ClusterFilterCheckbox({ cluster, enabled, onFilterChange }: ClusterFilterCheckboxProps) {
   const onChange = useCallback(() => onFilterChange(cluster), [onFilterChange, cluster])
   const theme = useTheme()
-  const color = useMemo(
-    () => getClusterPlotColor(cluster, theme.clusters.color.others, theme.plot.country.area.transparency),
-    [cluster, theme.clusters.color.others, theme.plot.country.area.transparency],
-  )
+  const color = useMemo(() => getClusterPlotColor(cluster, theme.plot.country.area.opacity), [
+    cluster,
+    theme.plot.country.area.opacity,
+  ])
 
   return (
     <FormGroup key={cluster} check>

--- a/web/src/components/DistributionSidebar/ClusterFilters.tsx
+++ b/web/src/components/DistributionSidebar/ClusterFilters.tsx
@@ -12,11 +12,11 @@ import {
   Row,
 } from 'reactstrap'
 
-import { getClusterColor } from 'src/io/getClusters'
+import { getClusterPlotColor } from 'src/io/getClusters'
 import { ColoredBox } from 'src/components/Common/ColoredBox'
 import { CardCollapsible } from 'src/components/Common/CardCollapsible'
 import type { ClusterState } from 'src/components/CountryDistribution/CountryDistributionPage'
-import styled from 'styled-components'
+import styled, { useTheme } from 'styled-components'
 
 export const FormGroup = styled(FormGroupBase)`
   flex: 1 0 320px;
@@ -39,12 +39,17 @@ export interface ClusterFilterCheckboxProps {
 
 export function ClusterFilterCheckbox({ cluster, enabled, onFilterChange }: ClusterFilterCheckboxProps) {
   const onChange = useCallback(() => onFilterChange(cluster), [onFilterChange, cluster])
+  const theme = useTheme()
+  const color = useMemo(
+    () => getClusterPlotColor(cluster, theme.clusters.color.others, theme.plot.country.area.transparency),
+    [cluster, theme.clusters.color.others, theme.plot.country.area.transparency],
+  )
 
   return (
     <FormGroup key={cluster} check>
       <Label htmlFor={CSS.escape(cluster)} check>
         <Input id={CSS.escape(cluster)} type="checkbox" checked={enabled} onChange={onChange} />
-        <ColoredBox $color={getClusterColor(cluster)} $size={14} $aspect={16 / 9} />
+        <ColoredBox $color={color} $size={14} $aspect={16 / 9} />
         <ClusterNameText>{cluster}</ClusterNameText>
       </Label>
     </FormGroup>

--- a/web/src/io/getClusters.ts
+++ b/web/src/io/getClusters.ts
@@ -1,10 +1,10 @@
 /* eslint-disable camelcase */
 import { groupBy } from 'lodash'
-import { mix, transparentize } from 'polished'
-import { notUndefinedOrNull } from 'src/helpers/notUndefined'
+import Color from 'color'
 
 import type { Mutation } from 'src/types'
 import { theme } from 'src/theme'
+import { notUndefinedOrNull } from 'src/helpers/notUndefined'
 
 import clustersJson from 'src/../data/clusters.json'
 
@@ -73,14 +73,25 @@ export function getClusterColor(clusterName: string) {
   return found ? found.col : theme.clusters.color.unknown
 }
 
-export function getClusterPlotColor(clusterName: string, othersColor: string, transparency: number) {
+/**
+ * Finds an opaque color equivalent to a transparent color (with given hex RGB color and  given opacity)
+ * added on top of white background
+ */
+export function opaqueAlpha(color: string, opacity: number) {
+  let clr = new Color(color)
+
+  const rgb = clr
+    .rgb()
+    .array()
+    .map((c) => 255 - opacity * (255 - c))
+
+  clr = new Color(rgb)
+  return clr.hex()
+}
+
+export function getClusterPlotColor(clusterName: string, opacity: number) {
   const color = getClusterColor(clusterName)
-
-  // const fg = transparentize(transparency, color)
-  // const bg = transparentize(transparency, othersColor)
-
-  const bg = mix(transparency, '#ffffff', othersColor)
-  return mix(transparency, color, bg)
+  return opaqueAlpha(color, opacity)
 }
 
 export type ClusterDataGrouped = Record<string, ClusterDatum[]>

--- a/web/src/io/getClusters.ts
+++ b/web/src/io/getClusters.ts
@@ -83,7 +83,7 @@ export function opaqueAlpha(color: string, opacity: number) {
   const rgb = clr
     .rgb()
     .array()
-    .map((c) => 255 - opacity * (255 - c))
+    .map((c) => (1 - (1 - opacity) * (1 - c / 255)) * 255)
 
   clr = new Color(rgb)
   return clr.hex()

--- a/web/src/io/getClusters.ts
+++ b/web/src/io/getClusters.ts
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import { groupBy } from 'lodash'
+import { mix, transparentize } from 'polished'
 import { notUndefinedOrNull } from 'src/helpers/notUndefined'
 
 import type { Mutation } from 'src/types'
@@ -70,6 +71,16 @@ export function getClusterColor(clusterName: string) {
   const clusters = getClustersIncludingHidden()
   const found = clusters.find(({ display_name }) => display_name === clusterName)
   return found ? found.col : theme.clusters.color.unknown
+}
+
+export function getClusterPlotColor(clusterName: string, othersColor: string, transparency: number) {
+  const color = getClusterColor(clusterName)
+
+  // const fg = transparentize(transparency, color)
+  // const bg = transparentize(transparency, othersColor)
+
+  const bg = mix(transparency, '#ffffff', othersColor)
+  return mix(transparency, color, bg)
 }
 
 export type ClusterDataGrouped = Record<string, ClusterDatum[]>

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -125,6 +125,9 @@ export const plot = {
     },
   },
   country: {
+    area: {
+      transparency: 0.4,
+    },
     legend: {
       lineIcon: {
         thickness: 2,

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -126,7 +126,7 @@ export const plot = {
   },
   country: {
     area: {
-      transparency: 0.4,
+      opacity: 0.6,
     },
     legend: {
       lineIcon: {

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1881,6 +1881,25 @@
   resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.10.tgz#cc658ca319b6355399efc1f5b9e818f1a24bf999"
   integrity sha512-1UzDldn9GfYYEsWWnn/P4wkTlkZDH7lDb0wBMGbtIQc9zXEQq7FlKBdZUn6OBqD8sKZZ2RQO2mAjGpXiDGoRmQ==
 
+"@types/color-convert@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/color-convert/-/color-convert-2.0.0.tgz#8f5ee6b9e863dcbee5703f5a517ffb13d3ea4e22"
+  integrity sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==
+  dependencies:
+    "@types/color-name" "*"
+
+"@types/color-name@*":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/color@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/color/-/color-3.0.1.tgz#2900490ed04da8116c5058cd5dba3572d5a25071"
+  integrity sha512-oeUWVaAwI+xINDUx+3F2vJkl/vVB03VChFF/Gl3iQCdbcakjuoJyMOba+3BXRtnBhxZ7uBYqQBi9EpLnvSoztA==
+  dependencies:
+    "@types/color-convert" "*"
+
 "@types/compare-versions@3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@types/compare-versions/-/compare-versions-3.3.0.tgz#a4634771f61cfc9326923d518ab8a04089e99314"
@@ -4030,7 +4049,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -4049,10 +4068,26 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.5.4:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.5.tgz#65474a8f0e7439625f3d27a6a19d89fc45223014"
+  integrity sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.1.3.tgz#ca67fb4e7b97d611dcde39eceed422067d91596e"
+  integrity sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==
+  dependencies:
+    color-convert "^1.9.1"
+    color-string "^1.5.4"
 
 colorette@^1.2.1:
   version "1.2.1"
@@ -7028,6 +7063,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-binary-path@^1.0.0:
   version "1.0.1"
@@ -11564,6 +11604,13 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
+  dependencies:
+    is-arrayish "^0.3.1"
 
 sisteransi@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
Attempts to address: https://twitter.com/hnoejgaard/status/1406896874766929922

The challenge is that the AreaPlot area segments are transparent (default opacity is 0.6, configurable). If we make the sidebar color boxes transparent it looks fins and the colors match. However, in the tooltip, the table is striped, so transparent colors get tinted by the row colors.

We need to ~find a way to~ produce a non-transparent version of the color.
**UPDATE**: figured it, in

https://github.com/hodcroftlab/covariants/blob/fc704b60edcf8121059f974bcdc4fb92e268dce8/web/src/io/getClusters.ts#L76-L95

**UPDATE2**: Nope, the colors are still slightly different.


One disadvantage of shifting to these "transparent" versions is that we are showing the color that is different from what comes from the data source. So it's confusing for maintainers, because they don't see the colors they put into the actual data.

Another way of tackling this problem is to use original, opaque colors everywhere, including the plots. It looks a bit angry though, due to the bright red colors:

![01](https://user-images.githubusercontent.com/9403403/122756890-45ed3400-d297-11eb-8f83-9b908d7cbaf3.png)

And to fix that, we could make the original colors more pastel. I think this would be the cleanest solution.
