### PR TITLE
Fix crash in old safari on missing ResizeObserver

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -111,6 +111,7 @@
     "reflect-metadata": "0.1.13",
     "regenerator-runtime": "0.13.7",
     "reselect": "4.0.0",
+    "resize-observer-polyfill": "1.5.1",
     "serialize-javascript": "5.0.1",
     "styled-components": "5.1.1",
     "typeface-droid-sans-mono": "0.0.44",

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import 'reflect-metadata'
+import 'resize-observer-polyfill/dist/ResizeObserver.global'
 
 import 'css.escape'
 

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -11144,7 +11144,7 @@ reserved-words@^0.1.2:
   resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.2.tgz#00a0940f98cd501aeaaac316411d9adc52b31ab1"
   integrity sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=
 
-resize-observer-polyfill@^1.5.1:
+resize-observer-polyfill@1.5.1, resize-observer-polyfill@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
   integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==


### PR DESCRIPTION
Plot rendering depends on ResizeObserver. Older Safari don't have ResizeObserver support and crash when navigating to one of the pages containing plots.

This PR adds a global polyfill (`resize-observer-polyfill` package)  so that Safari display plot pages correctly.


Just tested this PR on Browserstack. Looks like it now works on things as far back as iPhone 6, iOS 11, circa 2014. A blast from the past! 

![01](https://user-images.githubusercontent.com/9403403/123740459-c23fd280-d8a8-11eb-8890-976cc89c7854.png)


