### PR TITLE
improve speed of some of the steps

### DIFF
--- a/scripts/allClusterDynamics_faster.py
+++ b/scripts/allClusterDynamics_faster.py
@@ -410,6 +410,7 @@ for clus in clus_to_run:
 
     # get metadata for these sequences
     cluster_meta = meta[meta["strain"].isin(wanted_seqs)]
+    clus_data["cluster_meta"] = cluster_meta
 
     # re-set wanted_seqs
     wanted_seqs = list(cluster_meta["strain"])


### PR DESCRIPTION
Speed and logic improvements to the code

- Removes 'bad sequences' more efficiently at start
- Removes duplication of trying to remove sequences with invalid dates & bad sequences twice
- Filter mutations file to match metadata, so if a sequence has been removed from meta, it is also out of the mutations file
- (most significant) Reduces time to search for matching sequences in the mutations file
- (Unrelated) Clears some warnings associated with setting to copies of slices of dataframes