### PR TITLE
Remove old names from table

### DIFF
--- a/scripts/name_table.py
+++ b/scripts/name_table.py
@@ -11,9 +11,6 @@ name_table = [
         "others": [
             {"name": "VOC 202012/01", "url": None}
         ],
-        "oldnames": [
-            {"name": "20I/501Y.V1", "url": None}
-        ],
     },
     {
         "clade": "20H (Beta, V2)",
@@ -24,9 +21,6 @@ name_table = [
         "others": [
             {"name": "501Y.V2", "url": None}
         ],
-        "oldnames": [
-            {"name": "20H/501Y.V2", "url": None}
-        ],
     },
     {
         "clade": "20J (Gamma, V3)",
@@ -35,9 +29,6 @@ name_table = [
             {"name": "P.1", "url": None}
         ],
         "others": [],
-        "oldnames": [
-            {"name": "20J/501Y.V3", "url": None}
-        ],
     },
     {
         "clade": "21A (Delta)",
@@ -46,9 +37,6 @@ name_table = [
             {"name": "B.1.617.2", "url": "https://cov-lineages.org/lineages/lineage_B.1.617.2.html"}
         ],
         "others": [],
-        "oldnames": [
-            {"name": "21A/S:478K", "url": None}
-        ]
     },
     {
         "clade": "21B (Kappa)",
@@ -56,10 +44,7 @@ name_table = [
         "lineages": [
             {"name": "B.1.617.1", "url": "https://cov-lineages.org/lineages/lineage_B.1.617.1.html"}
         ],
-        "others": [],
-        "oldnames": [
-            {"name": "21A/S:154K", "url": None}
-        ]
+        "others": []
     },
     {
         "clade": "21C (Epsilon)",
@@ -71,9 +56,6 @@ name_table = [
         "others": [
             {"name": "CAL.20C", "url": None}
         ],
-        "oldnames": [
-            {"name": "20C/S:452R", "url": None}
-        ],
     },
     {
         "clade": "21D (Eta)",
@@ -82,9 +64,6 @@ name_table = [
             {"name": "B.1.525", "url": None}
         ],
         "others": [],
-        "oldnames": [
-            {"name": "20A/S:484K", "url": None},
-        ]
     },
     {
         "clade": "21F (Iota)",
@@ -94,9 +73,6 @@ name_table = [
         ],
         "others": [
             {"name": "(Part of Pango lineage)", "url": None},
-        ],
-        "oldnames": [
-            {"name": "20C/S:484K", "url": None},
         ]
     },
     {
@@ -106,7 +82,6 @@ name_table = [
             {"name": "C.37", "url": None}
         ],
         "others": [],
-        "oldnames": []
     },
     {
         "clade": "21H (Mu)",
@@ -115,7 +90,6 @@ name_table = [
             {"name": "B.1.621", "url": None}
         ],
         "others": [],
-        "oldnames": []
     },
     {
         "clade": "20E (EU1)",
@@ -126,9 +100,6 @@ name_table = [
         "others": [
             {"name": "EU1", "url": None}
         ],
-        "oldnames": [
-            {"name": "20A.EU1", "url": None}
-        ],
     },
     {
         "clade": "20B/S:732A",
@@ -137,7 +108,6 @@ name_table = [
             {"name": "B.1.1.519", "url": None}
         ],
         "others": [],
-        "oldnames": []
     },
     {
         "clade": "20A/S:126A",
@@ -146,7 +116,6 @@ name_table = [
             {"name": "B.1.620", "url": None}
         ],
         "others": [],
-        "oldnames": []
     },
     {
         "clade": "20A.EU2",
@@ -155,7 +124,6 @@ name_table = [
             {"name": "B.1.160", "url": None}
         ],
         "others": [],
-        "oldnames": [],
     },
     {
         "clade": "20A/S:439K",
@@ -164,7 +132,6 @@ name_table = [
             {"name": "B.1.258", "url": None}
         ],
         "others": [],
-        "oldnames": []
     },
     {
         "clade": "20A/S:98F",
@@ -173,7 +140,6 @@ name_table = [
             {"name": "B.1.221", "url": None}
         ],
         "others": [],
-        "oldnames": []
     },
     {
         "clade": "20C/S:80Y",
@@ -182,7 +148,6 @@ name_table = [
             {"name": "B.1.367", "url": None}
         ],
         "others": [],
-        "oldnames": []
     },
     {
         "clade": "20B/S:626S",
@@ -191,7 +156,6 @@ name_table = [
             {"name": "B.1.1.277", "url": None}
         ],
         "others": [],
-        "oldnames": []
     },
     {
         "clade": "20B/S:1122L",
@@ -200,7 +164,6 @@ name_table = [
             {"name": "B.1.1.302", "url": None}
         ],
         "others": [],
-        "oldnames": []
     }
 ]
 

--- a/web/data/nameTable.json
+++ b/web/data/nameTable.json
@@ -159,7 +159,7 @@
         }
       ],
       "others": [],
-      "who": ""
+      "who": null
     },
     {
       "clade": "20A/S:126A",
@@ -170,7 +170,7 @@
         }
       ],
       "others": [],
