### PR TITLE
feat: add missing flags

### DIFF
--- a/web/src/components/Common/CountryFlag.tsx
+++ b/web/src/components/Common/CountryFlag.tsx
@@ -12,10 +12,13 @@ import { ReactComponent as Oceania } from 'src/assets/images/continents/Oceania.
 import { ReactComponent as SouthAmerica } from 'src/assets/images/continents/South America.svg'
 
 export const missingCountryCodes: Record<string, string> = {
-  'Kosovo': 'XK',
   'Bonaire': 'BQ',
+  'Brunei': 'BN',
   'Curacao': 'CW',
+  'Iran': 'IR',
+  'Kosovo': 'XK',
   'North Macedonia': 'MK',
+  'Republic of the Congo': 'CD',
   'Russia': 'RU',
   'Sint Maarten': 'SX',
   'South Korea': 'KR',


### PR DESCRIPTION
Adds country names that do not adhere to ISO standards to the list of workarounds in order to be able to display flags.
