### PR TITLE
fix: format date ranges in cluster plot tooltips weekly

### DIFF
--- a/web/src/components/ClusterDistribution/ClusterDistributionPlotTooltip.tsx
+++ b/web/src/components/ClusterDistribution/ClusterDistributionPlotTooltip.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components'
 import type { ClusterDistributionDatum } from 'src/components/ClusterDistribution/ClusterDistributionPlot'
 import type { Props as DefaultTooltipContentProps } from 'recharts/types/component/DefaultTooltipContent'
 import { selectPerCountryTooltipSortBy, selectPerCountryTooltipSortReversed } from 'src/state/ui/ui.selectors'
-import { formatDateBiweekly, formatProportion } from 'src/helpers/format'
+import { formatDateWeekly, formatProportion } from 'src/helpers/format'
 import { getCountryColor, getCountryStrokeDashArray } from 'src/io/getCountryColor'
 
 const EPSILON = 1e-2
@@ -66,7 +66,7 @@ export function ClusterDistributionPlotTooltip(props: ClusterDistributionPlotToo
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  const week = formatDateBiweekly(data?.week)
+  const week = formatDateWeekly(data?.week)
 
   let payloadSorted = sortBy(payload, perCountryTooltipSortBy === 'country' ? 'name' : 'value')
 

--- a/web/src/helpers/format.ts
+++ b/web/src/helpers/format.ts
@@ -1,4 +1,4 @@
-import { DateTime } from 'luxon'
+import { DateTime, Duration, DurationObject } from 'luxon'
 
 export const formatProportion = (value: number) => value.toFixed(2)
 
@@ -6,10 +6,18 @@ export const formatInteger = (value: number) => value.toFixed(0)
 
 export const formatDate = (date: number) => DateTime.fromSeconds(date).toISODate()
 
-export const formatDateBiweekly = (weekTimestamp: number) => {
+export function formatDateRange(weekTimestamp: number, range: Duration | DurationObject) {
   const begin = DateTime.fromSeconds(weekTimestamp)
-  const end = begin.plus({ weeks: 2 })
+  const end = begin.plus(range)
   return `${begin.toFormat('dd MMM yyyy')} - ${end.toFormat('dd MMM yyyy')}`
+}
+
+export function formatDateWeekly(weekTimestamp: number) {
+  return formatDateRange(weekTimestamp, { weeks: 1 })
+}
+
+export function formatDateBiweekly(weekTimestamp: number) {
+  return formatDateRange(weekTimestamp, { weeks: 2 })
 }
 
 export const formatDateHumanely = (date: number) => DateTime.fromSeconds(date).toFormat('MMM yyyy').replace(' ', '\n')


### PR DESCRIPTION
This fixes formatting of dates in cluster plot tooltips.
Previously it was incorrectly showing 2-week intervals for each data point. However, the correct interval is 1 week.

This is only a visual fix, the underlying data is the same.

