### PR TITLE
Make tooltip settings sticky

### DIFF
--- a/web/src/components/ClusterDistribution/ClusterDistributionPage.tsx
+++ b/web/src/components/ClusterDistribution/ClusterDistributionPage.tsx
@@ -128,6 +128,13 @@ export function SortReverseCheckbox({ reverse, setReverse }: SortReverseCheckbox
   )
 }
 
+const StickyRow = styled(Row)`
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  align-self: flex-start;
+`
+
 export function ClusterDistributionPage() {
   const perCountryTooltipSortBy = useSelector(selectPerCountryTooltipSortBy)
   const perCountryTooltipSortReversed = useSelector(selectPerCountryTooltipSortReversed)
@@ -242,7 +249,7 @@ export function ClusterDistributionPage() {
               </SidebarFlex>
 
               <MainFlex>
-                <Row noGutters>
+                <StickyRow noGutters>
                   <Col>
                     <Card className="m-2">
                       <CardBody className="px-3 py-2">
@@ -256,7 +263,7 @@ export function ClusterDistributionPage() {
                       </CardBody>
                     </Card>
                   </Col>
-                </Row>
+                </StickyRow>
 
                 <Row noGutters>
                   <Col>

--- a/web/src/components/Layout/Layout.tsx
+++ b/web/src/components/Layout/Layout.tsx
@@ -29,7 +29,6 @@ const HeaderCol = styled(Col)`
 `
 
 const MainContainer = styled(ContainerBase)`
-  overflow: hidden;
   padding-bottom: 100px;
 `
 


### PR DESCRIPTION
Just a little idea to keep the tooltip settings in view when scrolling through the charts :)

The removal of the overflow is a risky one though, hopefully it doesn't break anything 🤞🏽 