### PR TITLE
Update Builds Links

### DIFF
--- a/content/PerCountryIntro/Switzerland.md
+++ b/content/PerCountryIntro/Switzerland.md
@@ -11,6 +11,8 @@ The Swiss regions are the same as those used for the [Sentinella](https://www.se
 - Region 5: Appenzell Innerrhoden, Appenzell Ausserrhoden, Glarus, Sankt Gallen, Schaffhausen, Thurgau, Zürich
 - Region 6: Graubünden, Ticino
 
+Swiss-focused builds for the major variants are available for [20I (Alpha, V1)](https://nextstrain.org/groups/neherlab/ncov/20I.Alpha.V1-swiss?c=division&f_clade_membership=20I%20%28Alpha,%20V1%29&f_country=Switzerland), [20H (Beta, V2)](https://nextstrain.org/groups/neherlab/ncov/20H.Beta.V2-swiss?c=division&f_clade_membership=20H%20%28Beta,%20V2%29&f_country=Switzerland), [20J (Gamma, V3)](https://nextstrain.org/groups/neherlab/ncov/20J.Gamma.V3-swiss?c=division&f_clade_membership=20J%20%28Gamma,%20V3%29&f_country=Switzerland), and [21A (Delta)](https://nextstrain.org/groups/neherlab/ncov/21A.Delta-swiss?c=division&f_clade_membership=21A%20%28Delta%29&f_country=Switzerland).
+
 <figure className="text-center">
   <img src={imageUrl} alt="Regions in Switzerland"/>
 </figure>

--- a/content/RegionBreakdownInfo.md
+++ b/content/RegionBreakdownInfo.md
@@ -1,6 +1,5 @@
 The grey colour between the top of the coloured curve and '1' on the Y-axis is composed of variants that aren't currently tracked on CoVariants.
-
-Sequence counts are binned into 2-week intervals, with the date shown on the X-axis being the _start_ of the 2-week period.
+Sequence counts are binned into 2-week intervals.
 
 <!-- **In early 2021** many places have started preferentially sequencing samples to detect the main variants of concern (see <Var name="20I/501Y.V1" prefix=""/>, <Var name="20H/501Y.V2" prefix=""/>, <Var name="20J/501Y.V3" prefix=""/>). Often this is through sequencing samples that have an 'S-drop-out,' which in particular biases the frequencies of <Var name="20A/S:439K"/> and 501Y.V1 (shown here as a bias in the 3 variants of concern). Alternatively, this can be through preferentially sequencing cases with particular travel histories, or connections to known cases of the variants of concern. -->
 

--- a/content/clusters/21A.Delta.md
+++ b/content/clusters/21A.Delta.md
@@ -12,4 +12,11 @@ Also known as <Lin name="B.1.617.2" /> and <Who name="Delta" />
 
 Many sequences in <Var name={'21A (Delta)'}/> also have a deletion at positions <AaMut mut={'ORF8:D119-'}/> and <AaMut mut={'ORF8:F120-'}/>.
 
+- [The PHE technical briefings](https://www.gov.uk/government/publications/investigation-of-novel-sars-cov-2-variant-variant-of-concern-20201201) contain assessments of <Var name={'21A (Delta)'} prefix=""/>'s transmissibility 
+
+Some <Var name={'21A (Delta)'} prefix=""/> viruses have acquired an additional mutation at position <Mut name="S:K417"/> to N (click the mutation badge for more information on this mutation).
+Two specific clusters of this mutation in <Var name={'21A (Delta)'} prefix=""/> have Pango lineage designations <Lin name="AY.1" /> and <Lin name="AY.2" />.
+
+A Nextstrain build focused on <Var name={'21A (Delta)'} prefix=""/> sequences with the <AaMut mut={'S:K417N'}/> mutation (including the two lineages above) can be seen [here](https://nextstrain.org/groups/neherlab/ncov/21A.Delta.S.K417?c=gt-S_417&f_clade_membership=21A%20%28Delta%29&label=clade:21A%20%28Delta%29).
+
 _Little else is known about this variant. Please let me know if you have more information!_


### PR DESCRIPTION
Primarily adds new links to new focal builds (Swiss-Delta + Delta+417N), but also adds a couple of other links and text changes. Tested locally, looks good.