### PR TITLE
Filter Metadata to What's in Mutation Summary before analysis

### DIFF
--- a/scripts/allClusterDynamics_faster.py
+++ b/scripts/allClusterDynamics_faster.py
@@ -260,6 +260,8 @@ meta['division'] = meta['division'].replace(swiss_regions)
 
 # Filter mutations to match Metadata - to exclude sequences with bad dates
 muts = muts[muts['Unnamed: 0'].isin(meta['strain'])]
+# Filter Metadata to only have those we have mutations for! Allows 'out of sync' files.
+meta = meta[meta["strain"].isin(muts["Unnamed: 0"])]
 
 t1 = time.time()
 print(f"Reading & cleaning meta run took {t1-t0} to run")


### PR DESCRIPTION
Small but important change means that we filter the `metadata` contents to only use what we have a matching `mutation_summary` entry for. Until now, if the code was run on a `metadata` file which had more entries than a `mutation_summary` file (ex: in a currently going run, where `mutation_summary` hasn't been generated yet), then there will be many recent sequences which are classed as 'other' just because there's no mutation information to identify them as variants. 
However, waiting to run analyses until files were in sync often meant that it was harder to run things as often.

With this change, only sequences which have a `mutation_summary` entry are included in the analysis, so that there's less need to be so careful to ensure files are 'in sync' before running.

As an added bonus, this also means that sequences which are in `exclude.txt` are excluded from the run, as they won't have a `mutation_summary` entry. This results in very small changes to numbers (1-5 seqs per week, for a few weeks, in some countries only) - nothing that impacts overall interpretation or graphs.

This has been tested on a full run with an 'updated' `metadata` and 'old' `mutation_summary`. 