-      "who": ""
+      "who": null
     },
     {
       "clade": "20A.EU2",

--- a/web/data/nameTable.json
+++ b/web/data/nameTable.json
@@ -8,12 +8,6 @@
           "url": "https://cov-lineages.org/global_report_B.1.1.7.html"
         }
       ],
-      "oldnames": [
-        {
-          "name": "20I/501Y.V1",
-          "url": null
-        }
-      ],
       "others": [
         {
           "name": "VOC 202012/01",
@@ -28,12 +22,6 @@
         {
           "name": "B.1.351",
           "url": "https://cov-lineages.org/global_report_B.1.351.html"
-        }
-      ],
-      "oldnames": [
-        {
-          "name": "20H/501Y.V2",
-          "url": null
         }
       ],
       "others": [
@@ -52,12 +40,6 @@
           "url": "https://cov-lineages.org/global_report_P.1.html"
         }
       ],
-      "oldnames": [
-        {
-          "name": "20J/501Y.V3",
-          "url": null
-        }
-      ],
       "others": [],
       "who": "Gamma"
     },
@@ -69,12 +51,6 @@
           "url": "https://cov-lineages.org/lineages/lineage_B.1.617.2.html"
         }
       ],
-      "oldnames": [
-        {
-          "name": "21A/S:478K",
-          "url": null
-        }
-      ],
       "others": [],
       "who": "Delta"
     },
@@ -84,12 +60,6 @@
         {
           "name": "B.1.617.1",
           "url": "https://cov-lineages.org/lineages/lineage_B.1.617.1.html"
-        }
-      ],
-      "oldnames": [
-        {
-          "name": "21A/S:154K",
-          "url": null
         }
       ],
       "others": [],
@@ -104,12 +74,6 @@
         },
         {
           "name": "B.1.429",
-          "url": null
-        }
-      ],
-      "oldnames": [
-        {
-          "name": "20C/S:452R",
           "url": null
         }
       ],
@@ -129,12 +93,6 @@
           "url": "https://cov-lineages.org/global_report_B.1.525.html"
         }
       ],
-      "oldnames": [
-        {
-          "name": "20A/S:484K",
-          "url": null
-        }
-      ],
       "others": [],
       "who": "Eta"
     },
@@ -143,12 +101,6 @@
       "lineages": [
         {
           "name": "B.1.526",
-          "url": null
-        }
-      ],
-      "oldnames": [
-        {
-          "name": "20C/S:484K",
           "url": null
         }
       ],
@@ -168,7 +120,6 @@
           "url": null
         }
       ],
-      "oldnames": [],
       "others": [],
       "who": "Lambda"
     },
@@ -180,7 +131,6 @@
           "url": null
         }
       ],
