### PR TITLE
name_table.py, MutationBadge.tsx: repair global reports polling and display logic

### DIFF
--- a/scripts/name_table.py
+++ b/scripts/name_table.py
@@ -204,9 +204,6 @@ def does_url_respond(url: str):
 def update_name_table(name_table):
     for datum in name_table:
         for lineage in datum["lineages"]:
-            if lineage["url"] is not None:
-                continue
-
             name = lineage["name"]
 
             # Make a request to a hypothetical URL where global report might reside.

--- a/web/src/components/Common/MutationBadge.tsx
+++ b/web/src/components/Common/MutationBadge.tsx
@@ -286,7 +286,7 @@ export interface LineageLinkBadgeProps {
 export function LineageLinkBadge({ name, href, prefix, report }: LineageLinkBadgeProps) {
   const url = useMemo(
     // prettier-ignore
-    () => (href ?? report ? `https://cov-lineages.org/global_report_${name}.html` : ''),
+    () => (href ?? (report ? `https://cov-lineages.org/global_report_${name}.html` : '')),
     [href, report, name],
   )
   const tooltip = useMemo(() => `Pango Lineage ${name}`, [name])


### PR DESCRIPTION
Tweak to `update_name_table()` to add a bit more checking for changes in global report page availability.  General notes below.

## covariants homepage error

This report linked in the name table does not exist:

- https://cov-lineages.org/global_report_B.1.617.1.html

## all global reports

As of now, the following pango global report pages exist:

- https://cov-lineages.org/global_report_A.23.1.html
- https://cov-lineages.org/global_report_B.1.1.529.html
- https://cov-lineages.org/global_report_B.1.1.7.html
- https://cov-lineages.org/global_report_B.1.351.html
- https://cov-lineages.org/global_report_B.1.525.html
- https://cov-lineages.org/global_report_B.1.617.2.html
- https://cov-lineages.org/global_report_P.1.html

## future global reports

Global reports for lineages not of VOC status were deprecated in https://github.com/cov-lineages/lineages-website/commit/ddd6db717fcf20a318640c693cbf490c6cd7d0e0.
Two reports excluded by this change have not yet been removed.
These are:

- https://cov-lineages.org/global_report_A.23.1.html
- https://cov-lineages.org/global_report_B.1.525.html

