### PR TITLE
fix: safari cluster buttons misaligned

### DIFF
--- a/web/.browserslistrc
+++ b/web/.browserslistrc
@@ -3,6 +3,7 @@ defaults
 cover 99.5%
 since 2013
 ie >= 10
+safari >= 10
 
 [development]
 last 5 Chrome versions

--- a/web/src/components/ClusterButtonPanel/ClusterButtonPanelLayout.tsx
+++ b/web/src/components/ClusterButtonPanel/ClusterButtonPanelLayout.tsx
@@ -15,8 +15,9 @@ const FlexContainer = styled.div`
 `
 
 const FlexFixed = styled.div`
-  flex: 0 0 180px;
-  display: flex;
+  flex: 0 0;
+  flex-basis: 180px;
+
   flex-wrap: wrap;
 `
 


### PR DESCRIPTION
Splitting the `flex-basis` out of the `flex` statement seems to be working correctly on Safari 14, while the compound variant does not.

Hello, Apple, anybody home?

Before:
![before](https://user-images.githubusercontent.com/9403403/122805070-ea3b9e80-d2c8-11eb-951b-bf40dd9a2637.png)

After:
![after](https://user-images.githubusercontent.com/9403403/122805084-ef98e900-d2c8-11eb-889e-45c3a7c78806.png)

iPhone 7 iOS 12 looks fine:
![7](https://user-images.githubusercontent.com/9403403/122805680-b14ff980-d2c9-11eb-93eb-d55a0c4c40c1.png)