-      "oldnames": [],
       "others": [],
       "who": "Mu"
     },
@@ -189,12 +139,6 @@
       "lineages": [
         {
           "name": "B.1.177",
-          "url": null
-        }
-      ],
-      "oldnames": [
-        {
-          "name": "20A.EU1",
           "url": null
         }
       ],
@@ -214,7 +158,6 @@
           "url": null
         }
       ],
-      "oldnames": [],
       "others": [],
       "who": ""
     },
@@ -226,7 +169,6 @@
           "url": null
         }
       ],
-      "oldnames": [],
       "others": [],
       "who": ""
     },
@@ -238,7 +180,6 @@
           "url": null
         }
       ],
-      "oldnames": [],
       "others": [],
       "who": null
     },
@@ -250,7 +191,6 @@
           "url": null
         }
       ],
-      "oldnames": [],
       "others": [],
       "who": null
     },
@@ -262,7 +202,6 @@
           "url": null
         }
       ],
-      "oldnames": [],
       "others": [],
       "who": null
     },
@@ -274,7 +213,6 @@
           "url": null
         }
       ],
-      "oldnames": [],
       "others": [],
       "who": null
     },
@@ -286,7 +224,6 @@
           "url": null
         }
       ],
-      "oldnames": [],
       "others": [],
       "who": null
     },
@@ -298,7 +235,6 @@
           "url": null
         }
       ],
-      "oldnames": [],
       "others": [],
       "who": null
     }

--- a/web/src/components/Common/NameTable.tsx
+++ b/web/src/components/Common/NameTable.tsx
@@ -72,7 +72,7 @@ export interface NameTableRowProps {
 }
 
 export function NameTableRow({ datum }: NameTableRowProps) {
-  const { clade, lineages, who, others, oldnames } = datum
+  const { clade, lineages, who, others } = datum
 
   const lineageEntries = useMemo(
     () =>
@@ -92,14 +92,6 @@ export function NameTableRow({ datum }: NameTableRowProps) {
     [others],
   )
 
-  const oldNames = useMemo(
-    () =>
-      joinWithCommas(
-        oldnames.map<ReactNode>((entry) => <NameTableEntryComponent key={entry.name} entry={entry} />),
-      ),
-    [oldnames],
-  )
-
   return (
     <Tr>
       <Td>
@@ -108,7 +100,6 @@ export function NameTableRow({ datum }: NameTableRowProps) {
       <Td>{lineageEntries}</Td>
       <Td>{who && <WhoBadge name={who} />}</Td>
       <Td>{otherEntries}</Td>
-      <Td>{oldNames}</Td>
     </Tr>
   )
 }
@@ -125,8 +116,7 @@ export function NameTable() {
               {'WHO Label'}
             </LinkExternal>
           </Th>
-          <Th>{'Other Names'}</Th>
-          <Th>{'Old CoVariants Names'}</Th>
+          <Th>{'Other'}</Th>
         </Tr>
       </Thead>
       <Tbody>

--- a/web/src/io/getNameTable.ts
+++ b/web/src/io/getNameTable.ts
@@ -10,7 +10,6 @@ export interface NameTableDatum {
   who: string | null
   lineages: NameTableEntry[]
   others: NameTableEntry[]
-  oldnames: NameTableEntry[]
 }
 
 export function getNameTable(): NameTableDatum[] {


### PR DESCRIPTION
In response to the fact that the name table is squashed on mobile devices, removed "Old CoVariants Name" from the table, and shortened "other names" to "other".
![image](https://user-images.githubusercontent.com/14290674/131980808-aacc5663-6d96-40a0-a4a9-c9a35bf31ab0.png)


This is a trade-off - right now it's unlikely anyone is still using the old CoVariants names, but in future if clades are given "official" names, then this may be useful again. However, it's likely not being widely used, and having the table be readable on mobile devices is likely more important. 

Still squashed on older devices (iPhone 5) with smaller screens, but should look good on the majority of more modern, slightly larger screens. 

