### PR TITLE
Provide (more) consistent linting and formatting with black and flake8

### DIFF
--- a/scripts/.flake8
+++ b/scripts/.flake8
@@ -1,0 +1,17 @@
+[flake8]
+ignore = E203, # Whitespace before :
+    E266, # Too many leading hashes in comment
+    E402, # Module import should be at the top
+    E501, # Line length exceeds max-line-length
+    E712, # Comparison to boolean value should use is
+    F401, # Imported but unsued
+    F403, # Unable to detect import names
+    F405, # Value may be undefined or imported via star import
+    F601, # Repeated dictionary key
+    F632, # Use ==/!= to compare constant literals
+    F821, # Undefined names
+    F841, # Local variable is assigned but never used
+    W605, # Invalid escape sequence, "\d" in regular expression
+max-complexity = 75
+max-line-length = 120
+exclude = .git,__pycache__,.mypycache,.venv

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,3 @@
+.venv
+.mypy_cache
+requirements.lock.txt

--- a/scripts/.vscode/settings.json
+++ b/scripts/.vscode/settings.json
@@ -1,0 +1,28 @@
+{
+    "python.defaultInterpreterPath": ".venv/bin/python",
+    "python.formatting.provider": "black",
+    "python.formatting.blackPath": ".venv/bin/black",
+    "python.formatting.blackArgs": [
+        "--line-length",
+        "120",
+    ],
+    "python.linting.pylintEnabled": false,
+    "python.linting.flake8Enabled": true,
+    "python.linting.flake8Path": ".venv/bin/flake8",
+    "python.linting.mypyEnabled": false,
+    "python.linting.mypyPath": ".venv/bin/mypy",
+    "python.linting.enabled": true,
+    "python.analysis.extraPaths": [ // setting for pylance when used
+        "PATH_TO_MISSING_MODULES",
+    ],
+    "[python]": {
+        "editor.formatOnPaste": false, // not supported by black
+        "editor.formatOnSaveMode": "file"
+    },
+    "editor.formatOnSave": true,
+    "editor.rulers": [
+        {
+            "column": 120,
+        }
+    ]
+}

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -1,0 +1,9 @@
+SHELL := /bin/bash
+.DEFAULT_GOAL := setup
+
+setup:
+	python3 -m venv '.venv'
+	source .venv/bin/activate \
+		&& python3 -m pip install --upgrade pip \
+		&& python3 -m pip install -r requirements.txt \
+		&& python3 -m pip freeze > requirements.lock.txt

--- a/scripts/allClusterDynamics.py
+++ b/scripts/allClusterDynamics.py
@@ -95,9 +95,7 @@ clus_to_run = ["S222"]
 reask = True
 
 while reask:
-    clus_answer = input(
-        "\nWhat cluster to run? (Enter for S222) Type 'all' for all, type 'all mink' for all+mink: "
-    )
+    clus_answer = input("\nWhat cluster to run? (Enter for S222) Type 'all' for all, type 'all mink' for all+mink: ")
     if len(clus_answer) != 0:
         if clus_answer in clusters.keys():
             print(f"Using {clus_answer}\n")
@@ -125,7 +123,7 @@ if print_files and "all" in clus_answer:
         fh.write(
             "# Overview of Clusters/Mutations in Europe\n"
             "[Overview of proportion of clusters in selected countries](country_overview.md)\n\n"
-            "In the graphs below, countries are displayed in the chart if the country has at least 20 sequences present in the cluster.\n\n"
+            "In the graphs below, countries are displayed in the chart if the country has at least 20 sequences present in the cluster.\n\n"  # noqa: E501
             "# Mutation Tables and Graphs\n"
             "- [20A.EU1](#20aeu1) _(S:A222V)_ \n"
             "- [20A.EU2](#20aeu2) _(S:S477N)_ \n"
@@ -153,8 +151,8 @@ for clus in clus_to_run:
         mink_meta = meta[meta["host"].apply(lambda x: x == "Mink")]
         wanted_seqs = list(mink_meta["strain"])
 
-        clusterlist_output = cluster_path + f"/clusters/cluster_mink.txt"
-        out_meta_file = cluster_path + f"/cluster_info/cluster_mink_meta.tsv"
+        clusterlist_output = cluster_path + "/clusters/cluster_mink.txt"
+        out_meta_file = cluster_path + "/cluster_info/cluster_mink_meta.tsv"
 
     else:
         clus_display = clusters[clus]["build_name"]
@@ -172,13 +170,8 @@ for clus in clus_to_run:
         else:
             exclude_snps = []
 
-        clusterlist_output = (
-            cluster_path + f'/clusters/cluster_{clusters[clus]["build_name"]}.txt'
-        )
-        out_meta_file = (
-            cluster_path
-            + f'/cluster_info/cluster_{clusters[clus]["build_name"]}_meta.tsv'
-        )
+        clusterlist_output = cluster_path + f'/clusters/cluster_{clusters[clus]["build_name"]}.txt'
+        out_meta_file = cluster_path + f'/cluster_info/cluster_{clusters[clus]["build_name"]}_meta.tsv'
 
         # get the sequences that we want - which are 'part of the cluster:
         wanted_seqs = []
@@ -189,24 +182,15 @@ for clus in clus_to_run:
             gaplist = row["gap_list"]
 
             # look for occurance of snp(s) *without* some other snp(s) (to exclude a certain group)
-            if (
-                snps
-                and not pd.isna(snplist)
-                and exclude_snps
-                and not pd.isna(exclude_snps)
-            ):
+            if snps and not pd.isna(snplist) and exclude_snps and not pd.isna(exclude_snps):
                 intsnp = [int(x) for x in snplist.split(",")]
-                if all(x in intsnp for x in snps) and all(
-                    x not in intsnp for x in exclude_snps
-                ):
+                if all(x in intsnp for x in snps) and all(x not in intsnp for x in exclude_snps):
                     wanted_seqs.append(row["strain"])
 
             elif snps and not pd.isna(snplist):
                 intsnp = [int(x) for x in snplist.split(",")]
                 # this looks for all SNPs in 'snps' OR all in 'snps2' (two nucs that affect same AA, for example)
-                if all(x in intsnp for x in snps) or (
-                    all(x in intsnp for x in snps2) and len(snps2) != 0
-                ):
+                if all(x in intsnp for x in snps) or (all(x in intsnp for x in snps2) and len(snps2) != 0):
                     # if meta.loc[meta['strain'] == strain].region.values[0] == "Europe":
                     wanted_seqs.append(row["strain"])
             # look for all locations in gap list
@@ -318,19 +302,12 @@ for clus in clus_to_run:
 
     # Make a version of N501 which does not have as much UK sequences for increased viewability
     if clus == "S501":
-        nouk_501_meta = cluster_meta[
-            cluster_meta["country"].apply(lambda x: x != "United Kingdom")
-        ]
+        nouk_501_meta = cluster_meta[cluster_meta["country"].apply(lambda x: x != "United Kingdom")]
         # re-set wanted_seqs
         extra501_wanted_seqs = list(nouk_501_meta["strain"])
 
-        noUK_clusterlist_output = (
-            cluster_path + f'/clusters/cluster_{clusters[clus]["build_name"]}-noUK.txt'
-        )
-        noUK_out_meta_file = (
-            cluster_path
-            + f'/cluster_info/cluster_{clusters[clus]["build_name"]}-noUK_meta.tsv'
-        )
+        noUK_clusterlist_output = cluster_path + f'/clusters/cluster_{clusters[clus]["build_name"]}-noUK.txt'
+        noUK_out_meta_file = cluster_path + f'/cluster_info/cluster_{clusters[clus]["build_name"]}-noUK_meta.tsv'
 
         if print_files:
             with open(noUK_clusterlist_output, "w") as f:
@@ -339,9 +316,7 @@ for clus in clus_to_run:
             build_nam = clusters[clus]["build_name"]
             copypath = noUK_clusterlist_output.replace(
                 f"{build_nam}-noUK",
-                "{}-noUK-{}".format(
-                    build_nam, datetime.date.today().strftime("%Y-%m-%d")
-                ),
+                "{}-noUK-{}".format(build_nam, datetime.date.today().strftime("%Y-%m-%d")),
             )
             copyfile(noUK_clusterlist_output, copypath)
             nouk_501_meta.to_csv(noUK_out_meta_file, sep="\t", index=False)
@@ -388,9 +363,7 @@ for clus in clus_to_run:
         country_info.loc[coun].last_seq = temp_meta["date"].max()
         country_info.loc[coun].num_seqs = len(temp_meta)
 
-        country_dates[coun] = [
-            datetime.datetime.strptime(dat, "%Y-%m-%d") for dat in temp_meta["date"]
-        ]
+        country_dates[coun] = [datetime.datetime.strptime(dat, "%Y-%m-%d") for dat in temp_meta["date"]]
 
         herbst_dates = [x for x in country_dates[coun] if x >= cutoffDate]
         if coun in uk_countries:
@@ -400,16 +373,12 @@ for clus in clus_to_run:
         all_dates = [
             datetime.datetime.strptime(x, "%Y-%m-%d")
             for x in temp_meta["date"]
-            if len(x) is 10
-            and "-XX" not in x
-            and datetime.datetime.strptime(x, "%Y-%m-%d") >= cutoffDate
+            if len(x) is 10 and "-XX" not in x and datetime.datetime.strptime(x, "%Y-%m-%d") >= cutoffDate
         ]
         if len(all_dates) == 0:
             country_info.loc[coun].sept_oct_freq = 0
         else:
-            country_info.loc[coun].sept_oct_freq = round(
-                len(herbst_dates) / len(all_dates), 2
-            )
+            country_info.loc[coun].sept_oct_freq = round(len(herbst_dates) / len(all_dates), 2)
 
     print(country_info)
     print("\n")
@@ -455,41 +424,31 @@ for clus in clus_to_run:
         if "all" in clus_answer and clus != "DanishCluster":
             with open(f"{tables_path}all_tables.md", "a") as fh:
                 fh.write(f"\n\n## {clus_display}\n")
-                fh.write(
-                    f"[Focal Build](https://nextstrain.org/groups/neherlab/ncov/{clus_display}?{url_params})\n\n"
-                )
+                fh.write(f"[Focal Build](https://nextstrain.org/groups/neherlab/ncov/{clus_display}?{url_params})\n\n")
                 if clus is "S501":
                     fh.write(
-                        f"Note any pre-2020 Chinese sequences are from SARS-like viruses in bats (not SARS-CoV-2).\n"
+                        "Note any pre-2020 Chinese sequences are from SARS-like viruses in bats (not SARS-CoV-2).\n"
                     )
                     fh.write(
-                        f"Note that this mutation has multiple amino-acid mutants - these numbers "
+                        "Note that this mutation has multiple amino-acid mutants - these numbers "
                         "refer to _all_ these mutations (Y, S, T).\n"
                     )
                 fh.write(mrk_tbl)
                 fh.write("\n\n")
-                fh.write(
-                    f"![Overall trends {clus_display}](/overall_trends_figures/overall_trends_{clus_display}.png)"
-                )
+                fh.write(f"![Overall trends {clus_display}](/overall_trends_figures/overall_trends_{clus_display}.png)")
 
         with open(f"{tables_path}{clus_display}_table.md", "w") as fh:
             fh.write(f"\n\n## {clus_display}\n")
-            fh.write(
-                f"[Focal Build](https://nextstrain.org/groups/neherlab/ncov/{clus_display}?{url_params})\n\n"
-            )
+            fh.write(f"[Focal Build](https://nextstrain.org/groups/neherlab/ncov/{clus_display}?{url_params})\n\n")
             if clus is "S501":
+                fh.write("Note any pre-2020 Chinese sequences are from SARS-like viruses in bats (not SARS-CoV-2).\n")
                 fh.write(
-                    f"Note any pre-2020 Chinese sequences are from SARS-like viruses in bats (not SARS-CoV-2).\n"
-                )
-                fh.write(
-                    f"Note that this mutation has multiple amino-acid mutants - these numbers "
+                    "Note that this mutation has multiple amino-acid mutants - these numbers "
                     "refer to _all_ these mutations (Y, S, T).\n"
                 )
             fh.write(mrk_tbl)
             fh.write("\n\n")
-            fh.write(
-                f"![Overall trends {clus_display}](/overall_trends_figures/overall_trends_{clus_display}.png)"
-            )
+            fh.write(f"![Overall trends {clus_display}](/overall_trends_figures/overall_trends_{clus_display}.png)")
 
     # ordered_country.to_markdown(f"{tables_path}all_tables.md", mode='a')
 
@@ -520,9 +479,7 @@ for clus in clus_to_run:
         # week 20
         for ri, row in temp_meta.iterrows():
             dat = row.date
-            if (
-                len(dat) is 10 and "-XX" not in dat
-            ):  # only take those that have real dates
+            if len(dat) is 10 and "-XX" not in dat:  # only take those that have real dates
                 dt = datetime.datetime.strptime(dat, "%Y-%m-%d")
                 # exclude sequences with identical dates & underdiverged
                 if coun == "Ireland" and dat == "2020-09-22":
@@ -544,12 +501,8 @@ for clus in clus_to_run:
         total_week_counts[coun] = counts_by_week
 
     if print_files:
-        with open(
-            f"{acknowledgement_folder}{clus}_acknowledgement_table.tsv", "w"
-        ) as fh:
-            fh.write(
-                "#strain\tEPI_ISOLATE_ID\tOriginating lab\tsubmitting lab\tauthors\n"
-            )
+        with open(f"{acknowledgement_folder}{clus}_acknowledgement_table.tsv", "w") as fh:
+            fh.write("#strain\tEPI_ISOLATE_ID\tOriginating lab\tsubmitting lab\tauthors\n")
             for d in acknowledgement_table:
                 fh.write("\t".join(d) + "\n")
 
@@ -640,12 +593,8 @@ for clus in clus_to_run:
 
                     ax1.text(strt, y_start + 0.003, q_times["msg"], fontsize=fs * 0.8)
                     if coun == "Denmark":
-                        strt = datetime.datetime.strptime(
-                            q_free_to_spain["Denmark2"]["start"], "%Y-%m-%d"
-                        )
-                        end = datetime.datetime.strptime(
-                            q_free_to_spain["Denmark2"]["end"], "%Y-%m-%d"
-                        )
+                        strt = datetime.datetime.strptime(q_free_to_spain["Denmark2"]["start"], "%Y-%m-%d")
+                        end = datetime.datetime.strptime(q_free_to_spain["Denmark2"]["end"], "%Y-%m-%d")
                         ax1.add_patch(
                             Rectangle(
                                 (strt, y_start),
@@ -686,24 +635,20 @@ for clus in clus_to_run:
 
         # for a simpler plot of most interesting countries use this:
         for coun in [x for x in countries_to_plot]:
-            week_as_date, cluster_count, total_count = non_zero_counts(
-                cluster_data, total_data, coun
-            )
+            week_as_date, cluster_count, total_count = non_zero_counts(cluster_data, total_data, coun)
             # remove last data point if that point as less than frac sequences compared to the previous count
             week_as_date, cluster_count, total_count = trim_last_data_point(
-                week_as_date, cluster_count, total_count, frac=0.1, keep_count=10
+                week_as_date,
+                cluster_count,
+                total_count,
+                frac=0.1,
+                keep_count=10,
             )
 
             json_output[clus_display][coun] = {}
-            json_output[clus_display][coun]["week"] = [
-                datetime.datetime.strftime(x, "%Y-%m-%d") for x in week_as_date
-            ]
-            json_output[clus_display][coun]["total_sequences"] = [
-                int(x) for x in total_count
-            ]
-            json_output[clus_display][coun]["cluster_sequences"] = [
-                int(x) for x in cluster_count
-            ]
+            json_output[clus_display][coun]["week"] = [datetime.datetime.strftime(x, "%Y-%m-%d") for x in week_as_date]
+            json_output[clus_display][coun]["total_sequences"] = [int(x) for x in total_count]
+            json_output[clus_display][coun]["cluster_sequences"] = [int(x) for x in cluster_count]
 
             ax3.plot(
                 week_as_date,

--- a/scripts/allClusterDynamics_faster.py
+++ b/scripts/allClusterDynamics_faster.py
@@ -36,10 +36,10 @@ web_data_folder = "../covariants/web/data/"
 fmt = "png"  # "pdf"
 grey_color = "#cccccc"  # for "other clusters" of country plots
 
-#dated_limit = "2021-03-31" #only works for Q677 currently
-#dated_limit = "2021-06-30"
-#dated_cluster = "21A (Delta)"
-#dated_cluster = "20I (Alpha, V1)"
+# dated_limit = "2021-03-31" #only works for Q677 currently
+# dated_limit = "2021-06-30"
+# dated_cluster = "21A (Delta)"
+# dated_cluster = "20I (Alpha, V1)"
 dated_cluster = "Q677"
 dated_limit = ""
 
@@ -63,17 +63,14 @@ import os
 import re
 import time
 
+
 def get_division_summary(cluster_meta, chosen_country):
 
-    country_meta = cluster_meta[
-        cluster_meta["country"].apply(lambda x: x == chosen_country)
-    ]
-    #remove any 'empty' divisions as we don't want these.
+    country_meta = cluster_meta[cluster_meta["country"].apply(lambda x: x == chosen_country)]
+    # remove any 'empty' divisions as we don't want these.
     observed_divisions = [x for x in country_meta["division"].unique() if x]
 
-    division_info = pd.DataFrame(
-        index=observed_divisions, columns=["first_seq", "num_seqs", "last_seq"]
-    )
+    division_info = pd.DataFrame(index=observed_divisions, columns=["first_seq", "num_seqs", "last_seq"])
     division_dates = {}
 
     for div in observed_divisions:
@@ -81,9 +78,7 @@ def get_division_summary(cluster_meta, chosen_country):
         division_info.loc[div].first_seq = temp_meta["date"].min()
         division_info.loc[div].last_seq = temp_meta["date"].max()
         division_info.loc[div].num_seqs = len(temp_meta)
-        division_dates[div] = [
-            datetime.datetime.strptime(dat, "%Y-%m-%d") for dat in temp_meta["date"]
-        ]
+        division_dates[div] = [datetime.datetime.strptime(dat, "%Y-%m-%d") for dat in temp_meta["date"]]
 
     division_info_df = pd.DataFrame(data=division_info)
 
@@ -93,17 +88,13 @@ def get_division_summary(cluster_meta, chosen_country):
 
 def get_summary(cluster_meta, observed_countries, division=False):
 
-    country_info = pd.DataFrame(
-        index=observed_countries, columns=["first_seq", "num_seqs", "last_seq"]
-    )
+    country_info = pd.DataFrame(index=observed_countries, columns=["first_seq", "num_seqs", "last_seq"])
     country_dates = {}
 
     for coun in observed_countries:
         if coun in uk_countries or division:
             # temp_meta = cluster_meta[cluster_meta['division'].isin([coun])]
-            temp_meta = cluster_meta[
-                cluster_meta["division"].apply(lambda x: x == coun)
-            ]
+            temp_meta = cluster_meta[cluster_meta["division"].apply(lambda x: x == coun)]
         else:
             # temp_meta = cluster_meta[cluster_meta['country'].isin([coun])]
             temp_meta = cluster_meta[cluster_meta["country"].apply(lambda x: x == coun)]
@@ -112,21 +103,22 @@ def get_summary(cluster_meta, observed_countries, division=False):
         country_info.loc[coun].last_seq = temp_meta["date"].max()
         country_info.loc[coun].num_seqs = len(temp_meta)
 
-        country_dates[coun] = [
-            datetime.datetime.strptime(dat, "%Y-%m-%d") for dat in temp_meta["date"]
-        ]
+        country_dates[coun] = [datetime.datetime.strptime(dat, "%Y-%m-%d") for dat in temp_meta["date"]]
 
     return country_info, country_dates
+
 
 def print_date_alerts(clus):
     print(clus)
     print(f"Expected date: {cluster_first_dates[clus]['first_date']}")
-    print(alert_first_date[clus][['strain','date','gisaid_epi_isl']])
+    print(alert_first_date[clus][["strain", "date", "gisaid_epi_isl"]])
+
 
 def print_all_date_alerts():
     for clus in alert_first_date.keys():
         print_date_alerts(clus)
         print("\n")
+
 
 def marker_size(n):
     if n > 100:
@@ -185,9 +177,7 @@ clus_to_run = ["EU1"]
 reask = True
 
 while reask:
-    clus_answer = input(
-        "\nWhat cluster to run? (Enter for S222) Type 'all' for all, type 'all mink' for all+mink: "
-    )
+    clus_answer = input("\nWhat cluster to run? (Enter for S222) Type 'all' for all, type 'all mink' for all+mink: ")
     if len(clus_answer) != 0:
         if clus_answer in clusters.keys():
             print(f"Using {clus_answer}\n")
@@ -215,7 +205,7 @@ while reask:
         reask = False
 print("These clusters will be run: ", clus_to_run)
 
-# ask user if they want to continue to do the full plotting - mostly we do these days 
+# ask user if they want to continue to do the full plotting - mostly we do these days
 do_country = False
 if "all" in clus_answer:
     print_answer = input("\nContinue to country plotting? (y/n) (Enter is no): ")
@@ -225,15 +215,11 @@ else:
     print("Can't do country plot as aren't doing 'all' clusters")
 
 if do_country == False:
-    print(
-        "You can alway run this step by calling `plot_country_data(clusters, proposed_coun_to_plot, print_files)`"
-    )
+    print("You can alway run this step by calling `plot_country_data(clusters, proposed_coun_to_plot, print_files)`")
 
 do_divisions_country = False
 if "all" in clus_answer:
-    print_answer = input(
-        "\nContinue to USA- & Swiss-specific country plotting? (y/n) (Enter is no): "
-    )
+    print_answer = input("\nContinue to USA- & Swiss-specific country plotting? (y/n) (Enter is no): ")
     if print_answer in ["y", "Y", "yes", "YES", "Yes"]:
         do_divisions_country = True
 
@@ -247,17 +233,15 @@ print("\nReading in files...\n")
 
 
 # Get mutation summary file - used to get list of SNPs of all sequences, to pick out seqs that have right SNPS
-muts_file = (
-    "results/mutation_summary_gisaid.tsv"  # "results/sequence-diagnostics.tsv"
-)
+muts_file = "results/mutation_summary_gisaid.tsv"  # "results/sequence-diagnostics.tsv"
 muts = pd.read_csv(muts_file, sep="\t", index_col=False)
 
 t0 = time.time()
 
 # Read metadata file
-#input_meta = "data/downloaded_gisaid.tsv"  
+# input_meta = "data/downloaded_gisaid.tsv"
 
-#dtype = {
+# dtype = {
 #    "strain": "str",
 #    "virus": "category",
 #    "gisaid_epi_isl": "str",
@@ -298,10 +282,19 @@ t0 = time.time()
 #    "QC_rare_mutations": "category",
 #    "QC_snp_clusters": "category",
 #    "clock_deviation": "category"
-#}
+# }
 input_meta = "data/metadata.tsv"
-dtype={'location': str, 'sampling_strategy': str, 'clock_deviation': str, 'age': str, 'QC_frame_shifts': str, 'frame_shifts': str}
-meta = pd.read_csv(input_meta, sep="\t", dtype=dtype, index_col=False) #dtype={'location': str, 'sampling_strategy': str, 'clock_deviation': str}, index_col=False)
+dtype = {
+    "location": str,
+    "sampling_strategy": str,
+    "clock_deviation": str,
+    "age": str,
+    "QC_frame_shifts": str,
+    "frame_shifts": str,
+}
+meta = pd.read_csv(
+    input_meta, sep="\t", dtype=dtype, index_col=False
+)  # dtype={'location': str, 'sampling_strategy': str, 'clock_deviation': str}, index_col=False)
 meta = meta.fillna("")
 
 # Clean up metadata
@@ -309,20 +302,18 @@ meta = meta.fillna("")
 print("\nCleaning up the metadata...\n")
 
 # If bad seq there  - exclude!
-maybe_bad = meta.loc[meta['strain'].isin(bad_seqs.keys())]
-really_bad = [s.date==bad_seqs[s.strain] for ri,s in maybe_bad.iterrows()]
-bad_indices =  maybe_bad.loc[really_bad].index
+maybe_bad = meta.loc[meta["strain"].isin(bad_seqs.keys())]
+really_bad = [s.date == bad_seqs[s.strain] for ri, s in maybe_bad.iterrows()]
+bad_indices = maybe_bad.loc[really_bad].index
 meta.drop(bad_indices, inplace=True)
 
-bads = meta[meta['strain'].isin(bad_seqs.keys())]
+bads = meta[meta["strain"].isin(bad_seqs.keys())]
 
 # do some modifications to metadata once, here - to exclude bad dates
 meta = meta[meta["date"].apply(lambda x: len(x) == 10)]
 meta = meta[meta["date"].apply(lambda x: "XX" not in x)]
 
-meta["date_formatted"] = meta["date"].apply(
-    lambda x: datetime.datetime.strptime(x, "%Y-%m-%d")
-)
+meta["date_formatted"] = meta["date"].apply(lambda x: datetime.datetime.strptime(x, "%Y-%m-%d"))
 
 # warn of any in the future
 future_meta = meta[meta["date_formatted"].apply(lambda x: x > datetime.date.today())]
@@ -333,12 +324,12 @@ if not future_meta.empty:
 meta = meta[meta["date_formatted"].apply(lambda x: x <= datetime.date.today())]
 
 # Replace Swiss divisions with swiss-region, but store original division
-meta['orig_division'] = meta['division']
-meta['division'] = meta['division'].replace(swiss_regions)
+meta["orig_division"] = meta["division"]
+meta["division"] = meta["division"].replace(swiss_regions)
 # meta[meta["country"].apply(lambda x: x == "Switzerland")]  #can check
 
 # Filter mutations to match Metadata - to exclude sequences with bad dates
-muts = muts[muts['Unnamed: 0'].isin(meta['strain'])]
+muts = muts[muts["Unnamed: 0"].isin(meta["strain"])]
 # Filter Metadata to only have those we have mutations for! Allows 'out of sync' files.
 meta = meta[meta["strain"].isin(muts["Unnamed: 0"])]
 
@@ -356,7 +347,7 @@ json_output = {}
 
 # if running all clusters, clear file so can write again.
 if print_files and "all" in clus_answer:
-    #empty file to write clean
+    # empty file to write clean
     with open(overall_tables_file, "w") as fh:
         fh.write("\n")
 
@@ -383,10 +374,8 @@ for clus in clus_to_run:
         clus_data["mink_meta"] = meta[meta["host"].apply(lambda x: x == "Mink")]
         clus_data["wanted_seqs"] = list(clus_data["mink_meta"]["strain"])
 
-        clus_data["clusterlist_output"] = cluster_path + f"/clusters/cluster_mink.txt"
-        clus_data["out_meta_file"] = (
-            cluster_path + f"/cluster_info/cluster_mink_meta.tsv"
-        )
+        clus_data["clusterlist_output"] = cluster_path + "/clusters/cluster_mink.txt"
+        clus_data["out_meta_file"] = cluster_path + "/cluster_info/cluster_mink_meta.tsv"
 
     else:
         clus_build_name = clusters[clus]["build_name"]
@@ -400,13 +389,8 @@ for clus in clus_to_run:
 
         clus_data["wanted_seqs"] = []
 
-        clus_data["clusterlist_output"] = (
-            cluster_path + f'/clusters/cluster_{clusters[clus]["build_name"]}.txt'
-        )
-        clus_data["out_meta_file"] = (
-            cluster_path
-            + f'/cluster_info/cluster_{clusters[clus]["build_name"]}_meta.tsv'
-        )
+        clus_data["clusterlist_output"] = cluster_path + f'/clusters/cluster_{clusters[clus]["build_name"]}.txt'
+        clus_data["out_meta_file"] = cluster_path + f'/cluster_info/cluster_{clusters[clus]["build_name"]}_meta.tsv'
 
 
 ##################################
@@ -417,8 +401,10 @@ t0 = time.time()
 
 print("\nLooking for the wanted sequences in the file...\n")
 
-muts["snp_pos"] = muts.nucleotide.fillna('').apply(lambda x: [int(y[1:-1]) for y in x.split(',') if y and y[-1] in 'ACGT'])
-muts["gap_pos"] = muts.nucleotide.fillna('').apply(lambda x: [int(y[1:-1]) for y in x.split(',') if y and y[-1] in '-'])
+muts["snp_pos"] = muts.nucleotide.fillna("").apply(
+    lambda x: [int(y[1:-1]) for y in x.split(",") if y and y[-1] in "ACGT"]
+)
+muts["gap_pos"] = muts.nucleotide.fillna("").apply(lambda x: [int(y[1:-1]) for y in x.split(",") if y and y[-1] in "-"])
 
 # If an official Nextstrain clade, then use Nextclade designation to find them.
 # If not an official Nextstrain clade, use our SNP method
@@ -432,7 +418,7 @@ for clus in [x for x in clus_to_run if x != "mink"]:
     snps = clus_data["snps"]
     snps2 = clus_data["snps2"]
     gaps = clus_data["gaps"]
-    display_name = clus_data['display_name']
+    display_name = clus_data["display_name"]
     exclude_snps = clus_data["exclude_snps"]
     wanted_seqs = clus_data["wanted_seqs"]
 
@@ -448,25 +434,34 @@ for clus in [x for x in clus_to_run if x != "mink"]:
         wanted_seqs.extend(list(next_assign.strain))
 
     else:
-    #Use SNPS
+        # Use SNPS
 
         # look for occurance of snp(s) *without* some other snp(s) (to exclude a certain group)
         if snps:
-            founds = muts.loc[muts.snp_pos.apply(lambda x: all((p in x) for p in snps) & all((p not in x) for p in exclude_snps)),'Unnamed: 0']
+            founds = muts.loc[
+                muts.snp_pos.apply(lambda x: all((p in x) for p in snps) & all((p not in x) for p in exclude_snps)),
+                "Unnamed: 0",
+            ]
             wanted_seqs.extend(founds)
 
         # look for additional occurances which have snps2
         # (to look for 2 muts that affect same AA, for example)
         if snps2:
-            founds = muts.loc[muts.snp_pos.apply(lambda x: all((p in x) for p in snps2) & all((p not in x) for p in exclude_snps)),'Unnamed: 0']
+            founds = muts.loc[
+                muts.snp_pos.apply(lambda x: all((p in x) for p in snps2) & all((p not in x) for p in exclude_snps)),
+                "Unnamed: 0",
+            ]
             wanted_seqs.extend(founds)
 
-        #look for sequences by gaps
+        # look for sequences by gaps
         if gaps:
-            founds = muts.loc[muts.gap_pos.apply(lambda x: all((p in x) for p in gaps) & all((p not in x) for p in exclude_snps)),'Unnamed: 0']
+            founds = muts.loc[
+                muts.gap_pos.apply(lambda x: all((p in x) for p in gaps) & all((p not in x) for p in exclude_snps)),
+                "Unnamed: 0",
+            ]
             wanted_seqs.extend(founds)
 
-    #dedup
+    # dedup
     wanted_seqs = list(set(wanted_seqs))
     t1a = time.time()
     print(f"Completed {n_done} out of {len(clus_to_run)}: {round((t1a-t0)/60,1)} min")
@@ -476,7 +471,9 @@ for clus in [x for x in clus_to_run if x != "mink"]:
 t1 = time.time()
 print(f"Finding sequences took {round((t1-t0)/60,1)} min to run")
 
-nextstrain_name_to_clus = {clusters[clus]["nextstrain_name"]: clus for clus in clus_to_run if "nextstrain_name" in clusters[clus]}
+nextstrain_name_to_clus = {
+    clusters[clus]["nextstrain_name"]: clus for clus in clus_to_run if "nextstrain_name" in clusters[clus]
+}
 
 ##################################
 ##################################
@@ -510,17 +507,16 @@ for clus in clus_to_run:
             print(f"Removing {clus} samples from {cla}")
             other_meta = clusters[nextstrain_name_to_clus[cla]]["cluster_meta"]
             other_wanted = clusters[nextstrain_name_to_clus[cla]]["wanted_seqs"]
-            #get the ones to remove from the other cluster 'record'
+            # get the ones to remove from the other cluster 'record'
             to_remove = cluster_meta[cluster_meta["Nextstrain_clade"] == cla].strain
-            #remove from meta
-            bad_seqs = other_meta.loc[other_meta['strain'].isin(to_remove)]
+            # remove from meta
+            bad_seqs = other_meta.loc[other_meta["strain"].isin(to_remove)]
             bad_indices = bad_seqs.index
             other_meta.drop(bad_indices, inplace=True)
-            #remove from wanted list
+            # remove from wanted list
             new_wanted = list(set(other_wanted) - set(to_remove))
-            #copy back
+            # copy back
             clusters[nextstrain_name_to_clus[cla]]["wanted_seqs"] = new_wanted
-
 
     # re-set wanted_seqs
     wanted_seqs = list(cluster_meta["strain"])
@@ -529,9 +525,9 @@ for clus in clus_to_run:
     print(len(wanted_seqs))  # how many are there?
     print("\n")
 
-    #Do we want to write out cluster for Nextstrain?
+    # Do we want to write out cluster for Nextstrain?
     if print_files:
-        nextstrain_run = clusters[clus]['nextstrain_build']
+        nextstrain_run = clusters[clus]["nextstrain_build"]
     else:
         nextstrain_run = False
 
@@ -552,41 +548,38 @@ for clus in clus_to_run:
             "{}-{}".format(build_nam, datetime.date.today().strftime("%Y-%m-%d")),
         )
         copyfile(clusterlist_output, copypath)
-        copypath2 = clusterlist_output.replace(
-            "clusters/cluster_", "clusters/current/cluster_"
-        )
+        copypath2 = clusterlist_output.replace("clusters/cluster_", "clusters/current/cluster_")
         copyfile(clusterlist_output, copypath2)
 
         # Just so we have the data, write out the metadata for these sequences
         cluster_meta.to_csv(out_meta_file, sep="\t", index=False)
 
     # If specified wanted dated Q677, do this
-    #if print_files and dated_limit and "Q677" in display_cluster:
+    # if print_files and dated_limit and "Q677" in display_cluster:
     # if want a dated limit, specify cluster and limit at top
     if print_files and dated_limit and dated_cluster in display_cluster:
-    ####### if dated_limit and "Q677" in clus_build_name: # (old)
+        ####### if dated_limit and "Q677" in clus_build_name: # (old)
         build_nam = clusters[clus]["build_name"]
-        dated_clus_met = cluster_meta[cluster_meta["date_formatted"].apply(lambda x: x < datetime.datetime.strptime(dated_limit, "%Y-%m-%d"))]
+        dated_clus_met = cluster_meta[
+            cluster_meta["date_formatted"].apply(lambda x: x < datetime.datetime.strptime(dated_limit, "%Y-%m-%d"))
+        ]
         dated_want_seqs = list(dated_clus_met["strain"])
 
         datedpath = clusterlist_output.replace(
             f"{build_nam}",
             "{}-{}".format(build_nam, dated_limit),
         )
-        curr_datedpath = datedpath.replace(
-            "clusters/cluster_", "clusters/current/cluster_"
-        )
+        curr_datedpath = datedpath.replace("clusters/cluster_", "clusters/current/cluster_")
         with open(curr_datedpath, "w") as f:
             for item in dated_want_seqs:
                 f.write("%s\n" % item)
 
-
     # What countries do sequences in the cluster come from?
-    #observed_countries = [x for x in cluster_meta["country"].unique() if x]
+    # observed_countries = [x for x in cluster_meta["country"].unique() if x]
     observed_countries = list(cluster_meta.country.unique())
     clus_data["observed_countries"] = observed_countries
     # Use below to print observed countries, if interested
-    #print(f"The cluster is found in: {observed_countries}\n")
+    # print(f"The cluster is found in: {observed_countries}\n")
 
     # Let's get some summary stats on number of sequences, first, and last, for each country.
     country_info, country_dates = get_summary(cluster_meta, observed_countries)
@@ -623,21 +616,14 @@ for clus in clus_to_run:
             alert_first_date[clus] = before_date
 
     # Make a version of Delta which does not have as much UK/India sequences for increased viewability
-    #if clus == "21AS478":
+    # if clus == "21AS478":
     if clus_build_name == "21A.Delta":
-        nouk_delta_meta = cluster_meta[
-            cluster_meta["country"].apply(lambda x: x != "United Kingdom" and x != "India")
-        ]
+        nouk_delta_meta = cluster_meta[cluster_meta["country"].apply(lambda x: x != "United Kingdom" and x != "India")]
         # re-set wanted_seqs
         extraDelta_wanted_seqs = list(nouk_delta_meta["strain"])
 
-        noUK_clusterlist_output = (
-            cluster_path + f'/clusters/cluster_{clusters[clus]["build_name"]}-noUKIndia.txt'
-        )
-        noUK_out_meta_file = (
-            cluster_path
-            + f'/cluster_info/cluster_{clusters[clus]["build_name"]}-noUKIndia_meta.tsv'
-        )
+        noUK_clusterlist_output = cluster_path + f'/clusters/cluster_{clusters[clus]["build_name"]}-noUKIndia.txt'
+        noUK_out_meta_file = cluster_path + f'/cluster_info/cluster_{clusters[clus]["build_name"]}-noUKIndia_meta.tsv'
 
         if print_files:
             with open(noUK_clusterlist_output, "w") as f:
@@ -646,71 +632,63 @@ for clus in clus_to_run:
             build_nam = clusters[clus]["build_name"]
             copypath = noUK_clusterlist_output.replace(
                 f"{build_nam}-noUKIndia",
-                "{}-noUKIndia-{}".format(
-                    build_nam, datetime.date.today().strftime("%Y-%m-%d")
-                ),
+                "{}-noUKIndia-{}".format(build_nam, datetime.date.today().strftime("%Y-%m-%d")),
             )
             copyfile(noUK_clusterlist_output, copypath)
             nouk_delta_meta.to_csv(noUK_out_meta_file, sep="\t", index=False)
-            copypath2 = noUK_clusterlist_output.replace(
-                "clusters/cluster_", "clusters/current/cluster_"
-            )
+            copypath2 = noUK_clusterlist_output.replace("clusters/cluster_", "clusters/current/cluster_")
             copyfile(noUK_clusterlist_output, copypath2)
 
     # Make a version of Delta for Europe
     ### DISABLED because there are now 3 delta categories -no way to pull Europe seqs from each.
-    #if clus == "21AS478":
-#    if clus_build_name == "21A.Delta":
-#        eu_delta_meta = cluster_meta[
-#            cluster_meta["region"].apply(lambda x: x == "Europe")
-#        ]
-#        # re-set wanted_seqs
-#        extraDelta_wanted_seqs = list(eu_delta_meta["strain"])
-#
-#        eu_clusterlist_output = (
-#            cluster_path + f'/clusters/cluster_{clusters[clus]["build_name"]}-europe.txt'
-#        )
-#        eu_out_meta_file = (
-#            cluster_path
-#            + f'/cluster_info/cluster_{clusters[clus]["build_name"]}-europe_meta.tsv'
-#        )
-#
-#        if print_files:
-#            with open(eu_clusterlist_output, "w") as f:
-#                for item in extraDelta_wanted_seqs:
-#                    f.write("%s\n" % item)
-#            build_nam = clusters[clus]["build_name"]
-#            copypath = eu_clusterlist_output.replace(
-#                f"{build_nam}-europe",
-#                "{}-europe-{}".format(
-#                    build_nam, datetime.date.today().strftime("%Y-%m-%d")
-#                ),
-#            )
-#            copyfile(eu_clusterlist_output, copypath)
-#            eu_delta_meta.to_csv(eu_out_meta_file, sep="\t", index=False)
-#            copypath2 = eu_clusterlist_output.replace(
-#                "clusters/cluster_", "clusters/current/cluster_"
-#            )
-#            copyfile(eu_clusterlist_output, copypath2)
+    # if clus == "21AS478":
+    #    if clus_build_name == "21A.Delta":
+    #        eu_delta_meta = cluster_meta[
+    #            cluster_meta["region"].apply(lambda x: x == "Europe")
+    #        ]
+    #        # re-set wanted_seqs
+    #        extraDelta_wanted_seqs = list(eu_delta_meta["strain"])
+    #
+    #        eu_clusterlist_output = (
+    #            cluster_path + f'/clusters/cluster_{clusters[clus]["build_name"]}-europe.txt'
+    #        )
+    #        eu_out_meta_file = (
+    #            cluster_path
+    #            + f'/cluster_info/cluster_{clusters[clus]["build_name"]}-europe_meta.tsv'
+    #        )
+    #
+    #        if print_files:
+    #            with open(eu_clusterlist_output, "w") as f:
+    #                for item in extraDelta_wanted_seqs:
+    #                    f.write("%s\n" % item)
+    #            build_nam = clusters[clus]["build_name"]
+    #            copypath = eu_clusterlist_output.replace(
+    #                f"{build_nam}-europe",
+    #                "{}-europe-{}".format(
+    #                    build_nam, datetime.date.today().strftime("%Y-%m-%d")
+    #                ),
+    #            )
+    #            copyfile(eu_clusterlist_output, copypath)
+    #            eu_delta_meta.to_csv(eu_out_meta_file, sep="\t", index=False)
+    #            copypath2 = eu_clusterlist_output.replace(
+    #                "clusters/cluster_", "clusters/current/cluster_"
+    #            )
+    #            copyfile(eu_clusterlist_output, copypath2)
 
     # Make a version of  Alpha-Delta which only have Swiss sequences for increased focus
-    #if clus in ["501YV1", "501YV2", "501YV3", "21AS478"]:
+    # if clus in ["501YV1", "501YV2", "501YV3", "21AS478"]:
     ## DISABLED for DELTA because now 3 categories of Delta - no way to pull seqs from all of them...
-    if clus_build_name in ["20I.Alpha.V1", "20H.Beta.V2", "20J.Gamma.V3" ]: #, "21A.Delta"]:
-        swiss_voc_meta = cluster_meta[
-            cluster_meta["country"].apply(lambda x: x == "Switzerland")
-        ]
+    if clus_build_name in [
+        "20I.Alpha.V1",
+        "20H.Beta.V2",
+        "20J.Gamma.V3",
+    ]:  # , "21A.Delta"]:
+        swiss_voc_meta = cluster_meta[cluster_meta["country"].apply(lambda x: x == "Switzerland")]
         # re-set wanted_seqs
         extravoc_wanted_seqs = list(swiss_voc_meta["strain"])
 
-        swissvoc_clusterlist_output = (
-            cluster_path
-            + f'/clusters/cluster_{clusters[clus]["build_name"]}-swiss.txt'
-        )
-        swissvoc_out_meta_file = (
-            cluster_path
-            + f'/cluster_info/cluster_{clusters[clus]["build_name"]}-swiss_meta.tsv'
-        )
+        swissvoc_clusterlist_output = cluster_path + f'/clusters/cluster_{clusters[clus]["build_name"]}-swiss.txt'
+        swissvoc_out_meta_file = cluster_path + f'/cluster_info/cluster_{clusters[clus]["build_name"]}-swiss_meta.tsv'
 
         if print_files:
             with open(swissvoc_clusterlist_output, "w") as f:
@@ -719,15 +697,11 @@ for clus in clus_to_run:
             build_nam = clusters[clus]["build_name"]
             copypath = swissvoc_clusterlist_output.replace(
                 f"{build_nam}-swiss",
-                "{}-swiss-{}".format(
-                    build_nam, datetime.date.today().strftime("%Y-%m-%d")
-                ),
+                "{}-swiss-{}".format(build_nam, datetime.date.today().strftime("%Y-%m-%d")),
             )
             copyfile(swissvoc_clusterlist_output, copypath)
             swiss_voc_meta.to_csv(swissvoc_out_meta_file, sep="\t", index=False)
-            copypath2 = swissvoc_clusterlist_output.replace(
-                "clusters/cluster_", "clusters/current/cluster_"
-            )
+            copypath2 = swissvoc_clusterlist_output.replace("clusters/cluster_", "clusters/current/cluster_")
             copyfile(swissvoc_clusterlist_output, copypath2)
 
     #######
@@ -755,9 +729,9 @@ for clus in clus_to_run:
         # do not put in acknowledgement folder, on request from GISAID
         # acknowledgement_table.to_csv(f'{acknowledgement_folder}{clus}_acknowledgement_table.tsv', sep="\t")
         if clus_build_name != "DanishCluster":
-            acknowledgement_by_variant["acknowledgements"][
-                clus_build_name
-            ] = cluster_meta.loc[:, ["gisaid_epi_isl"]]["gisaid_epi_isl"].tolist()
+            acknowledgement_by_variant["acknowledgements"][clus_build_name] = cluster_meta.loc[:, ["gisaid_epi_isl"]][
+                "gisaid_epi_isl"
+            ].tolist()
 
         # only do this for 'all' runs as otherwise the main file won't be updated.
         if clus_build_name != "DanishCluster" and "all" in clus_answer:
@@ -766,17 +740,12 @@ for clus in clus_to_run:
                 os.mkdir(ack_out_folder)
             ack_list = acknowledgement_by_variant["acknowledgements"][clus_build_name]
             chunk_size = 1000
-            chunks = [
-                ack_list[i : i + chunk_size]
-                for i in range(0, len(ack_list), chunk_size)
-            ]
+            chunks = [ack_list[i : i + chunk_size] for i in range(0, len(ack_list), chunk_size)]
 
             # get number & file names
             ack_file_names = ["{0:03}".format(i) for i in range(len(chunks))]
             acknowledgement_keys["acknowledgements"][clus_build_name] = {}
-            acknowledgement_keys["acknowledgements"][clus_build_name]["numChunks"] = len(
-                chunks
-            )
+            acknowledgement_keys["acknowledgements"][clus_build_name]["numChunks"] = len(chunks)
 
             for ch, fn in zip(chunks, ack_file_names):
                 with open(ack_out_folder + fn + ".json", "w") as fh:
@@ -808,10 +777,8 @@ all_observed_countries = list(meta.country.unique())
 for coun in all_observed_countries:
     temp_meta = meta[meta["country"].apply(lambda x: x == coun)].copy()
 
-    #For by week 
-    temp_meta["calendar_week"] = temp_meta["date_formatted"].apply(
-        lambda x: (x.isocalendar()[0], x.isocalendar()[1])
-    )
+    # For by week
+    temp_meta["calendar_week"] = temp_meta["date_formatted"].apply(lambda x: (x.isocalendar()[0], x.isocalendar()[1]))
     temp_meta = temp_meta[temp_meta["calendar_week"] >= min_data_week]
     # If no samples are after min_data_week, will be empty!!
     if temp_meta.empty:
@@ -821,7 +788,7 @@ for coun in all_observed_countries:
     week_counts = temp_meta["calendar_week"].value_counts().sort_index()
     counts_by_week = week_counts.to_dict()
     all_sequence_counts[coun] = {}
-    all_sequence_counts[coun]['week'] = counts_by_week
+    all_sequence_counts[coun]["week"] = counts_by_week
 
     # TWO WEEKS
     temp_meta["calendar_2week"] = temp_meta["date_formatted"].apply(
@@ -830,7 +797,7 @@ for coun in all_observed_countries:
     temp_meta = temp_meta[temp_meta["calendar_2week"] >= min_data_week]
     week2_counts = temp_meta["calendar_2week"].value_counts().sort_index()
     counts_by_2week = week2_counts.to_dict()
-    all_sequence_counts[coun]['2week'] = counts_by_2week
+    all_sequence_counts[coun]["2week"] = counts_by_2week
 
 ##################################
 ##################################
@@ -841,7 +808,7 @@ if division:
         division_all_sequence_counts[sel_coun] = {}
         # use list comprehension to get rid of empty divisions!!!
         observed_divisions = [x for x in meta[meta["country"].apply(lambda x: x == sel_coun)].division.unique() if x]
-    
+
         for div in observed_divisions:
             temp_meta = meta[meta["division"].apply(lambda x: x == div)].copy()
 
@@ -858,7 +825,7 @@ if division:
             week_counts = temp_meta["calendar_week"].value_counts().sort_index()
             counts_by_week = week_counts.to_dict()
             division_all_sequence_counts[sel_coun][div] = {}
-            division_all_sequence_counts[sel_coun][div]['week'] = counts_by_week
+            division_all_sequence_counts[sel_coun][div]["week"] = counts_by_week
 
             # TWO WEEKS
             temp_meta["calendar_2week"] = temp_meta["date_formatted"].apply(
@@ -867,7 +834,7 @@ if division:
             temp_meta = temp_meta[temp_meta["calendar_2week"] >= min_data_week]
             week2_counts = temp_meta["calendar_2week"].value_counts().sort_index()
             counts_by_2week = week2_counts.to_dict()
-            division_all_sequence_counts[sel_coun][div]['2week'] = counts_by_2week
+            division_all_sequence_counts[sel_coun][div]["2week"] = counts_by_2week
 
 t1 = time.time()
 print(f"Gathering up sequences took {round((t1-t0)/60,1)} min to run (partway through binning)\n")
@@ -896,14 +863,10 @@ for clus in clus_to_run:
             clus_data[sel_coun]["total_data_div"] = []
 
             # divide out data for divisions
-            cluster_meta_div = cluster_meta[
-                cluster_meta["country"].apply(lambda x: x == sel_coun)
-            ]
+            cluster_meta_div = cluster_meta[cluster_meta["country"].apply(lambda x: x == sel_coun)]
             observed_divisions = [x for x in cluster_meta_div["division"].unique() if x]
 
-            division_info, division_dates = get_summary(
-                cluster_meta_div, observed_divisions, division=True
-            )
+            division_info, division_dates = get_summary(cluster_meta_div, observed_divisions, division=True)
 
             clus_data[sel_coun]["observed_divisions"] = observed_divisions
             clus_data[sel_coun]["division_info"] = division_info
@@ -923,7 +886,9 @@ for clus in clus_to_run:
     # converts to tuple (year, ISO calendar week)
     cluster_meta["yr_wk"] = cluster_meta.date_formatted.apply(lambda x: (x.isocalendar()[0], x.isocalendar()[1]))
     # converts to tuple (year, ISO calendar week - every 2 weeks)
-    cluster_meta["yr_2wk"] = cluster_meta.date_formatted.apply(lambda x: (x.isocalendar()[0], x.isocalendar()[1] // 2 * 2))
+    cluster_meta["yr_2wk"] = cluster_meta.date_formatted.apply(
+        lambda x: (x.isocalendar()[0], x.isocalendar()[1] // 2 * 2)
+    )
 
     for coun in observed_countries:
         temp = cluster_meta[cluster_meta["country"].apply(lambda x: x == coun)]
@@ -933,9 +898,9 @@ for clus in clus_to_run:
     # Get counts per week for sequences regardless of whether in the cluster or not - from week 20 only.
     total_week_counts = {}
     total_2week_counts = {}
-    for coun in observed_countries: 
-        total_week_counts[coun] = all_sequence_counts[coun]['week']
-        total_2week_counts[coun] = all_sequence_counts[coun]['2week']
+    for coun in observed_countries:
+        total_week_counts[coun] = all_sequence_counts[coun]["week"]
+        total_2week_counts[coun] = all_sequence_counts[coun]["2week"]
 
     # COUNTRY LEVEL
     # Convert into dataframe
@@ -965,7 +930,7 @@ for clus in clus_to_run:
         for sel_coun in selected_country:
             clus_week_counts_div = {}
             clus_2week_counts_div = {}
-            observed_divisions = clus_data[sel_coun]["observed_divisions"] 
+            observed_divisions = clus_data[sel_coun]["observed_divisions"]
             for div in observed_divisions:
                 temp = cluster_meta[cluster_meta["division"].apply(lambda x: x == div)]
                 clus_week_counts_div[div] = temp.value_counts(subset="yr_wk").sort_index().to_dict()
@@ -975,8 +940,8 @@ for clus in clus_to_run:
             total_week_counts_div = {}
             total_2week_counts_div = {}
             for div in observed_divisions:
-                total_week_counts_div[div] = division_all_sequence_counts[sel_coun][div]['week']
-                total_2week_counts_div[div] = division_all_sequence_counts[sel_coun][div]['2week']
+                total_week_counts_div[div] = division_all_sequence_counts[sel_coun][div]["week"]
+                total_2week_counts_div[div] = division_all_sequence_counts[sel_coun][div]["2week"]
 
             # DIVISION LEVEL
             # Convert into dataframe
@@ -1015,8 +980,8 @@ clusters_tww = []
 for clus in clus_to_run:
     c_i = clusters[clus]["country_info"]
     c_i[c_i["num_seqs"] > cutoff_num_seqs]
-    #print(f"Countries with >{cutoff_num_seqs} seqs in cluster {clus}:")
-    #print("\t", ", ".join(c_i[c_i["num_seqs"] > 10].index))
+    # print(f"Countries with >{cutoff_num_seqs} seqs in cluster {clus}:")
+    # print("\t", ", ".join(c_i[c_i["num_seqs"] > 10].index))
     if len(c_i[c_i["num_seqs"] > 10]) > 0 and clus_build_name != "DanishCluster":
         clusters_tww.append(clus)
     print("")
@@ -1085,17 +1050,15 @@ for clus in clus_to_run:
     # Only plot countries with >= X seqs
     min_to_plot = cutoff_num_seqs
 
-    countries_to_plot_min = country_info_df[
-        country_info_df.num_seqs > min_to_plot
-    ].index
+    countries_to_plot_min = country_info_df[country_info_df.num_seqs > min_to_plot].index
 
-    #only plot those over >=X seqs - or if already going to plot elsewhere!
-    countries_to_plot_min = [x for x in country_info_df.index if (x in countries_to_plot_final or country_info_df.num_seqs[x] > min_to_plot)]
+    # only plot those over >=X seqs - or if already going to plot elsewhere!
+    countries_to_plot_min = [
+        x for x in country_info_df.index if (x in countries_to_plot_final or country_info_df.num_seqs[x] > min_to_plot)
+    ]
 
     countries_to_plot = [
-        x
-        for x in country_info_df[country_info_df.num_seqs > min_to_plot].index
-        if x in countries_to_plot_final
+        x for x in country_info_df[country_info_df.num_seqs > min_to_plot].index if x in countries_to_plot_final
     ]
 
     for coun in [x for x in countries_to_plot_min]:
@@ -1110,33 +1073,21 @@ for clus in clus_to_run:
         week_as_date, cluster_count, total_count = trim_last_data_point(
             week_as_date, cluster_count, total_count, frac=0.1, keep_count=10
         )
-        if len(cluster_count) < len(
-            unsmoothed_cluster_count
-        ):  # if the trim_last_data_point came true, match trimming
+        if len(cluster_count) < len(unsmoothed_cluster_count):  # if the trim_last_data_point came true, match trimming
             unsmoothed_cluster_count = unsmoothed_cluster_count[:-1]
             unsmoothed_total_count = unsmoothed_total_count[:-1]
 
         json_output[clus_build_name][coun] = {}
-        json_output[clus_build_name][coun]["week"] = [
-            datetime.datetime.strftime(x, "%Y-%m-%d") for x in week_as_date
-        ]
-        json_output[clus_build_name][coun]["total_sequences"] = [
-            int(x) for x in total_count
-        ]
-        json_output[clus_build_name][coun]["cluster_sequences"] = [
-            int(x) for x in cluster_count
-        ]
-        json_output[clus_build_name][coun]["unsmoothed_cluster_sequences"] = [
-            int(x) for x in unsmoothed_cluster_count
-        ]
-        json_output[clus_build_name][coun]["unsmoothed_total_sequences"] = [
-            int(x) for x in unsmoothed_total_count
-        ]
+        json_output[clus_build_name][coun]["week"] = [datetime.datetime.strftime(x, "%Y-%m-%d") for x in week_as_date]
+        json_output[clus_build_name][coun]["total_sequences"] = [int(x) for x in total_count]
+        json_output[clus_build_name][coun]["cluster_sequences"] = [int(x) for x in cluster_count]
+        json_output[clus_build_name][coun]["unsmoothed_cluster_sequences"] = [int(x) for x in unsmoothed_cluster_count]
+        json_output[clus_build_name][coun]["unsmoothed_total_sequences"] = [int(x) for x in unsmoothed_total_count]
 
         # This used to only plot a subset (those in 'countries to plot' below.)
         # However for a long time (as of Jul 21) all have been selected,
         # And I think this is most intuitive - so setting all to 'True'
-        countries_plotted[coun] = "True" #"False"
+        countries_plotted[coun] = "True"  # "False"
 
         if print_files:
             with open(tables_path + f"{clus_build_name}_data.json", "w") as fh:
@@ -1157,7 +1108,7 @@ if "all" in clus_answer:
 
 ## Write out plotting information - only if all clusters have run
 if print_files and "all" in clus_answer:
-    with open(tables_path + f"perVariant_countries_toPlot.json", "w") as fh:
+    with open(tables_path + "perVariant_countries_toPlot.json", "w") as fh:
         json.dump(countries_plotted, fh)
 
 print("Date alerts:")
@@ -1180,9 +1131,6 @@ print("############################\n\n")
 # Start of the country data/plotting
 
 
-
-        
-
 def get_ordered_clusters_to_plot(clusters, division=False, selected_country=None):
     # fix cluster order in a list so it's reliable
     clus_keys = [x for x in clusters.keys()]  # if x in clusters_tww]
@@ -1195,8 +1143,7 @@ def get_ordered_clusters_to_plot(clusters, division=False, selected_country=None
         clus_keys = [
             x
             for x in clus_keys
-            if clusters[x]["type"] == "variant"
-            or ("usa_graph" in clusters[x] and clusters[x]["usa_graph"] is True)
+            if clusters[x]["type"] == "variant" or ("usa_graph" in clusters[x] and clusters[x]["usa_graph"] is True)
         ]
         cluster_data_key = "cluster_data_2wk_div"
         min_to_plot = 20
@@ -1221,9 +1168,7 @@ def get_ordered_clusters_to_plot(clusters, division=False, selected_country=None
             country_inf = clusters[clus][selected_country]["division_info"]
         else:
             country_inf = clusters[clus]["country_info_df"]
-        proposed_coun_to_plot.extend(
-            country_inf[country_inf.num_seqs > min_to_plot].index
-        )
+        proposed_coun_to_plot.extend(country_inf[country_inf.num_seqs > min_to_plot].index)
     proposed_coun_to_plot = set(proposed_coun_to_plot)
     print(f"At min plot {min_to_plot}, there are {len(proposed_coun_to_plot)} entries")
 
@@ -1240,9 +1185,7 @@ def get_ordered_clusters_to_plot(clusters, division=False, selected_country=None
             if coun in country_inf.index:
                 total_coun_counts[coun] += country_inf.num_seqs[coun]
 
-    sorted_country_tups = sorted(
-        total_coun_counts.items(), key=lambda x: x[1], reverse=True
-    )
+    sorted_country_tups = sorted(total_coun_counts.items(), key=lambda x: x[1], reverse=True)
     proposed_coun_to_plot = [x[0] for x in sorted_country_tups]
 
     return proposed_coun_to_plot, clus_keys
@@ -1258,7 +1201,6 @@ def plot_country_data(
     selected_country=None,
 ):
     country_week = {clus: {} for clus in clusters}
-
 
     min_week = datetime.datetime(2020, 12, 31)
     max_week = datetime.datetime(2020, 1, 1)
@@ -1293,13 +1235,17 @@ def plot_country_data(
                 unsmoothed_cluster_count,
                 unsmoothed_total_count,
             ) = non_zero_counts(cluster_data, total_data, coun)
-            
-            if len(total_count)<2:
+
+            if len(total_count) < 2:
                 continue
 
             # trim away any last data points that only have 1 or 2 seqs
             week_as_date, cluster_count, total_count = trim_last_data_point(
-                week_as_date, cluster_count, total_count, frac=0.1, keep_count=10
+                week_as_date,
+                cluster_count,
+                total_count,
+                frac=0.1,
+                keep_count=10,
             )
 
             mindat = min(week_as_date)
@@ -1311,9 +1257,7 @@ def plot_country_data(
 
             week_as_dates[coun] = week_as_date
 
-            country_data[clusters[clus]["display_name"]] = list(
-                cluster_count
-            )
+            country_data[clusters[clus]["display_name"]] = list(cluster_count)
 
             country_week[clus][coun] = cluster_count / total_count
 
@@ -1327,22 +1271,14 @@ def plot_country_data(
 
             first_clus_count = cluster_count  # unindented
             i += 1
-        country_data["week"] = [
-            datetime.datetime.strftime(x, "%Y-%m-%d") for x in week_as_date
-        ]
-        country_data["total_sequences"] = [
-            int(x) for x in total_count
-        ]
-        if len(total_count)>=2:
+        country_data["week"] = [datetime.datetime.strftime(x, "%Y-%m-%d") for x in week_as_date]
+        country_data["total_sequences"] = [int(x) for x in total_count]
+        if len(total_count) >= 2:
             json_output["countries"][coun] = country_data
 
     json_output["plotting_dates"] = {}
-    json_output["plotting_dates"]["min_date"] = datetime.datetime.strftime(
-        min_week, "%Y-%m-%d"
-    )
-    json_output["plotting_dates"]["max_date"] = datetime.datetime.strftime(
-        max_week, "%Y-%m-%d"
-    )
+    json_output["plotting_dates"]["min_date"] = datetime.datetime.strftime(min_week, "%Y-%m-%d")
+    json_output["plotting_dates"]["max_date"] = datetime.datetime.strftime(max_week, "%Y-%m-%d")
 
     if print_files:
         with open(tables_path + f"{file_prefix}_data.json", "w") as fh:
@@ -1351,15 +1287,11 @@ def plot_country_data(
 
 if do_country:
     proposed_coun_to_plot, clus_keys = get_ordered_clusters_to_plot(clusters)
-    plot_country_data(
-        clusters, proposed_coun_to_plot, print_files, clus_keys, "EUClusters"
-    )
+    plot_country_data(clusters, proposed_coun_to_plot, print_files, clus_keys, "EUClusters")
 
 
 if do_divisions_country:
-    proposed_coun_to_plot, clus_keys = get_ordered_clusters_to_plot(
-        clusters, True, "USA"
-    )
+    proposed_coun_to_plot, clus_keys = get_ordered_clusters_to_plot(clusters, True, "USA")
     plot_country_data(
         clusters,
         proposed_coun_to_plot,
@@ -1370,9 +1302,7 @@ if do_divisions_country:
         "USA",
     )
 
-    proposed_coun_to_plot, clus_keys = get_ordered_clusters_to_plot(
-        clusters, True, "Switzerland"
-    )
+    proposed_coun_to_plot, clus_keys = get_ordered_clusters_to_plot(clusters, True, "Switzerland")
     plot_country_data(
         clusters,
         proposed_coun_to_plot,
@@ -1388,22 +1318,21 @@ if do_divisions_country:
 update_json = {"lastUpdated": str(datetime.datetime.now().isoformat())}
 
 if print_files and "all" in clus_answer:
-    with open(web_data_folder + f"update.json", "w") as fh:
+    with open(web_data_folder + "update.json", "w") as fh:
         json.dump(update_json, fh)
 
 if "all" in clus_answer:
     ccounts = []
     for clus in clusters:
-        if clusters[clus]['type'] == "variant":
+        if clusters[clus]["type"] == "variant":
             displayn = clusters[clus]["display_name"]
-            ccounts.append([displayn, len(clusters[clus]['cluster_meta'])])
+            ccounts.append([displayn, len(clusters[clus]["cluster_meta"])])
 
-    count_df = pd.DataFrame(ccounts, columns=['cluster', 'counts'])
+    count_df = pd.DataFrame(ccounts, columns=["cluster", "counts"])
     print("Showing cluster counts")
     print(count_df.sort_values(by="counts"))
 
-#repeat to be sure they are seen
+# repeat to be sure they are seen
 print("\nDate alerts:")
 print([f"{x}: {len(alert_first_date[x])}" for x in alert_first_date.keys()])
 print("To view, use 'print_date_alerts(clus)' or 'print_all_date_alerts()'")
-

--- a/scripts/approx_first_dates.py
+++ b/scripts/approx_first_dates.py
@@ -1,31 +1,31 @@
 cluster_first_dates = {
-    "EU1": {"first_date": "2020-04-01"}, #EU1
+    "EU1": {"first_date": "2020-04-01"},  # EU1
     "EU2": {"first_date": "2020-07-01"},
     "S439": {"first_date": "2020-04-02"},
     "S98": {"first_date": "2020-06-01"},
-    "Epsilon": {"first_date": "2020-07-20"}, #Epsilon
+    "Epsilon": {"first_date": "2020-07-20"},  # Epsilon
     "S80": {"first_date": "2020-07-01"},
     "S626": {"first_date": "2020-07-01"},
     "S1122": {"first_date": "2020-03-15"},
-    "Alpha": {"first_date": "2020-09-20"}, #Alpha
-    "Beta": {"first_date": "2020-08-10"}, #Beta
-    "Gamma": {"first_date": "2020-10-19"}, #Gamma
-    "Delta": {"first_date": "2020-10-22"}, #Delta
-    "21I.Delta": {"first_date": "2020-10-22"}, #21I Delta
-    "21J.Delta": {"first_date": "2020-10-22"}, #21J Delta
-    "21K.Omicron": {"first_date": "2021-10-20"}, #omicron
-    "Kappa": {"first_date": "2020-10-30"}, #Kappa
-    "Delta417": {"first_date": "2020-10-30"}, #Delta plus (same as delta)
-    "Eta": {"first_date": "2020-11-21"}, #Eta
-    "Iota": {"first_date": "2020-11-10"}, #Iota
-    "21GLambda": {"first_date": "2020-11-05"}, # Lambda
-    "21H": {"first_date": "2020-12-10"}, # B.1.621
-    "20BS732": {"first_date": "2020-10-01"}, #B.1.1.519
-    "20AS126": {"first_date": "2021-01-15"}, #B.1.620
+    "Alpha": {"first_date": "2020-09-20"},  # Alpha
+    "Beta": {"first_date": "2020-08-10"},  # Beta
+    "Gamma": {"first_date": "2020-10-19"},  # Gamma
+    "Delta": {"first_date": "2020-10-22"},  # Delta
+    "21I.Delta": {"first_date": "2020-10-22"},  # 21I Delta
+    "21J.Delta": {"first_date": "2020-10-22"},  # 21J Delta
+    "21K.Omicron": {"first_date": "2021-10-20"},  # omicron
+    "Kappa": {"first_date": "2020-10-30"},  # Kappa
+    "Delta417": {"first_date": "2020-10-30"},  # Delta plus (same as delta)
+    "Eta": {"first_date": "2020-11-21"},  # Eta
+    "Iota": {"first_date": "2020-11-10"},  # Iota
+    "21GLambda": {"first_date": "2020-11-05"},  # Lambda
+    "21H": {"first_date": "2020-12-10"},  # B.1.621
+    "20BS732": {"first_date": "2020-10-01"},  # B.1.1.519
+    "20AS126": {"first_date": "2021-01-15"},  # B.1.620
     "S677HRobin1": {"first_date": "2020-06-01"},
     "S677PPelican": {"first_date": "2020-08-01"},
 }
 
 first_date_exceptions = {
-    "21AS478": ["India/MP-NCDC-2509230/2020"], #Delta
+    "21AS478": ["India/MP-NCDC-2509230/2020"],  # Delta
 }

--- a/scripts/bad_sequences.py
+++ b/scripts/bad_sequences.py
@@ -62,67 +62,67 @@ bad_seqs = {
     "USA/CA-LACPHL-AF00662/2020": "2020-03-10",  # divergence of 20 with date March 2020 highly unlikely - prob year mixup
     "Netherlands/ZH-EMC-1944/2020": "2020-03-10",  # EU2 - too diverged for date
     "Italy/LAZ-TIGEM-6927/2021": "2017-11-21",  # impossible year of 2017
-    "USA/TN-UT2050/2020" : "2020-06-04", #pelican - too diverged
-    "USA/TN-UT2063/2020" : "2020-06-03", #pelican - too diverged
-    "USA/NMDOH-2021083688/2020" : "2020-03-02", #S:452R - too diverged
-    "Spain/VC-IBV-99028305/2020": "2020-03-15", #V1 - impossible given date
-    "Italy/MAR-UnivPM30_45476/2020":  "2002-10-04", #impossible date
-    "Italy/MAR-UnivPM31_45989/2020":  "2002-10-05", #impossible date
-    "Italy/MAR-UnivPM32_47190/2020":  "2002-10-05", #impossible date
+    "USA/TN-UT2050/2020": "2020-06-04",  # pelican - too diverged
+    "USA/TN-UT2063/2020": "2020-06-03",  # pelican - too diverged
+    "USA/NMDOH-2021083688/2020": "2020-03-02",  # S:452R - too diverged
+    "Spain/VC-IBV-99028305/2020": "2020-03-15",  # V1 - impossible given date
+    "Italy/MAR-UnivPM30_45476/2020": "2002-10-04",  # impossible date
+    "Italy/MAR-UnivPM31_45989/2020": "2002-10-05",  # impossible date
+    "Italy/MAR-UnivPM32_47190/2020": "2002-10-05",  # impossible date
     # All these are European sequences, borderline, but divergence does not suggest they are real
-    "England/NOTT-246E4E/2020":  "2020-06-02",
-    "England/NOTT-246EF3/2020":  "2020-06-03",
-    "England/NOTT-246FD2/2020":  "2020-06-03",
-    "Wales/PHWC-49C25A/2020":  "2020-07-07",
-    "Wales/PHWC-4BD059/2020":  "2020-06-17",
-    "England/NOTT-246E11/2020":  "2020-06-03",
-    "England/MILK-69DECC/2020":  "2020-07-02",
-    "Netherlands/ZH-EMC-1863/2020":  "2020-07-12",
-    "Germany/BAV-PL-virotum_DZBZW/2020":  "2020-06-19",
-    "England/NOTT-246E3F/2020":  "2020-06-02",
-    "England/NOTT-246F96/2020":  "2020-06-02",
-    "England/NOTT-246F4B/2020":  "2020-06-03",
-    "England/NOTT-246F3C/2020":  "2020-06-03",
-    "England/NOTT-246E20/2020":  "2020-06-03",
-    "Netherlands/ZH-EMC-1818/2020":  "2020-06-12",
-    "Netherlands/ZH-EMC-1819/2020":  "2020-06-12",
-    "France/IDF_HB_112007052326/2020":  "2020-07-15",
-    "USA/ND-NDDH-02591/2021": "2021-09-28", #from the future
-    "Mexico/AGU-InDRE_FB18599_S4467/2020": "2020-09-22", #delta
-    "USA/MI-MDHHS-SC30215/2020" : "2020-04-19", # alpha
-    "USA/MI-MDHHS-SC25865/2020" : "2020-04-15", # robin 1
-    "Colombia/ANT-CWOHC-VG-SEC01275A/2020" : "2020-09-21", # bad quality
-    "Ecuador/USFQ-1969/2021" : "2021-08-13", # divergence is 0-10 muts!
-    "Ecuador/USFQ-1977/2021" : "2021-08-13", # divergence is 0-10 muts!
-    "Ecuador/USFQ-1981/2021" : "2021-08-16", # divergence is 0-10 muts!
-    "Ecuador/USFQ-1983/2021" : "2021-08-17", # divergence is 0-10 muts!
-    "Ecuador/USFQ-1986/2021" : "2021-08-16", # divergence is 0-10 muts!
-    "Ecuador/USFQ-1987/2021" : "2021-08-16", # divergence is 0-10 muts!
-    "Ecuador/USFQ-1988/2021" : "2021-08-16", # divergence is 0-10 muts!
-    "Ecuador/USFQ-1989/2021" : "2021-08-16", # divergence is 0-10 muts!
-    "Ecuador/USFQ-1990/2021" : "2021-08-16", # divergence is 0-10 muts!
-    "Ecuador/USFQ-1996/2021" : "2021-08-16", # divergence is 0-10 muts!
-    "Ecuador/USFQ-1997/2021" : "2021-08-16", # divergence is 0-10 muts!
-    "Ecuador/USFQ-1999/2021" : "2021-08-18", # divergence is 0-10 muts!
-    "Ecuador/USFQ-2005/2021" : "2021-08-19", # divergence is 0-10 muts!
-    "Ecuador/USFQ-2007/2021" : "2021-08-19", # divergence is 0-10 muts!
-    "Ecuador/USFQ-2009/2021" : "2021-08-19", # divergence is 0-10 muts!
-    #alpha, all below
-    "USA/CA-SEARCH-101999/2020" : "2020-07-08",
-    "USA/CA-SEARCH-101987/2020" : "2020-07-08",
-    "USA/CA-SEARCH-102007/2020" : "2020-07-08",
-    "USA/MI-MDHHS-SC30215/2020" : "2020-04-19",
-    "USA/CA-SEARCH-101973/2020" : "2020-07-11",
-    "USA/CA-SEARCH-102015/2020" : "2020-07-09",
-    "USA/CA-SEARCH-101984/2020" : "2020-07-11",
-    "USA/CA-SEARCH-101991/2020" : "2020-07-08",
-    "Canada/QC-1nJWFTV-3641914/2020" : "2020-07-01",
-    "Canada/QC-1nJWFTV-3642019/2020" : "2020-07-24",
-    "Canada/QC-1nJWFTV-3643537/2020" : "2020-09-25",
-    "USA/TX-HMH-MCoV-35256/2020" : "2020-08-10",
-    "Slovenia/08-039382-MB/2020" : "2020-09-14",
-    "Spain/MD-HRYC-71299296/2020" : "2020-08-26",
-    "USA/AZ-TG808802/2020" : "2020-08-24",
+    "England/NOTT-246E4E/2020": "2020-06-02",
+    "England/NOTT-246EF3/2020": "2020-06-03",
+    "England/NOTT-246FD2/2020": "2020-06-03",
+    "Wales/PHWC-49C25A/2020": "2020-07-07",
+    "Wales/PHWC-4BD059/2020": "2020-06-17",
+    "England/NOTT-246E11/2020": "2020-06-03",
+    "England/MILK-69DECC/2020": "2020-07-02",
+    "Netherlands/ZH-EMC-1863/2020": "2020-07-12",
+    "Germany/BAV-PL-virotum_DZBZW/2020": "2020-06-19",
+    "England/NOTT-246E3F/2020": "2020-06-02",
+    "England/NOTT-246F96/2020": "2020-06-02",
+    "England/NOTT-246F4B/2020": "2020-06-03",
+    "England/NOTT-246F3C/2020": "2020-06-03",
+    "England/NOTT-246E20/2020": "2020-06-03",
+    "Netherlands/ZH-EMC-1818/2020": "2020-06-12",
+    "Netherlands/ZH-EMC-1819/2020": "2020-06-12",
+    "France/IDF_HB_112007052326/2020": "2020-07-15",
+    "USA/ND-NDDH-02591/2021": "2021-09-28",  # from the future
+    "Mexico/AGU-InDRE_FB18599_S4467/2020": "2020-09-22",  # delta
+    "USA/MI-MDHHS-SC30215/2020": "2020-04-19",  # alpha
+    "USA/MI-MDHHS-SC25865/2020": "2020-04-15",  # robin 1
+    "Colombia/ANT-CWOHC-VG-SEC01275A/2020": "2020-09-21",  # bad quality
+    "Ecuador/USFQ-1969/2021": "2021-08-13",  # divergence is 0-10 muts!
+    "Ecuador/USFQ-1977/2021": "2021-08-13",  # divergence is 0-10 muts!
+    "Ecuador/USFQ-1981/2021": "2021-08-16",  # divergence is 0-10 muts!
+    "Ecuador/USFQ-1983/2021": "2021-08-17",  # divergence is 0-10 muts!
+    "Ecuador/USFQ-1986/2021": "2021-08-16",  # divergence is 0-10 muts!
+    "Ecuador/USFQ-1987/2021": "2021-08-16",  # divergence is 0-10 muts!
+    "Ecuador/USFQ-1988/2021": "2021-08-16",  # divergence is 0-10 muts!
+    "Ecuador/USFQ-1989/2021": "2021-08-16",  # divergence is 0-10 muts!
+    "Ecuador/USFQ-1990/2021": "2021-08-16",  # divergence is 0-10 muts!
+    "Ecuador/USFQ-1996/2021": "2021-08-16",  # divergence is 0-10 muts!
+    "Ecuador/USFQ-1997/2021": "2021-08-16",  # divergence is 0-10 muts!
+    "Ecuador/USFQ-1999/2021": "2021-08-18",  # divergence is 0-10 muts!
+    "Ecuador/USFQ-2005/2021": "2021-08-19",  # divergence is 0-10 muts!
+    "Ecuador/USFQ-2007/2021": "2021-08-19",  # divergence is 0-10 muts!
+    "Ecuador/USFQ-2009/2021": "2021-08-19",  # divergence is 0-10 muts!
+    # alpha, all below
+    "USA/CA-SEARCH-101999/2020": "2020-07-08",
+    "USA/CA-SEARCH-101987/2020": "2020-07-08",
+    "USA/CA-SEARCH-102007/2020": "2020-07-08",
+    "USA/MI-MDHHS-SC30215/2020": "2020-04-19",
+    "USA/CA-SEARCH-101973/2020": "2020-07-11",
+    "USA/CA-SEARCH-102015/2020": "2020-07-09",
+    "USA/CA-SEARCH-101984/2020": "2020-07-11",
+    "USA/CA-SEARCH-101991/2020": "2020-07-08",
+    "Canada/QC-1nJWFTV-3641914/2020": "2020-07-01",
+    "Canada/QC-1nJWFTV-3642019/2020": "2020-07-24",
+    "Canada/QC-1nJWFTV-3643537/2020": "2020-09-25",
+    "USA/TX-HMH-MCoV-35256/2020": "2020-08-10",
+    "Slovenia/08-039382-MB/2020": "2020-09-14",
+    "Spain/MD-HRYC-71299296/2020": "2020-08-26",
+    "USA/AZ-TG808802/2020": "2020-08-24",
     # These sequences are from EU1 - early dated but the divergence doesn't match the dates...
     "England/NOTT-246E3F/2020": "2020-06-02",
     "England/NOTT-246E11/2020": "2020-06-03",
@@ -150,3894 +150,3886 @@ bad_seqs = {
     "Italy/CAM-CRGS-544/2020": "2020-03-14",
     "Spain/IB-HUSE-00001/2020": "2020-03-02",
     "Spain/VC-IBV-99028301/2020": "2020-03-17",
-    "Belgium/MBLGc7385/2020":   "2020-05-20",
+    "Belgium/MBLGc7385/2020": "2020-05-20",
     "England/NOTT-246D8D/2020": "2020-06-02",
     "France/IDF-HB_112010014593/2020": "2020-03-10",
-    "England/SHEF-10B2F49/2020" : "2020-05-21", 
-    "Belgium/LHUB11590048/2020" : "2020-03-31",
-    'bat/Yunnan/RaTG13/2013'    : "2013-07-24", #this is RatG13 - legit, but looks weird in table
-    'bat/Yunnan/RmYN02/2019'    : "2019-06-25", # bat sequence - legit but looks weird
-    "Morocco/INH-107/2020" : "2020-02-02", 
-    "Morocco/INH-108/2020" : "2020-02-02", 
-    "Morocco/INH-109/2020" : "2020-02-02", 
-    "bat/Yunnan/RmYN01/2019" : "2019-06-25", 
-
+    "England/SHEF-10B2F49/2020": "2020-05-21",
+    "Belgium/LHUB11590048/2020": "2020-03-31",
+    "bat/Yunnan/RaTG13/2013": "2013-07-24",  # this is RatG13 - legit, but looks weird in table
+    "bat/Yunnan/RmYN02/2019": "2019-06-25",  # bat sequence - legit but looks weird
+    "Morocco/INH-107/2020": "2020-02-02",
+    "Morocco/INH-108/2020": "2020-02-02",
+    "Morocco/INH-109/2020": "2020-02-02",
+    "bat/Yunnan/RmYN01/2019": "2019-06-25",
     # these are all before expected cluster start date:
-    "Canada/NS-NML-2284/2020" : "2020-05-14",
-    "Germany/BY-MVP-000003914/2020" : "2020-05-19",
-    "Germany/BY-MVP-000004014/2020" : "2020-05-19",
-    "Spain/CL-IBV-98029694/2020" : "2020-05-19",
-    "Spain/CL-IBV-98029695/2020" : "2020-05-19",
-    "Spain/CL-IBV-98029696/2020" : "2020-05-19",
-    "Spain/CL-IBV-98029697/2020" : "2020-05-19",
-    "Switzerland/SO-UHB-42850063/2021" : "2020-05-11",
-    "USA/KS-KHEL-1913/2020" : "2020-05-20",
-    "USA/TX-HMH-MCoV-40892/2020" : "2020-07-22",
-    "USA/TX-HMH-MCoV-40911/2020" : "2020-07-22",
-    "USA/TX-HMH-MCoV-40977/2020" : "2020-07-21",
-    "USA/TX-HMH-MCoV-41485/2020" : "2020-07-31",
-    "Kenya/ICGEB-KEMRI-7_S23_S7_S21_S25/2021" : "2020-09-09",
-    "Nigeria/S03/2020" : "2020-08-12",
-    "Japan/PG-50814/2020" : "2020-04-24",
-    "Japan/PG-50815/2020" : "2020-04-24",
-    "Japan/PG-50816/2020" : "2020-04-24",
-    "Japan/PG-50817/2020" : "2020-04-25",
-    "Japan/PG-50818/2020" : "2020-04-25",
-    "Japan/PG-50819/2020" : "2020-04-25",
-    "Japan/PG-50820/2020" : "2020-04-25",
-    "HongKong/HKPU-00083/2020" : "2020-02-25",
-    "HongKong/HKPU-00084/2020" : "2020-02-25",
-    "Italy/CAM-TIGEM-IZSM-COLLI-14397/2021" : "2020-03-16",
-    "Poland/NIPH-NIH_ECDC-4488/2021" : "2020-04-22",
-    "SouthKorea/KDCA4115/2020" : "2020-04-26",
-    "Spain/CL-COV00781/2020" : "2020-02-07",
-    "Spain/ML-ISCIII-214384/2020" : "2020-04-22",
-    "Sweden/01_SE100_21CS503247/2020" : "2020-03-12",
-    "Switzerland/SO-UHB-42850063/2021" : "2020-05-11",
-    "Switzerland/VD-CHUV-GEN2474/2020" : "2020-03-09",
-    "USA/CA-CZB-32337/2020" : "2020-04-12",
-    "USA/DC-DFS-PHL-0666/2021" : "2020-01-19",
-    "USA/IL-RIPHL_30044_G/2021" : "2020-04-17",
-    "USA/IN-ISDHQ396/2020" : "2020-04-23",
-    "USA/IN-ISDHQ401/2020" : "2020-04-23",
-    "USA/IN-ISDHQ403/2020" : "2020-04-23",
-    "USA/IN-ISDHQ404/2020" : "2020-04-23",
-    "USA/IN-ISDHQ405/2020" : "2020-04-23",
-    "USA/IN-ISDHQ407/2020" : "2020-04-23",
-    "USA/MI-MDHHS-SC28884/2021" : "2020-04-07",
-    "USA/MI-MDHHS-SC28909/2021" : "2020-04-12",
-    "USA/NY-COV-1352/2020" : "2020-03-19",
-    "USA/TX-HMH-MCoV-40892/2020" : "2020-07-22",
-    "USA/TX-HMH-MCoV-40911/2020" : "2020-07-22",
-    "USA/TX-HMH-MCoV-40977/2020" : "2020-07-21",
-    "USA/TX-HMH-MCoV-41485/2020" : "2020-07-31",
-    "USA/UT-UPHL-2104759182/2020" : "2020-04-10",
-    "Qatar/QA.QU_18.10.B12/2020" : "2020-03-27",
-    "Qatar/QA.QU_18.10.E12/2020" : "2020-04-05",
-    "USA/SC-DHEC-1826/2020" : "2020-05-07",
-    "Zimbabwe/CERI-KRISP-K011643/2020" : "2020-07-09",
-    "Zimbabwe/CERI-KRISP-K011662/2020" : "2020-05-27",
-    "Brazil/GO-2732R1/2021" : "2020-10-26",
-    "Brazil/PB-BA1200-250009713/2020" : "2020-10-01",
-    "Brazil/PR-L119-CD7789/2020" : "2020-10-26",
-    "Brazil/SP-L112-CD4087/2020" : "2020-09-11",
-    "USA/IL-RED-FUL-39828238/2020" : "2020-04-07",
-    "USA/IN-ISDHQ409/2020" : "2020-04-23",
-    "India/MP-NCDC-2509230/2020" : "2020-09-07",
-    "India/un-IRSHA-CD210871/2020" : "2020-03-03",
-    "India/un-IRSHA-CD210927/2020" : "2020-03-06",
-    "India/un-IRSHA-CD210929/2020" : "2020-03-06",
-    "USA/CA-LACPHL-AF00986/2020" : "2020-04-21",
-    "USA/IN-ISDHQ400/2020" : "2020-04-23",
-    "USA/CA-ACPHD-00310/2020" : "2020-04-11",
-    "USA/NV-NSPHL-357909/2020" : "2020-04-15",
-    "USA/OH-ODH-SC1040172/2020" : "2020-02-08",
-    "Belgium/UZA-UA-CV0615326772/2020" : "2020-02-06",
-    "France/IDF-HB_112010005538/2020" : "2020-01-10",
-    "France/IDF-HB_112010012225/2020" : "2020-03-10",
-    "France/IDF-HB_112010016707/2020" : "2020-05-10",
-    "France/NOR-04525421/2020" : "2020-03-11",
-    "Netherlands/NB-EMC-849/2020" : "2020-06-10",
-    "bat/Cambodia/RShSTT182/2010" : "2010-12-06",
-    "bat/Cambodia/RShSTT200/2010" : "2010-12-06",
-    "Belgium/UZA-UA-CV2006969709/2020" : "2020-02-14",
-    "Netherlands/NB-EMC-750/2020" : "2020-02-09",
-    "Netherlands/NB-EMC-811/2020" : "2020-02-12",
-    "Netherlands/NB-EMC-812/2020" : "2020-04-12",
-    "Netherlands/NB-EMC-837/2020" : "2020-04-11",
-    "Netherlands/ZH-EMC-1922/2020" : "2020-03-10",
-    "Netherlands/ZH-EMC-1934/2020" : "2020-03-10",
-    "Netherlands/ZH-EMC-2849/2020" : "2020-04-12",
-    "Poland/KCZ_1.73/2020" : "2020-01-14",
-    "Sweden/01_SE100_21CS101869/2020" : "2020-05-12",
-    "Canada/QC-1nKGZ-Q8090981/2020" : "2020-04-09",
-    "USA/MD-HP07440-PIDRGJGOUB/2020" : "2020-07-15",
-    "USA/MD-HP07441-PIDNJPIZZN/2020" : "2020-07-22",
-    "Mexico/YUC-NYGC-39037-20/2020" : "2020-08-28", # 20B/S.732
-    "Belgium/MR81DY0537/2020" : "2020-05-01", #S98
-    "Senegal/SC20-504/2020" : "2020-08-28", #Alpha, V1
-    "Senegal/SC20-507/2020" : "2020-08-02", #Alpha, V1
-    "Canada/QC-1nMCY-S1190638/2020" : "2020-05-19", #Alpha V1
-    "Canada/QC-1nMCY-S1190677/2020" : "2020-05-19", #Alpha V1
-    "India/DL-ILBS-17395/2020" : "2020-06-04", #delta
-    "USA/CA-ALSR-105475/2020" : "2020-07-11", #alpha
-    "USA/CT-CDC-2-4331901/2020" : "2020-04-14", #alpha
-    "Brazil/PA-ITV-65/2020" : "2020-05-06", #gamma
-    "Brazil/PA-ITV-69/2020" : "2020-05-06", #gamma
-    "USA/NY-GEO-0231/2020" : "2020-01-28", # 20c/484K
-    "USA/MA-UMASSMED-P006D11/2020" : "2020-04-30", #epsilon S452
-    "Canada/QC-1nMCY-S1110667/2020" : "2020-05-11", #alpha
-    "Indonesia/JK-FKUI-MKIM21/2020" : "2020-08-25", #delta
-    "Indonesia/JK-FKUI-MKIM24/2020" : "2020-10-15", #delta
-    "Indonesia/JK-FKUI-MKIM26/2020" : "2020-10-12", #delta
-    "Indonesia/JK-FKUI-MKIM27/2020" : "2020-10-12", #delta
-    "Indonesia/JK-FKUI-MKIM33/2020" : "2020-09-28", #delta
-    "Indonesia/JK-FKUI-MKIM35/2020" : "2020-10-07", #delta
-    "USA/AZ-TG968438/2020" : "2020-10-22", #delta
-    "USA/AZ-TG968448/2020" : "2020-10-23", #delta
-    "USA/AZ-TG968459/2020" : "2020-10-02", #delta
-    "USA/AZ-TG968474/2020" : "2020-10-29", #delta
-    "USA/AZ-TG968478/2020" : "2020-10-29", #delta
-    "USA/AZ-TG968492/2020" : "2020-10-03", #delta
-    "USA/AZ-TG968499/2020" : "2020-09-17", #delta
-    "USA/AZ-TG968502/2020" : "2020-09-21", #delta
-    "USA/AZ-TG968441/2020" : "2020-10-22", #iota
-    "USA/CA-CDPH1224/2020" : "2020-03-11", #epsilon
-    "Canada/QC-L00333784001/2020" : "2020-03-12", # 477
-    "India/GJ-INSACOG-GBRC1538/2020" : "2020-03-19", #kappa
-    "India/GJ-INSACOG-GBRC1539/2020" : "2020-03-17", #kappa
-    "Brazil/PE-FIOCRUZ-IAM3285/2020" : "2020-09-22", # gamma - too divergent - not near base
-    "France/PAC-IHU-3957-Nano1/2020" : "2020-09-03", #alpha
-    "France/PAC-IHU-3957_Nano1/2020" : "2020-09-03", #alpha
-    "France/PAC-IHU-5143-N1/2021" : "2020-05-24", #alpha
-    "France/PAC-IHU-5148-N1/2021" : "2020-08-26", #alpha
-    "Germany/SN-RKI-I-213505/2020" : "2020-08-21", #delta
-    "England/PHEC-U303UC24/2021"  : "2020-03-20", #alpha
-    "England/PHEC-U303UC33/2021"  : "2020-03-20", #alpha
-    "Italy/VEN-IZSVe-21RS8085-7_TV/2020" : "2020-08-13", #delta
-    "USA/DC-DFS-PHL-01331/2020" : "2020-08-10", #delta
-    "India/GJ-INSACOG-GBRC2186/2020" : "2020-03-19", #delta
-    "India/GJ-INSACOG-GBRC2187/2020" : "2020-03-17", #delta
-    "Italy/CAM-TIGEM-IZSM-COLLI-14397/2020" : "2020-03-16", #alpha
-    "Kenya/ICGEB-KEMRI-7_S23_S7_S21_S25/2020" : "2020-09-09", #alpha
-    "Poland/NIPH-NIH_ECDC-4488/2020" : "2020-04-22", #alpha
-    "Switzerland/SO-UHB-42850063/2020" : "2020-05-11", #alpha
-    "USA/IL-RIPHL_30044_G/2020" : "2020-04-17", #alpha
-    "USA/MI-MDHHS-SC28884/2020" : "2020-04-07", #alpha
-    "USA/MI-MDHHS-SC28909/2020" : "2020-04-12", #alpha
-    "BurkinaFaso/CV1920/2020" : "2020-09-16", #delta
-    "BurkinaFaso/CV1921/2020" : "2020-09-18", #delta
-    "BurkinaFaso/CV1728/2020" : "2020-03-28", # 20A.484
-    "USA/MS-USAFSAM-S3006/2020" : "2020-10-05", #21H
-    "Argentina/PAIS-A0964/2020" : "2020-07-22", #gamma
-    "Argentina/PAIS-A0965/2020" : "2020-08-01", #gamma
-    "Spain/UN-ORC01380/2020" : "2020-03-26", #alpha
-    "USA/CA-ALSR-101973/2020" : "2020-07-11", #alpha
-    "USA/CA-ALSR-101984/2020" : "2020-07-11", #alpha
-    "USA/CA-ALSR-101987/2020" : "2020-07-08", #alpha
-    "USA/CA-ALSR-101991/2020" : "2020-07-08", #alpha
-    "USA/CA-ALSR-101999/2020" : "2020-07-08", #alpha
-    "USA/CA-ALSR-102007/2020" : "2020-07-08", #alpha
-    "USA/CA-ALSR-102015/2020" : "2020-07-09", #alpha
-    "USA/MN-MDH-13426/2020" : "2020-08-07", #delta
-    "USA/WI-WSLH-219155/2020" : "2020-08-12", #delta
-    "USA/WY-WYPHL-21070660/2020" : "2020-09-02", #delta
-    "USA/VI-Yale-10210/2020" : "2020-08-21", #delta
-    "USA/VI-Yale-10211/2020" : "2020-08-21", #delta
-    "USA/TX-HMH-MCoV-40926/2020" : "2020-07-22", #alpha
-    "USA/TX-HMH-MCoV-40929/2020" : "2020-07-22", #alpha
-    "Vanuatu/VAN003/2020" : "2020-04-17", #alpha
-    "Rwanda/CV2217/2020" : "2020-06-04", #beta
-    "England/MILK-1FF99A3/2020" : "2020-04-16", #delta
-    "England/MILK-1FF99C1/2020" : "2020-04-16", #delta
-    "England/MILK-1FF9A19/2020" : "2020-04-16", #delta
-    "England/MILK-1FF9A37/2020" : "2020-04-16", #delta
-    "England/MILK-1FF9A46/2020" : "2020-04-16", #delta
-    "England/MILK-1FF9A64/2020" : "2020-04-16", #delta
-    "England/MILK-1FF9A82/2020" : "2020-04-16", #delta
-    "England/MILK-1FF9ABF/2020" : "2020-04-16", #delta
-    "England/MILK-1FF9ADD/2020" : "2020-04-16", #delta
-    "England/MILK-1FF9B43/2020" : "2020-04-19", #delta
-    "England/MILK-1FF9B8F/2020" : "2020-04-16", #delta
-    "England/MILK-1FF9BE9/2020" : "2020-04-16", #delta
-    "England/MILK-1FF9D6B/2020" : "2020-04-16", #delta
-    "England/MILK-1FF9DA7/2020" : "2020-04-16", #delta
-    "England/MILK-1FF9DC5/2020" : "2020-04-18", #delta
-    "England/MILK-1FF9DD4/2020" : "2020-04-16", #delta
-    "England/MILK-1FF9DF2/2020" : "2020-04-16", #delta
-    "England/MILK-1FF9FB0/2020" : "2020-04-16", #delta
-    "England/MILK-1FF9FDE/2020" : "2020-04-16", #delta
-    "England/MILK-1FF9FFC/2020" : "2020-04-16", #delta
-    "England/MILK-1FFA034/2020" : "2020-04-16", #delta
-    "England/MILK-1FFA061/2020" : "2020-04-16", #delta
-    "England/MILK-1FFA0BC/2020" : "2020-04-16", #delta
-    "England/MILK-1FFA131/2020" : "2020-04-16", #delta
-    "England/MILK-1FFA17D/2020" : "2020-04-16", #delta
-    "England/MILK-1FFA19B/2020" : "2020-04-16", #delta
-    "England/MILK-1FFA1B9/2020" : "2020-04-16", #delta
-    "England/MILK-1FFA1D7/2020" : "2020-04-16", #delta
-    "England/MILK-1FFA25C/2020" : "2020-04-16", #delta
-    "England/MILK-1FFA2A7/2020" : "2020-04-16", #delta
-    "England/MILK-1FFA30E/2020" : "2020-04-16", #delta
-    "England/MILK-1FFA359/2020" : "2020-04-16", #delta
-    "England/MILK-1FFA438/2020" : "2020-04-16", #delta
-    "England/MILK-1FFA492/2020" : "2020-04-16", #delta
-    "England/MILK-1FFA4B0/2020" : "2020-04-16", #delta
-    "England/MILK-1FFA4ED/2020" : "2020-04-16", #delta
-    "England/MILK-1FFA4FC/2020" : "2020-04-16", #delta
-    "England/MILK-1FFA508/2020" : "2020-04-16", #delta
-    "England/MILK-1FFA526/2020" : "2020-04-16", #delta
-    "Fiji/FJ493/2020" : "2020-08-25", #delta
-    "Rwanda/CV2197/2020" : "2020-09-10", #delta
-    "USA/ND-NDDH-4397/2020" : "2020-09-09", #delta
-    "USA/WV-WVU-WV121217/2020" : "2020-07-21", #delta
-    "Sudan/N6667/2020" : "2020-10-04", #eta
-    "Colombia/DC-Mx263_sarscov2/2020" : "2020-09-19", #21H
-    "Colombia/DC-Mx318_sarscov2/2020" : "2020-10-06", #21H
-    "Morocco/INH-101/2020" : "2020-02-02", #S98
-    "Morocco/INH-105/2020" : "2020-02-02", #S98
-    "USA/IN-ISDHQ397/2020" : "2020-04-23", #alpha
-    "USA/TX-HMH-MCoV-44272/2020" : "2020-07-31", #alpha
-    "USA/TX-HMH-MCoV-45474/2020" : "2020-07-31", #alpha
-    "USA/TX-HMH-MCoV-45482/2020" : "2020-07-31", #alpha
-    "USA/TX-HMH-MCoV-45578/2020" : "2020-07-31", #alpha
-    "USA/TX-HMH-MCoV-45753/2020" : "2020-07-31", #alpha
-    "USA/TX-HMH-MCoV-47089/2020" : "2020-07-31", #alpha
-    "USA/TX-HMH-MCoV-47116/2020" : "2020-07-31", #alpha
-    "USA/TX-HMH-MCoV-47370/2020" : "2020-07-30", #alpha
-    "USA/TX-HMH-MCoV-39835/2020" : "2020-08-06", #alpha
-    "USA/TX-HMH-MCoV-44274/2020" : "2020-07-31", #alpha
-    "USA/TX-HMH-MCoV-45478/2020" : "2020-07-31", #alpha
-    "USA/TX-HMH-MCoV-45481/2020" : "2020-07-31", #alpha
-    "USA/TX-HMH-MCoV-45754/2020" : "2020-07-31", #alpha
-    "USA/TX-HMH-MCoV-45758/2020" : "2020-07-31", #alpha
-    "USA/TX-HMH-MCoV-45768/2020" : "2020-07-31", #alpha
-    "USA/TX-HMH-MCoV-47118/2020" : "2020-07-31", #alpha
-    "USA/NY-MSHSPSP-PV21126/2020" : "2020-10-11", # 20C/S484
-    "USA/NY-MSHSPSP-PV21129/2020" : "2020-10-10", # 20C/S484
-    "USA/NY-MSHSPSP-PV21166/2020" : "2020-10-09", # 20C/S484
-    "USA/NY-MSHSPSP-PV21203/2020" : "2020-10-13", # 20C/S484
-    "Pakistan/UOL-IMBB-KKU-25/2021" : "2021-10-22", #future date
-    "Pakistan/UOL-IMBB-KKU-26/2021" : "2021-10-23", #future date
-    "England/PHEP-YYBYUTJ/2020" : "2020-08-03", #delta
-    "Indonesia/JA-GS-EIJK-RSRM-0168/2020" : "2020-07-29", #delta
-    "Indonesia/JA-GS-EIJK-RSRM-0169/2020" : "2020-07-29", #delta
-    "Indonesia/JA-GS-EIJK-RSRM-0170/2020" : "2020-07-29", #delta
-    "Indonesia/JA-GS-EIJK-RSRM-0172/2020" : "2020-07-29", #delta
-    "Indonesia/JA-GS-EIJK-RSRM-0200/2020" : "2020-07-29", #delta
-    "USA/CA-SEARCH-109796/2020" : "2020-08-31", #delta
-    "USA/TX-HMH-MCoV-48794/2020" : "2020-07-15", #delta
-    "USA/TX-HMH-MCoV-49501/2020" : "2020-07-13", #delta
-    "Italy/VEN-UA-ORC00183/2020" : "2020-03-14", #alpha
-    "Brazil/SP-IB_112782/2020" : "2020-08-07", #gamma
-    "Japan/PG-149116/2020" : "2020-08-30", #Delta
-    "Germany/NW-RKI-I-291769/2020" : "2020-10-13", #delta
-    "Germany/NW-RKI-I-291770/2020" : "2020-10-13", #delta
-    "Germany/NW-RKI-I-291771/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291772/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291773/2020" : "2020-10-17", #delta
-    "Germany/NW-RKI-I-291774/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291775/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291776/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291777/2020" : "2020-10-17", #delta
-    "Germany/NW-RKI-I-291778/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291779/2020" : "2020-10-17", #delta
-    "Germany/NW-RKI-I-291780/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291781/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291782/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291783/2020" : "2020-10-13", #delta
-    "Germany/NW-RKI-I-291784/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291786/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291788/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291789/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291790/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291791/2020" : "2020-10-16", #delta
-    "Germany/NW-RKI-I-291792/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291793/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291794/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291795/2020" : "2020-10-17", #delta
-    "Germany/NW-RKI-I-291796/2020" : "2020-10-13", #delta
-    "Germany/NW-RKI-I-291797/2020" : "2020-10-16", #delta
-    "Germany/NW-RKI-I-291798/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291799/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291800/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291801/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291802/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291803/2020" : "2020-10-17", #delta
-    "Germany/NW-RKI-I-291804/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291805/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291806/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291808/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291809/2020" : "2020-10-16", #delta
-    "Germany/NW-RKI-I-291810/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291811/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291812/2020" : "2020-10-16", #delta
-    "Germany/SL-RKI-I-297962/2020" : "2020-10-17", #delta
-    "USA/NY-COV-900/2020" : "2020-06-06", #Alpha
-    "Peru/LIM-INS-8425/2020" : "2020-07-21", # lambda
-    "Netherlands/ZH-EMC-3837/2020" : "2020-05-10", #S98
-    "Netherlands/ZH-EMC-3838/2020" : "2020-03-12", #S98
-    "Netherlands/ZH-EMC-3839/2020" : "2020-04-12", #S98
-    "England/NORT-YYNW7P/2020" : "2020-10-27", #delta
-    "USA/TX-HMH-MCoV-34911/2020" : "2020-08-13", #Alpha
-    "Colombia/ANT-LDSP461/2020" : "2020-10-14", #Mu
-    "India/DL-ILBS-22053/2020" : "2020-06-13", #21A Delta
-    "Italy/LOM-TIGEM-IZSM-COLLI-14397/2020" : "2020-03-16", #alpha
-    "Italy/SIC_ISS_7543/2020" : "2020-03-02", #alpha
-    "Romania/SV_SJU_17854/2020" : "2020-08-16", #alpha
-    "Romania/SV_SJU_18749/2020" : "2020-08-26", #alpha
-    "Romania/SV_SJU_19042/2020" : "2020-08-28", #alpha
-    "USA/TX-HMH-MCoV-40893/2020" : "2020-07-22", #alpha
-    "USA/TX-HMH-MCoV-45566/2020" : "2020-07-31", #alpha
-    "USA/TX-HMH-MCoV-45752/2020" : "2020-07-31", #alpha
-    "USA/TX-HMH-MCoV-45766/2020" : "2020-07-31", #alpha
-    "SouthAfrica/NICD-N19828/2020" : "2020-06-26", #beta
-    "SouthAfrica/NICD-N19829/2020" : "2020-06-26", #beta
-    "Brazil/MS-HRMS_1490/2020" : "2020-08-24", #gamma
-    "India/TG-CCMB-CIB1089/2020" : "2020-10-04", #delta
-    "India/TG-CCMB-CIB1094/2020" : "2020-10-20", #delta
-    "India/TG-CCMB-CIB1117/2020" : "2020-08-26", #delta
-    "India/TG-CCMB-CIB1118/2020" : "2020-08-26", #delta
-    "India/TG-CCMB-CIB1124/2020" : "2020-08-29", #delta
-    "India/TG-CCMB-CIB1125/2020" : "2020-08-29", #delta
-    "India/TG-CCMB-CIB1133/2020" : "2020-09-12", #delta
-    "India/TG-CCMB-CIB1134/2020" : "2020-09-22", #delta
-    "India/TG-RFCH00157_CIB1134/2020" : "2020-09-22", #delta
-    "SouthAfrica/NICD-N19863/2020" : "2020-06-26", #delta
-    "India/TG-CCMB-CIB1077/2020" : "2020-10-02", #delta
-    "PapuaNewGuinea/PNG4040/2020" : "2020-08-01", #delta
-    "SouthAfrica/NICD-N19840/2020" : "2020-07-07", #delta
-    "USA/CA-CDPH-MC2409222/2020" : "2020-10-10", #delta
-    "USA/NY-WMC2021-152/2020" : "2020-03-12", #delta
-    "USA/CA-CZB-13785/2020" : "2020-09-22", #iota
-    "USA/NY-MSHSPSP-PV22505/2020" : "2020-11-03", #iota
-    "England/PHEP-YYBYUTJ/2020" : "2020-08-03", #delta
-    "USA/TX-HMH-MCoV-49453/2020": "2020-07-12", #delta
-    "USA/TX-HMH-MCoV-49803/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49806/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49808/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49809/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49814/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49815/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49816/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49817/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49827/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49831/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49836/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49838/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49840/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49851/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49852/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49854/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49855/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49859/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49862/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49866/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49873/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49874/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49876/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49878/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49880/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49881/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49883/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49888/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49889/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49892/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49894/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49896/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49898/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49899/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49901/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49905/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49911/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49913/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49915/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49917/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49919/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49920/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49922/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49923/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49924/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49925/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49928/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49930/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49933/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49935/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49937/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49938/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49939/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49946/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49948/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49951/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49953/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49958/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49959/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49963/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49966/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49969/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49973/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49975/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49976/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49978/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49982/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49984/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49985/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49988/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49989/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49994/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50010/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50013/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50024/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50028/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50034/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50045/2020" : "2020-07-15", #delta
-    "USA/TX-HMH-MCoV-50046/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50067/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50486/2020" : "2020-07-17", #delta
-    "USA/TX-HMH-MCoV-50501/2020" : "2020-07-17", #delta
-    "USA/TX-HMH-MCoV-50545/2020" : "2020-07-17", #delta
-    "USA/TX-HMH-MCoV-50566/2020" : "2020-07-17", #delta
-    "USA/TX-HMH-MCoV-50048/2020" : "2020-07-20", #delta
-    "USA/TX-HMH-MCoV-50050/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50068/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50082/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50084/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50493/2020" : "2020-07-17", #delta
-    "USA/TX-HMH-MCoV-50519/2020" : "2020-07-17", #delta
-    "USA/TX-HMH-MCoV-49841/2020" : "2020-07-16", #delta
-
+    "Canada/NS-NML-2284/2020": "2020-05-14",
+    "Germany/BY-MVP-000003914/2020": "2020-05-19",
+    "Germany/BY-MVP-000004014/2020": "2020-05-19",
+    "Spain/CL-IBV-98029694/2020": "2020-05-19",
+    "Spain/CL-IBV-98029695/2020": "2020-05-19",
+    "Spain/CL-IBV-98029696/2020": "2020-05-19",
+    "Spain/CL-IBV-98029697/2020": "2020-05-19",
+    "Switzerland/SO-UHB-42850063/2021": "2020-05-11",
+    "USA/KS-KHEL-1913/2020": "2020-05-20",
+    "USA/TX-HMH-MCoV-40892/2020": "2020-07-22",
+    "USA/TX-HMH-MCoV-40911/2020": "2020-07-22",
+    "USA/TX-HMH-MCoV-40977/2020": "2020-07-21",
+    "USA/TX-HMH-MCoV-41485/2020": "2020-07-31",
+    "Kenya/ICGEB-KEMRI-7_S23_S7_S21_S25/2021": "2020-09-09",
+    "Nigeria/S03/2020": "2020-08-12",
+    "Japan/PG-50814/2020": "2020-04-24",
+    "Japan/PG-50815/2020": "2020-04-24",
+    "Japan/PG-50816/2020": "2020-04-24",
+    "Japan/PG-50817/2020": "2020-04-25",
+    "Japan/PG-50818/2020": "2020-04-25",
+    "Japan/PG-50819/2020": "2020-04-25",
+    "Japan/PG-50820/2020": "2020-04-25",
+    "HongKong/HKPU-00083/2020": "2020-02-25",
+    "HongKong/HKPU-00084/2020": "2020-02-25",
+    "Italy/CAM-TIGEM-IZSM-COLLI-14397/2021": "2020-03-16",
+    "Poland/NIPH-NIH_ECDC-4488/2021": "2020-04-22",
+    "SouthKorea/KDCA4115/2020": "2020-04-26",
+    "Spain/CL-COV00781/2020": "2020-02-07",
+    "Spain/ML-ISCIII-214384/2020": "2020-04-22",
+    "Sweden/01_SE100_21CS503247/2020": "2020-03-12",
+    "Switzerland/SO-UHB-42850063/2021": "2020-05-11",
+    "Switzerland/VD-CHUV-GEN2474/2020": "2020-03-09",
+    "USA/CA-CZB-32337/2020": "2020-04-12",
+    "USA/DC-DFS-PHL-0666/2021": "2020-01-19",
+    "USA/IL-RIPHL_30044_G/2021": "2020-04-17",
+    "USA/IN-ISDHQ396/2020": "2020-04-23",
+    "USA/IN-ISDHQ401/2020": "2020-04-23",
+    "USA/IN-ISDHQ403/2020": "2020-04-23",
+    "USA/IN-ISDHQ404/2020": "2020-04-23",
+    "USA/IN-ISDHQ405/2020": "2020-04-23",
+    "USA/IN-ISDHQ407/2020": "2020-04-23",
+    "USA/MI-MDHHS-SC28884/2021": "2020-04-07",
+    "USA/MI-MDHHS-SC28909/2021": "2020-04-12",
+    "USA/NY-COV-1352/2020": "2020-03-19",
+    "USA/TX-HMH-MCoV-40892/2020": "2020-07-22",
+    "USA/TX-HMH-MCoV-40911/2020": "2020-07-22",
+    "USA/TX-HMH-MCoV-40977/2020": "2020-07-21",
+    "USA/TX-HMH-MCoV-41485/2020": "2020-07-31",
+    "USA/UT-UPHL-2104759182/2020": "2020-04-10",
+    "Qatar/QA.QU_18.10.B12/2020": "2020-03-27",
+    "Qatar/QA.QU_18.10.E12/2020": "2020-04-05",
+    "USA/SC-DHEC-1826/2020": "2020-05-07",
+    "Zimbabwe/CERI-KRISP-K011643/2020": "2020-07-09",
+    "Zimbabwe/CERI-KRISP-K011662/2020": "2020-05-27",
+    "Brazil/GO-2732R1/2021": "2020-10-26",
+    "Brazil/PB-BA1200-250009713/2020": "2020-10-01",
+    "Brazil/PR-L119-CD7789/2020": "2020-10-26",
+    "Brazil/SP-L112-CD4087/2020": "2020-09-11",
+    "USA/IL-RED-FUL-39828238/2020": "2020-04-07",
+    "USA/IN-ISDHQ409/2020": "2020-04-23",
+    "India/MP-NCDC-2509230/2020": "2020-09-07",
+    "India/un-IRSHA-CD210871/2020": "2020-03-03",
+    "India/un-IRSHA-CD210927/2020": "2020-03-06",
+    "India/un-IRSHA-CD210929/2020": "2020-03-06",
+    "USA/CA-LACPHL-AF00986/2020": "2020-04-21",
+    "USA/IN-ISDHQ400/2020": "2020-04-23",
+    "USA/CA-ACPHD-00310/2020": "2020-04-11",
+    "USA/NV-NSPHL-357909/2020": "2020-04-15",
+    "USA/OH-ODH-SC1040172/2020": "2020-02-08",
+    "Belgium/UZA-UA-CV0615326772/2020": "2020-02-06",
+    "France/IDF-HB_112010005538/2020": "2020-01-10",
+    "France/IDF-HB_112010012225/2020": "2020-03-10",
+    "France/IDF-HB_112010016707/2020": "2020-05-10",
+    "France/NOR-04525421/2020": "2020-03-11",
+    "Netherlands/NB-EMC-849/2020": "2020-06-10",
+    "bat/Cambodia/RShSTT182/2010": "2010-12-06",
+    "bat/Cambodia/RShSTT200/2010": "2010-12-06",
+    "Belgium/UZA-UA-CV2006969709/2020": "2020-02-14",
+    "Netherlands/NB-EMC-750/2020": "2020-02-09",
+    "Netherlands/NB-EMC-811/2020": "2020-02-12",
+    "Netherlands/NB-EMC-812/2020": "2020-04-12",
+    "Netherlands/NB-EMC-837/2020": "2020-04-11",
+    "Netherlands/ZH-EMC-1922/2020": "2020-03-10",
+    "Netherlands/ZH-EMC-1934/2020": "2020-03-10",
+    "Netherlands/ZH-EMC-2849/2020": "2020-04-12",
+    "Poland/KCZ_1.73/2020": "2020-01-14",
+    "Sweden/01_SE100_21CS101869/2020": "2020-05-12",
+    "Canada/QC-1nKGZ-Q8090981/2020": "2020-04-09",
+    "USA/MD-HP07440-PIDRGJGOUB/2020": "2020-07-15",
+    "USA/MD-HP07441-PIDNJPIZZN/2020": "2020-07-22",
+    "Mexico/YUC-NYGC-39037-20/2020": "2020-08-28",  # 20B/S.732
+    "Belgium/MR81DY0537/2020": "2020-05-01",  # S98
+    "Senegal/SC20-504/2020": "2020-08-28",  # Alpha, V1
+    "Senegal/SC20-507/2020": "2020-08-02",  # Alpha, V1
+    "Canada/QC-1nMCY-S1190638/2020": "2020-05-19",  # Alpha V1
+    "Canada/QC-1nMCY-S1190677/2020": "2020-05-19",  # Alpha V1
+    "India/DL-ILBS-17395/2020": "2020-06-04",  # delta
+    "USA/CA-ALSR-105475/2020": "2020-07-11",  # alpha
+    "USA/CT-CDC-2-4331901/2020": "2020-04-14",  # alpha
+    "Brazil/PA-ITV-65/2020": "2020-05-06",  # gamma
+    "Brazil/PA-ITV-69/2020": "2020-05-06",  # gamma
+    "USA/NY-GEO-0231/2020": "2020-01-28",  # 20c/484K
+    "USA/MA-UMASSMED-P006D11/2020": "2020-04-30",  # epsilon S452
+    "Canada/QC-1nMCY-S1110667/2020": "2020-05-11",  # alpha
+    "Indonesia/JK-FKUI-MKIM21/2020": "2020-08-25",  # delta
+    "Indonesia/JK-FKUI-MKIM24/2020": "2020-10-15",  # delta
+    "Indonesia/JK-FKUI-MKIM26/2020": "2020-10-12",  # delta
+    "Indonesia/JK-FKUI-MKIM27/2020": "2020-10-12",  # delta
+    "Indonesia/JK-FKUI-MKIM33/2020": "2020-09-28",  # delta
+    "Indonesia/JK-FKUI-MKIM35/2020": "2020-10-07",  # delta
+    "USA/AZ-TG968438/2020": "2020-10-22",  # delta
+    "USA/AZ-TG968448/2020": "2020-10-23",  # delta
+    "USA/AZ-TG968459/2020": "2020-10-02",  # delta
+    "USA/AZ-TG968474/2020": "2020-10-29",  # delta
+    "USA/AZ-TG968478/2020": "2020-10-29",  # delta
+    "USA/AZ-TG968492/2020": "2020-10-03",  # delta
+    "USA/AZ-TG968499/2020": "2020-09-17",  # delta
+    "USA/AZ-TG968502/2020": "2020-09-21",  # delta
+    "USA/AZ-TG968441/2020": "2020-10-22",  # iota
+    "USA/CA-CDPH1224/2020": "2020-03-11",  # epsilon
+    "Canada/QC-L00333784001/2020": "2020-03-12",  # 477
+    "India/GJ-INSACOG-GBRC1538/2020": "2020-03-19",  # kappa
+    "India/GJ-INSACOG-GBRC1539/2020": "2020-03-17",  # kappa
+    "Brazil/PE-FIOCRUZ-IAM3285/2020": "2020-09-22",  # gamma - too divergent - not near base
+    "France/PAC-IHU-3957-Nano1/2020": "2020-09-03",  # alpha
+    "France/PAC-IHU-3957_Nano1/2020": "2020-09-03",  # alpha
+    "France/PAC-IHU-5143-N1/2021": "2020-05-24",  # alpha
+    "France/PAC-IHU-5148-N1/2021": "2020-08-26",  # alpha
+    "Germany/SN-RKI-I-213505/2020": "2020-08-21",  # delta
+    "England/PHEC-U303UC24/2021": "2020-03-20",  # alpha
+    "England/PHEC-U303UC33/2021": "2020-03-20",  # alpha
+    "Italy/VEN-IZSVe-21RS8085-7_TV/2020": "2020-08-13",  # delta
+    "USA/DC-DFS-PHL-01331/2020": "2020-08-10",  # delta
+    "India/GJ-INSACOG-GBRC2186/2020": "2020-03-19",  # delta
+    "India/GJ-INSACOG-GBRC2187/2020": "2020-03-17",  # delta
+    "Italy/CAM-TIGEM-IZSM-COLLI-14397/2020": "2020-03-16",  # alpha
+    "Kenya/ICGEB-KEMRI-7_S23_S7_S21_S25/2020": "2020-09-09",  # alpha
+    "Poland/NIPH-NIH_ECDC-4488/2020": "2020-04-22",  # alpha
+    "Switzerland/SO-UHB-42850063/2020": "2020-05-11",  # alpha
+    "USA/IL-RIPHL_30044_G/2020": "2020-04-17",  # alpha
+    "USA/MI-MDHHS-SC28884/2020": "2020-04-07",  # alpha
+    "USA/MI-MDHHS-SC28909/2020": "2020-04-12",  # alpha
+    "BurkinaFaso/CV1920/2020": "2020-09-16",  # delta
+    "BurkinaFaso/CV1921/2020": "2020-09-18",  # delta
+    "BurkinaFaso/CV1728/2020": "2020-03-28",  # 20A.484
+    "USA/MS-USAFSAM-S3006/2020": "2020-10-05",  # 21H
+    "Argentina/PAIS-A0964/2020": "2020-07-22",  # gamma
+    "Argentina/PAIS-A0965/2020": "2020-08-01",  # gamma
+    "Spain/UN-ORC01380/2020": "2020-03-26",  # alpha
+    "USA/CA-ALSR-101973/2020": "2020-07-11",  # alpha
+    "USA/CA-ALSR-101984/2020": "2020-07-11",  # alpha
+    "USA/CA-ALSR-101987/2020": "2020-07-08",  # alpha
+    "USA/CA-ALSR-101991/2020": "2020-07-08",  # alpha
+    "USA/CA-ALSR-101999/2020": "2020-07-08",  # alpha
+    "USA/CA-ALSR-102007/2020": "2020-07-08",  # alpha
+    "USA/CA-ALSR-102015/2020": "2020-07-09",  # alpha
+    "USA/MN-MDH-13426/2020": "2020-08-07",  # delta
+    "USA/WI-WSLH-219155/2020": "2020-08-12",  # delta
+    "USA/WY-WYPHL-21070660/2020": "2020-09-02",  # delta
+    "USA/VI-Yale-10210/2020": "2020-08-21",  # delta
+    "USA/VI-Yale-10211/2020": "2020-08-21",  # delta
+    "USA/TX-HMH-MCoV-40926/2020": "2020-07-22",  # alpha
+    "USA/TX-HMH-MCoV-40929/2020": "2020-07-22",  # alpha
+    "Vanuatu/VAN003/2020": "2020-04-17",  # alpha
+    "Rwanda/CV2217/2020": "2020-06-04",  # beta
+    "England/MILK-1FF99A3/2020": "2020-04-16",  # delta
+    "England/MILK-1FF99C1/2020": "2020-04-16",  # delta
+    "England/MILK-1FF9A19/2020": "2020-04-16",  # delta
+    "England/MILK-1FF9A37/2020": "2020-04-16",  # delta
+    "England/MILK-1FF9A46/2020": "2020-04-16",  # delta
+    "England/MILK-1FF9A64/2020": "2020-04-16",  # delta
+    "England/MILK-1FF9A82/2020": "2020-04-16",  # delta
+    "England/MILK-1FF9ABF/2020": "2020-04-16",  # delta
+    "England/MILK-1FF9ADD/2020": "2020-04-16",  # delta
+    "England/MILK-1FF9B43/2020": "2020-04-19",  # delta
+    "England/MILK-1FF9B8F/2020": "2020-04-16",  # delta
+    "England/MILK-1FF9BE9/2020": "2020-04-16",  # delta
+    "England/MILK-1FF9D6B/2020": "2020-04-16",  # delta
+    "England/MILK-1FF9DA7/2020": "2020-04-16",  # delta
+    "England/MILK-1FF9DC5/2020": "2020-04-18",  # delta
+    "England/MILK-1FF9DD4/2020": "2020-04-16",  # delta
+    "England/MILK-1FF9DF2/2020": "2020-04-16",  # delta
+    "England/MILK-1FF9FB0/2020": "2020-04-16",  # delta
+    "England/MILK-1FF9FDE/2020": "2020-04-16",  # delta
+    "England/MILK-1FF9FFC/2020": "2020-04-16",  # delta
+    "England/MILK-1FFA034/2020": "2020-04-16",  # delta
+    "England/MILK-1FFA061/2020": "2020-04-16",  # delta
+    "England/MILK-1FFA0BC/2020": "2020-04-16",  # delta
+    "England/MILK-1FFA131/2020": "2020-04-16",  # delta
+    "England/MILK-1FFA17D/2020": "2020-04-16",  # delta
+    "England/MILK-1FFA19B/2020": "2020-04-16",  # delta
+    "England/MILK-1FFA1B9/2020": "2020-04-16",  # delta
+    "England/MILK-1FFA1D7/2020": "2020-04-16",  # delta
+    "England/MILK-1FFA25C/2020": "2020-04-16",  # delta
+    "England/MILK-1FFA2A7/2020": "2020-04-16",  # delta
+    "England/MILK-1FFA30E/2020": "2020-04-16",  # delta
+    "England/MILK-1FFA359/2020": "2020-04-16",  # delta
+    "England/MILK-1FFA438/2020": "2020-04-16",  # delta
+    "England/MILK-1FFA492/2020": "2020-04-16",  # delta
+    "England/MILK-1FFA4B0/2020": "2020-04-16",  # delta
+    "England/MILK-1FFA4ED/2020": "2020-04-16",  # delta
+    "England/MILK-1FFA4FC/2020": "2020-04-16",  # delta
+    "England/MILK-1FFA508/2020": "2020-04-16",  # delta
+    "England/MILK-1FFA526/2020": "2020-04-16",  # delta
+    "Fiji/FJ493/2020": "2020-08-25",  # delta
+    "Rwanda/CV2197/2020": "2020-09-10",  # delta
+    "USA/ND-NDDH-4397/2020": "2020-09-09",  # delta
+    "USA/WV-WVU-WV121217/2020": "2020-07-21",  # delta
+    "Sudan/N6667/2020": "2020-10-04",  # eta
+    "Colombia/DC-Mx263_sarscov2/2020": "2020-09-19",  # 21H
+    "Colombia/DC-Mx318_sarscov2/2020": "2020-10-06",  # 21H
+    "Morocco/INH-101/2020": "2020-02-02",  # S98
+    "Morocco/INH-105/2020": "2020-02-02",  # S98
+    "USA/IN-ISDHQ397/2020": "2020-04-23",  # alpha
+    "USA/TX-HMH-MCoV-44272/2020": "2020-07-31",  # alpha
+    "USA/TX-HMH-MCoV-45474/2020": "2020-07-31",  # alpha
+    "USA/TX-HMH-MCoV-45482/2020": "2020-07-31",  # alpha
+    "USA/TX-HMH-MCoV-45578/2020": "2020-07-31",  # alpha
+    "USA/TX-HMH-MCoV-45753/2020": "2020-07-31",  # alpha
+    "USA/TX-HMH-MCoV-47089/2020": "2020-07-31",  # alpha
+    "USA/TX-HMH-MCoV-47116/2020": "2020-07-31",  # alpha
+    "USA/TX-HMH-MCoV-47370/2020": "2020-07-30",  # alpha
+    "USA/TX-HMH-MCoV-39835/2020": "2020-08-06",  # alpha
+    "USA/TX-HMH-MCoV-44274/2020": "2020-07-31",  # alpha
+    "USA/TX-HMH-MCoV-45478/2020": "2020-07-31",  # alpha
+    "USA/TX-HMH-MCoV-45481/2020": "2020-07-31",  # alpha
+    "USA/TX-HMH-MCoV-45754/2020": "2020-07-31",  # alpha
+    "USA/TX-HMH-MCoV-45758/2020": "2020-07-31",  # alpha
+    "USA/TX-HMH-MCoV-45768/2020": "2020-07-31",  # alpha
+    "USA/TX-HMH-MCoV-47118/2020": "2020-07-31",  # alpha
+    "USA/NY-MSHSPSP-PV21126/2020": "2020-10-11",  # 20C/S484
+    "USA/NY-MSHSPSP-PV21129/2020": "2020-10-10",  # 20C/S484
+    "USA/NY-MSHSPSP-PV21166/2020": "2020-10-09",  # 20C/S484
+    "USA/NY-MSHSPSP-PV21203/2020": "2020-10-13",  # 20C/S484
+    "Pakistan/UOL-IMBB-KKU-25/2021": "2021-10-22",  # future date
+    "Pakistan/UOL-IMBB-KKU-26/2021": "2021-10-23",  # future date
+    "England/PHEP-YYBYUTJ/2020": "2020-08-03",  # delta
+    "Indonesia/JA-GS-EIJK-RSRM-0168/2020": "2020-07-29",  # delta
+    "Indonesia/JA-GS-EIJK-RSRM-0169/2020": "2020-07-29",  # delta
+    "Indonesia/JA-GS-EIJK-RSRM-0170/2020": "2020-07-29",  # delta
+    "Indonesia/JA-GS-EIJK-RSRM-0172/2020": "2020-07-29",  # delta
+    "Indonesia/JA-GS-EIJK-RSRM-0200/2020": "2020-07-29",  # delta
+    "USA/CA-SEARCH-109796/2020": "2020-08-31",  # delta
+    "USA/TX-HMH-MCoV-48794/2020": "2020-07-15",  # delta
+    "USA/TX-HMH-MCoV-49501/2020": "2020-07-13",  # delta
+    "Italy/VEN-UA-ORC00183/2020": "2020-03-14",  # alpha
+    "Brazil/SP-IB_112782/2020": "2020-08-07",  # gamma
+    "Japan/PG-149116/2020": "2020-08-30",  # Delta
+    "Germany/NW-RKI-I-291769/2020": "2020-10-13",  # delta
+    "Germany/NW-RKI-I-291770/2020": "2020-10-13",  # delta
+    "Germany/NW-RKI-I-291771/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291772/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291773/2020": "2020-10-17",  # delta
+    "Germany/NW-RKI-I-291774/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291775/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291776/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291777/2020": "2020-10-17",  # delta
+    "Germany/NW-RKI-I-291778/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291779/2020": "2020-10-17",  # delta
+    "Germany/NW-RKI-I-291780/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291781/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291782/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291783/2020": "2020-10-13",  # delta
+    "Germany/NW-RKI-I-291784/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291786/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291788/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291789/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291790/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291791/2020": "2020-10-16",  # delta
+    "Germany/NW-RKI-I-291792/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291793/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291794/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291795/2020": "2020-10-17",  # delta
+    "Germany/NW-RKI-I-291796/2020": "2020-10-13",  # delta
+    "Germany/NW-RKI-I-291797/2020": "2020-10-16",  # delta
+    "Germany/NW-RKI-I-291798/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291799/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291800/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291801/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291802/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291803/2020": "2020-10-17",  # delta
+    "Germany/NW-RKI-I-291804/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291805/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291806/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291808/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291809/2020": "2020-10-16",  # delta
+    "Germany/NW-RKI-I-291810/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291811/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291812/2020": "2020-10-16",  # delta
+    "Germany/SL-RKI-I-297962/2020": "2020-10-17",  # delta
+    "USA/NY-COV-900/2020": "2020-06-06",  # Alpha
+    "Peru/LIM-INS-8425/2020": "2020-07-21",  # lambda
+    "Netherlands/ZH-EMC-3837/2020": "2020-05-10",  # S98
+    "Netherlands/ZH-EMC-3838/2020": "2020-03-12",  # S98
+    "Netherlands/ZH-EMC-3839/2020": "2020-04-12",  # S98
+    "England/NORT-YYNW7P/2020": "2020-10-27",  # delta
+    "USA/TX-HMH-MCoV-34911/2020": "2020-08-13",  # Alpha
+    "Colombia/ANT-LDSP461/2020": "2020-10-14",  # Mu
+    "India/DL-ILBS-22053/2020": "2020-06-13",  # 21A Delta
+    "Italy/LOM-TIGEM-IZSM-COLLI-14397/2020": "2020-03-16",  # alpha
+    "Italy/SIC_ISS_7543/2020": "2020-03-02",  # alpha
+    "Romania/SV_SJU_17854/2020": "2020-08-16",  # alpha
+    "Romania/SV_SJU_18749/2020": "2020-08-26",  # alpha
+    "Romania/SV_SJU_19042/2020": "2020-08-28",  # alpha
+    "USA/TX-HMH-MCoV-40893/2020": "2020-07-22",  # alpha
+    "USA/TX-HMH-MCoV-45566/2020": "2020-07-31",  # alpha
+    "USA/TX-HMH-MCoV-45752/2020": "2020-07-31",  # alpha
+    "USA/TX-HMH-MCoV-45766/2020": "2020-07-31",  # alpha
+    "SouthAfrica/NICD-N19828/2020": "2020-06-26",  # beta
+    "SouthAfrica/NICD-N19829/2020": "2020-06-26",  # beta
+    "Brazil/MS-HRMS_1490/2020": "2020-08-24",  # gamma
+    "India/TG-CCMB-CIB1089/2020": "2020-10-04",  # delta
+    "India/TG-CCMB-CIB1094/2020": "2020-10-20",  # delta
+    "India/TG-CCMB-CIB1117/2020": "2020-08-26",  # delta
+    "India/TG-CCMB-CIB1118/2020": "2020-08-26",  # delta
+    "India/TG-CCMB-CIB1124/2020": "2020-08-29",  # delta
+    "India/TG-CCMB-CIB1125/2020": "2020-08-29",  # delta
+    "India/TG-CCMB-CIB1133/2020": "2020-09-12",  # delta
+    "India/TG-CCMB-CIB1134/2020": "2020-09-22",  # delta
+    "India/TG-RFCH00157_CIB1134/2020": "2020-09-22",  # delta
+    "SouthAfrica/NICD-N19863/2020": "2020-06-26",  # delta
+    "India/TG-CCMB-CIB1077/2020": "2020-10-02",  # delta
+    "PapuaNewGuinea/PNG4040/2020": "2020-08-01",  # delta
+    "SouthAfrica/NICD-N19840/2020": "2020-07-07",  # delta
+    "USA/CA-CDPH-MC2409222/2020": "2020-10-10",  # delta
+    "USA/NY-WMC2021-152/2020": "2020-03-12",  # delta
+    "USA/CA-CZB-13785/2020": "2020-09-22",  # iota
+    "USA/NY-MSHSPSP-PV22505/2020": "2020-11-03",  # iota
+    "England/PHEP-YYBYUTJ/2020": "2020-08-03",  # delta
+    "USA/TX-HMH-MCoV-49453/2020": "2020-07-12",  # delta
+    "USA/TX-HMH-MCoV-49803/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49806/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49808/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49809/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49814/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49815/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49816/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49817/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49827/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49831/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49836/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49838/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49840/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49851/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49852/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49854/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49855/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49859/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49862/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49866/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49873/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49874/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49876/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49878/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49880/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49881/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49883/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49888/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49889/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49892/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49894/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49896/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49898/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49899/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49901/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49905/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49911/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49913/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49915/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49917/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49919/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49920/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49922/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49923/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49924/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49925/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49928/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49930/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49933/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49935/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49937/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49938/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49939/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49946/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49948/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49951/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49953/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49958/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49959/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49963/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49966/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49969/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49973/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49975/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49976/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49978/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49982/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49984/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49985/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49988/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49989/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49994/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50010/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50013/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50024/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50028/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50034/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50045/2020": "2020-07-15",  # delta
+    "USA/TX-HMH-MCoV-50046/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50067/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50486/2020": "2020-07-17",  # delta
+    "USA/TX-HMH-MCoV-50501/2020": "2020-07-17",  # delta
+    "USA/TX-HMH-MCoV-50545/2020": "2020-07-17",  # delta
+    "USA/TX-HMH-MCoV-50566/2020": "2020-07-17",  # delta
+    "USA/TX-HMH-MCoV-50048/2020": "2020-07-20",  # delta
+    "USA/TX-HMH-MCoV-50050/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50068/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50082/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50084/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50493/2020": "2020-07-17",  # delta
+    "USA/TX-HMH-MCoV-50519/2020": "2020-07-17",  # delta
+    "USA/TX-HMH-MCoV-49841/2020": "2020-07-16",  # delta
     # these are suspicious dates - seem unlikely when checked in Nextclade
-    "England/PHEP-YYBYUTJ/2020" : "2020-08-03", #delta
-    "Fiji/FJ493/2020" : "2020-08-25", #delta
-    "BurkinaFaso/CV1920/2020" : "2020-09-16", #delta
-    "BurkinaFaso/CV1921/2020" : "2020-09-18", #delta
-    "Indonesia/JA-GS-EIJK-RSRM-0168/2020" : "2020-07-29", #delta
-    "Indonesia/JA-GS-EIJK-RSRM-0169/2020" : "2020-07-29", #delta
-    "Indonesia/JA-GS-EIJK-RSRM-0170/2020" : "2020-07-29", #delta
-    "Indonesia/JA-GS-EIJK-RSRM-0172/2020" : "2020-07-29", #delta
-    "Indonesia/JA-GS-EIJK-RSRM-0200/2020" : "2020-07-29", #delta
-    "Mexico/AGU-InDRE_FB18599_S4467/2020" : "2020-09-22", #delta
-    "PapuaNewGuinea/PNG4040/2020" : "2020-08-01", #delta
-    "Rwanda/CV2197/2020" : "2020-09-10", #delta
-    "SouthAfrica/NICD-N19840/2020" : "2020-07-07", #delta
-    "SouthAfrica/NICD-N19863/2020" : "2020-06-26", #delta
-    "USA/CA-LACPHL-AF03229/2020" : "2020-08-12", #delta
-    "USA/CA-SEARCH-109796/2020" : "2020-08-31", #delta
-    "USA/ND-NDDH-4397/2020" : "2020-09-09", #delta
-    "USA/NY-WMC2021-152/2020" : "2020-03-12", #delta
-    "USA/TX-HMH-MCoV-48794/2020" : "2020-07-15", #delta
-    "USA/TX-HMH-MCoV-49501/2020" : "2020-07-13", #delta
-    "USA/VI-Yale-10210/2020" : "2020-08-21", #delta
-    "USA/VI-Yale-10211/2020" : "2020-08-21", #delta
-    "USA/WV-WVU-WV121217/2020" : "2020-07-21", #delta
-    "USA/WY-WYPHL-21070660/2020" : "2020-09-02", #delta
-    "Rwanda/CV2223/2020" : "2020-12-21", #delta
-    "Scotland/CVR8617/2020" : "2020-12-27", #delta
-    "Slovenia/17-047667-CE/2020" : "2020-11-13", #delta
-    "Slovenia/17-073336-CE/2020" : "2020-12-31", #delta
-    "Slovenia/251283/2020" : "2020-12-04", #delta
-    "Spain/CT-HUGTiPM043JX9G11/2020" : "2020-11-03", #delta
-    "Spain/MD-HRYC-1052050/2020" : "2020-11-18", #delta
-    "Sweden/10097141/2020" : "2020-11-19", #delta
-    "USA/CA-CDPH-MC2409222/2020" : "2020-10-10", #delta
-    "USA/MD-HP20064-PIDZAEYGDO/2020" : "2020-11-03", #delta
-    "USA/NY-NYCPHL-005674/2020" : "2020-11-20", #delta
-    "USA/TX-HHD-210729KVI6183/2020" : "2020-12-26", #delta
-    "USA/TX-Noblis-S709B19/2020" : "2020-12-03", #delta
-    "USA/TX-Noblis-S710B20/2020" : "2020-12-03", #delta
-    "USA/UT-UPHL-210729652440/2020" : "2020-12-16", #delta
-    "USA/WY-WYPHL-20167074/2020" : "2020-12-16", #delta
-    "BurkinaFaso/CV1847/2020" : "2020-12-18", #delta
-    "BurkinaFaso/CV1908/2020" : "2020-12-07", #delta
-    "BurkinaFaso/CV1909/2020" : "2020-12-03", #delta
-    "BurkinaFaso/CV1910/2020" : "2020-12-03", #delta
-    "BurkinaFaso/CV1911/2020" : "2020-12-03", #delta
-    "BurkinaFaso/CV1922/2020" : "2020-12-21", #delta
-    "BurkinaFaso/CV1923/2020" : "2020-12-21", #delta
-    "BurkinaFaso/CV1943/2020" : "2020-12-08", #delta
-    "BurkinaFaso/CV1944/2020" : "2020-12-18", #delta
-    "BurkinaFaso/CV1945/2020" : "2020-12-18", #delta
-    "BurkinaFaso/CV1946/2020" : "2020-12-18", #delta
-    "BurkinaFaso/CV1947/2020" : "2020-12-18", #delta
-    "BurkinaFaso/CV1955/2020" : "2020-12-27", #delta
-    "BurkinaFaso/CV1956/2020" : "2020-12-27", #delta
-    "BurkinaFaso/CV1957/2020" : "2020-12-17", #delta
-    "England/MILK-18DD450/2020" : "2020-11-04", #delta
-    "England/NORT-YYNW7P/2020" : "2020-10-27", #delta
-    "England/NORW-30146BA/2020" : "2020-11-15", #delta
-
-    #unlikely for beta from SA
-    "SouthAfrica/CERI-KRISP-K026612/2021" : "2021-10-06", #deta
-    "SouthAfrica/CERI-KRISP-K026946/2021" : "2021-10-15", #deta
-    "SouthAfrica/CERI-KRISP-K027301/2021" : "2021-10-20", #deta
-    "SouthAfrica/NICD-N18899/2021" : "2021-10-10", #deta
-    "SouthAfrica/NICD-N18921/2021" : "2021-10-12", #deta
-    "SouthAfrica/NICD-N20404/2021" : "2021-10-15", #deta
-    "SouthAfrica/NICD-N20493/2021" : "2021-10-20", #deta
-    "SouthAfrica/NICD-N20495/2021" : "2021-10-20", #deta
-    "SouthAfrica/NICD-N20496/2021" : "2021-10-18", #deta
-    "SouthAfrica/NICD-N20498/2021" : "2021-10-22", #deta
-    "SouthAfrica/NICD-N20507/2021" : "2021-10-02", #deta
-    "SouthAfrica/NICD-N20510/2021" : "2021-10-03", #deta
-    "SouthAfrica/NICD-N20511/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20512/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20514/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20515/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20516/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20517/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20519/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20520/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20522/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20523/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20525/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20527/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20530/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20532/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20533/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20534/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20535/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20536/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20538/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20539/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20542/2021" : "2021-10-04", #deta
-    "SouthAfrica/NICD-N20543/2021" : "2021-10-05", #deta
-    "SouthAfrica/NICD-N20544/2021" : "2021-10-05", #deta
-    "SouthAfrica/NICD-N20548/2021" : "2021-10-05", #deta
-    "SouthAfrica/NICD-N20549/2021" : "2021-10-05", #deta
-    "SouthAfrica/NICD-N20550/2021" : "2021-10-05", #deta
-    "SouthAfrica/NICD-N20552/2021" : "2021-10-05", #deta
-    "SouthAfrica/NICD-N20553/2021" : "2021-10-05", #deta
-    "SouthAfrica/NICD-N20554/2021" : "2021-10-07", #deta
-    "SouthAfrica/NICD-N20555/2021" : "2021-10-07", #deta
-    "SouthAfrica/NICD-N20558/2021" : "2021-10-06", #deta
-    "SouthAfrica/NICD-N20559/2021" : "2021-10-06", #deta
-    "SouthAfrica/NICD-N20560/2021" : "2021-10-06", #deta
-    "SouthAfrica/NICD-N20561/2021" : "2021-10-06", #deta
-    "SouthAfrica/NICD-N20562/2021" : "2021-10-06", #deta
-    "SouthAfrica/NICD-N20563/2021" : "2021-10-06", #deta
-    "SouthAfrica/NICD-N20564/2021" : "2021-10-06", #deta
-    "SouthAfrica/NICD-N20565/2021" : "2021-10-06", #deta
-    "SouthAfrica/NICD-N20567/2021" : "2021-10-06", #deta
-    "SouthAfrica/NICD-N20568/2021" : "2021-10-06", #deta
-    "SouthAfrica/NICD-N20569/2021" : "2021-10-07", #deta
-    "SouthAfrica/NICD-N20570/2021" : "2021-10-09", #deta
-    "SouthAfrica/NICD-N20571/2021" : "2021-10-09", #deta
-    "SouthAfrica/NICD-N20572/2021" : "2021-10-09", #deta
-    "SouthAfrica/NICD-N20576/2021" : "2021-10-09", #deta
-    "SouthAfrica/NICD-N20577/2021" : "2021-10-09", #deta
-    "SouthAfrica/NICD-N20578/2021" : "2021-10-08", #deta
-    "SouthAfrica/NICD-N20580/2021" : "2021-10-08", #deta
-    "SouthAfrica/NICD-N20581/2021" : "2021-10-08", #deta
-    "SouthAfrica/NICD-N20582/2021" : "2021-10-08", #deta
-    "SouthAfrica/Tygerberg_2967/2021" : "2021-10-26", #deta
-
+    "England/PHEP-YYBYUTJ/2020": "2020-08-03",  # delta
+    "Fiji/FJ493/2020": "2020-08-25",  # delta
+    "BurkinaFaso/CV1920/2020": "2020-09-16",  # delta
+    "BurkinaFaso/CV1921/2020": "2020-09-18",  # delta
+    "Indonesia/JA-GS-EIJK-RSRM-0168/2020": "2020-07-29",  # delta
+    "Indonesia/JA-GS-EIJK-RSRM-0169/2020": "2020-07-29",  # delta
+    "Indonesia/JA-GS-EIJK-RSRM-0170/2020": "2020-07-29",  # delta
+    "Indonesia/JA-GS-EIJK-RSRM-0172/2020": "2020-07-29",  # delta
+    "Indonesia/JA-GS-EIJK-RSRM-0200/2020": "2020-07-29",  # delta
+    "Mexico/AGU-InDRE_FB18599_S4467/2020": "2020-09-22",  # delta
+    "PapuaNewGuinea/PNG4040/2020": "2020-08-01",  # delta
+    "Rwanda/CV2197/2020": "2020-09-10",  # delta
+    "SouthAfrica/NICD-N19840/2020": "2020-07-07",  # delta
+    "SouthAfrica/NICD-N19863/2020": "2020-06-26",  # delta
+    "USA/CA-LACPHL-AF03229/2020": "2020-08-12",  # delta
+    "USA/CA-SEARCH-109796/2020": "2020-08-31",  # delta
+    "USA/ND-NDDH-4397/2020": "2020-09-09",  # delta
+    "USA/NY-WMC2021-152/2020": "2020-03-12",  # delta
+    "USA/TX-HMH-MCoV-48794/2020": "2020-07-15",  # delta
+    "USA/TX-HMH-MCoV-49501/2020": "2020-07-13",  # delta
+    "USA/VI-Yale-10210/2020": "2020-08-21",  # delta
+    "USA/VI-Yale-10211/2020": "2020-08-21",  # delta
+    "USA/WV-WVU-WV121217/2020": "2020-07-21",  # delta
+    "USA/WY-WYPHL-21070660/2020": "2020-09-02",  # delta
+    "Rwanda/CV2223/2020": "2020-12-21",  # delta
+    "Scotland/CVR8617/2020": "2020-12-27",  # delta
+    "Slovenia/17-047667-CE/2020": "2020-11-13",  # delta
+    "Slovenia/17-073336-CE/2020": "2020-12-31",  # delta
+    "Slovenia/251283/2020": "2020-12-04",  # delta
+    "Spain/CT-HUGTiPM043JX9G11/2020": "2020-11-03",  # delta
+    "Spain/MD-HRYC-1052050/2020": "2020-11-18",  # delta
+    "Sweden/10097141/2020": "2020-11-19",  # delta
+    "USA/CA-CDPH-MC2409222/2020": "2020-10-10",  # delta
+    "USA/MD-HP20064-PIDZAEYGDO/2020": "2020-11-03",  # delta
+    "USA/NY-NYCPHL-005674/2020": "2020-11-20",  # delta
+    "USA/TX-HHD-210729KVI6183/2020": "2020-12-26",  # delta
+    "USA/TX-Noblis-S709B19/2020": "2020-12-03",  # delta
+    "USA/TX-Noblis-S710B20/2020": "2020-12-03",  # delta
+    "USA/UT-UPHL-210729652440/2020": "2020-12-16",  # delta
+    "USA/WY-WYPHL-20167074/2020": "2020-12-16",  # delta
+    "BurkinaFaso/CV1847/2020": "2020-12-18",  # delta
+    "BurkinaFaso/CV1908/2020": "2020-12-07",  # delta
+    "BurkinaFaso/CV1909/2020": "2020-12-03",  # delta
+    "BurkinaFaso/CV1910/2020": "2020-12-03",  # delta
+    "BurkinaFaso/CV1911/2020": "2020-12-03",  # delta
+    "BurkinaFaso/CV1922/2020": "2020-12-21",  # delta
+    "BurkinaFaso/CV1923/2020": "2020-12-21",  # delta
+    "BurkinaFaso/CV1943/2020": "2020-12-08",  # delta
+    "BurkinaFaso/CV1944/2020": "2020-12-18",  # delta
+    "BurkinaFaso/CV1945/2020": "2020-12-18",  # delta
+    "BurkinaFaso/CV1946/2020": "2020-12-18",  # delta
+    "BurkinaFaso/CV1947/2020": "2020-12-18",  # delta
+    "BurkinaFaso/CV1955/2020": "2020-12-27",  # delta
+    "BurkinaFaso/CV1956/2020": "2020-12-27",  # delta
+    "BurkinaFaso/CV1957/2020": "2020-12-17",  # delta
+    "England/MILK-18DD450/2020": "2020-11-04",  # delta
+    "England/NORT-YYNW7P/2020": "2020-10-27",  # delta
+    "England/NORW-30146BA/2020": "2020-11-15",  # delta
+    # unlikely for beta from SA
+    "SouthAfrica/CERI-KRISP-K026612/2021": "2021-10-06",  # deta
+    "SouthAfrica/CERI-KRISP-K026946/2021": "2021-10-15",  # deta
+    "SouthAfrica/CERI-KRISP-K027301/2021": "2021-10-20",  # deta
+    "SouthAfrica/NICD-N18899/2021": "2021-10-10",  # deta
+    "SouthAfrica/NICD-N18921/2021": "2021-10-12",  # deta
+    "SouthAfrica/NICD-N20404/2021": "2021-10-15",  # deta
+    "SouthAfrica/NICD-N20493/2021": "2021-10-20",  # deta
+    "SouthAfrica/NICD-N20495/2021": "2021-10-20",  # deta
+    "SouthAfrica/NICD-N20496/2021": "2021-10-18",  # deta
+    "SouthAfrica/NICD-N20498/2021": "2021-10-22",  # deta
+    "SouthAfrica/NICD-N20507/2021": "2021-10-02",  # deta
+    "SouthAfrica/NICD-N20510/2021": "2021-10-03",  # deta
+    "SouthAfrica/NICD-N20511/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20512/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20514/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20515/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20516/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20517/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20519/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20520/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20522/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20523/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20525/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20527/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20530/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20532/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20533/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20534/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20535/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20536/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20538/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20539/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20542/2021": "2021-10-04",  # deta
+    "SouthAfrica/NICD-N20543/2021": "2021-10-05",  # deta
+    "SouthAfrica/NICD-N20544/2021": "2021-10-05",  # deta
+    "SouthAfrica/NICD-N20548/2021": "2021-10-05",  # deta
+    "SouthAfrica/NICD-N20549/2021": "2021-10-05",  # deta
+    "SouthAfrica/NICD-N20550/2021": "2021-10-05",  # deta
+    "SouthAfrica/NICD-N20552/2021": "2021-10-05",  # deta
+    "SouthAfrica/NICD-N20553/2021": "2021-10-05",  # deta
+    "SouthAfrica/NICD-N20554/2021": "2021-10-07",  # deta
+    "SouthAfrica/NICD-N20555/2021": "2021-10-07",  # deta
+    "SouthAfrica/NICD-N20558/2021": "2021-10-06",  # deta
+    "SouthAfrica/NICD-N20559/2021": "2021-10-06",  # deta
+    "SouthAfrica/NICD-N20560/2021": "2021-10-06",  # deta
+    "SouthAfrica/NICD-N20561/2021": "2021-10-06",  # deta
+    "SouthAfrica/NICD-N20562/2021": "2021-10-06",  # deta
+    "SouthAfrica/NICD-N20563/2021": "2021-10-06",  # deta
+    "SouthAfrica/NICD-N20564/2021": "2021-10-06",  # deta
+    "SouthAfrica/NICD-N20565/2021": "2021-10-06",  # deta
+    "SouthAfrica/NICD-N20567/2021": "2021-10-06",  # deta
+    "SouthAfrica/NICD-N20568/2021": "2021-10-06",  # deta
+    "SouthAfrica/NICD-N20569/2021": "2021-10-07",  # deta
+    "SouthAfrica/NICD-N20570/2021": "2021-10-09",  # deta
+    "SouthAfrica/NICD-N20571/2021": "2021-10-09",  # deta
+    "SouthAfrica/NICD-N20572/2021": "2021-10-09",  # deta
+    "SouthAfrica/NICD-N20576/2021": "2021-10-09",  # deta
+    "SouthAfrica/NICD-N20577/2021": "2021-10-09",  # deta
+    "SouthAfrica/NICD-N20578/2021": "2021-10-08",  # deta
+    "SouthAfrica/NICD-N20580/2021": "2021-10-08",  # deta
+    "SouthAfrica/NICD-N20581/2021": "2021-10-08",  # deta
+    "SouthAfrica/NICD-N20582/2021": "2021-10-08",  # deta
+    "SouthAfrica/Tygerberg_2967/2021": "2021-10-26",  # deta
     # these have very unlikely dates for Delta
-    "Australia/VIC18503/2021" : "2021-02-08", #delta
-    "Belize/CML-101/2021" : "2021-01-07", #delta
-    "Belize/CML-102/2021" : "2021-01-07", #delta
-    "Belize/CML-92/2021" : "2021-02-07", #delta
-    "Canada/QC-1nEAQ-0667616/2021" : "2021-01-26", #delta
-    "CzechRepublic/CSQ1259/2021" : "2021-01-28", #delta
-    "CzechRepublic/NRL_10092/2021" : "2021-02-12", #delta
-    "CzechRepublic/NRL_13299/2021" : "2021-02-08", #delta
-    "CzechRepublic/NRL_13887/2021" : "2021-02-24", #delta
-    "CzechRepublic/NRL_9986/2021" : "2021-02-11", #delta
-    "England/LOND-13670C5/2021" : "2021-02-17", #delta
-    "England/LOND-13679CA/2021" : "2021-02-19", #delta
-    "England/NEWC-2729532/2021" : "2021-01-09", #delta
-    "England/NORT-1BF0F53/2021" : "2021-01-21", #delta
-    "England/NORT-1BF4BE2/2021" : "2021-01-24", #delta
-    "England/NORT-1BF6E50/2021" : "2021-01-27", #delta
-    "England/NORT-1BF71A1/2021" : "2021-01-29", #delta
-    "England/NORT-YYBGBS/2021" : "2021-01-26", #delta
-    "England/NORT-YYBI4W/2021" : "2021-02-27", #delta
-    "England/NORT-YYWTNN/2021" : "2021-01-01", #delta
-    "England/NORW-13F3969/2021" : "2021-02-20", #delta
-    "England/NORW-13F67E4/2021" : "2021-01-22", #delta
-    "England/NORW-13F8560/2021" : "2021-02-27", #delta
-    "England/NORW-306189D/2021" : "2021-02-09", #delta
-    "England/NORW-3079BFC/2021" : "2021-01-14", #delta
-    "England/NORW-30902CC/2021" : "2021-01-21", #delta
-    "England/NORW-309F9F0/2021" : "2021-02-04", #delta
-    "England/NORW-30A0375/2021" : "2021-02-04", #delta
-    "England/PHEC-3504B7/2021" : "2021-01-27", #delta
-    "England/PHEP-006474/2021" : "2021-02-06", #delta
-    "England/PHEP-262264/2021" : "2021-01-11", #delta
-    "Ethiopia/CERI-KRISP-K025808/2021" : "2021-02-11", #delta
-    "France/BFC-HMN-21082040163/2021" : "2021-02-27", #delta
-    "France/GES-HCL0211536735/2021" : "2021-01-16", #delta
-    "Gambia/PF0203/2021" : "2021-02-08", #delta
-    "Gambia/PF6266/2021" : "2021-02-08", #delta
-    "Indonesia/JA-GS-EIJK-RSRM-0203/2021" : "2021-02-01", #delta
-    "Indonesia/JK-NIHRD-WGS00007/2021" : "2021-01-07", #delta
-    "Indonesia/KS-NIHRD-WGS12290/2021" : "2021-01-09", #delta
-    "Indonesia/KS-NIHRD-WGS12291/2021" : "2021-01-09", #delta
-    "Indonesia/KS-NIHRD-WGS12292/2021" : "2021-02-09", #delta
-    "Indonesia/SS-NIHRD-WGS002218/2021" : "2021-01-15", #delta
-    "Indonesia/SS-NIHRD-WGS00441/2021" : "2021-01-08", #delta
-    "Indonesia/SS-NIHRD-WGS00445/2021" : "2021-01-12", #delta
-    "Israel/CVL-22307/2021" : "2021-01-30", #delta
-    "Israel/CVL-22309/2021" : "2021-01-02", #delta
-    "Israel/CVL-22311/2021" : "2021-01-07", #delta
-    "Israel/CVL-22314/2021" : "2021-01-09", #delta
-    "Israel/CVL-22316/2021" : "2021-01-08", #delta
-    "Israel/CVL-22319/2021" : "2021-01-03", #delta
-    "Italy/SIC_CQRC_2726144/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2726239/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2726263/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2727245/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2727475/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2727482/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2727983/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2728951/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2729676/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2731727/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2736383/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2737746/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2737781/2021" : "2021-01-11", #delta
-    "Italy/TUS-AOUC-40/2021" : "2021-01-24", #delta
-    "Kenya/ILRI_COVM01044/2021" : "2021-01-07", #delta
-    "Kenya/ILRI_COVM01048/2021" : "2021-01-07", #delta
-    "Kenya/ILRI_COVM01050/2021" : "2021-01-07", #delta
-    "Kenya/ILRI_COVM01069/2021" : "2021-01-07", #delta
-    "Kenya/ILRI_COVM01233/2021" : "2021-01-21", #delta
-    "Kenya/ILRI_COVM01347/2021" : "2021-01-09", #delta
-    "Kenya/SS1398/2021" : "2021-02-08", #delta
-    "Kenya/SS1399/2021" : "2021-02-08", #delta
-    "Malaysia/UNIMAS-GHML323/2021" : "2021-02-09", #delta
-    "Malaysia/UNIMAS-GHML324/2021" : "2021-02-09", #delta
-    "Malaysia/UNIMAS-GHML325/2021" : "2021-02-09", #delta
-    "Malaysia/UNIMAS-GHML326/2021" : "2021-02-09", #delta
-    "Malaysia/UNIMAS-GHML327/2021" : "2021-02-09", #delta
-    "Malaysia/UNIMAS-GHML328/2021" : "2021-02-09", #delta
-    "Mexico/AGU_InDRE_FB29455_S6243/2021" : "2021-01-27", #delta
-    "Mexico/BCN-SEARCH-104131/2021" : "2021-02-04", #delta
-    "Mexico/CMX-InDRE_FD78180_S4428/2021" : "2021-02-26", #delta
-    "Mexico/MOR_IBT_SSMor_11/2021" : "2021-01-21", #delta
-    "Mexico/MOR_IBT_SSMor_12/2021" : "2021-01-21", #delta
-    "Monaco/IPP14905/2021" : "2021-02-22", #delta
-    "Norway/24584/2021" : "2021-01-21", #delta
-    "Norway/26496/2021" : "2021-01-11", #delta
-    "Oman/rega-OM-232/2021" : "2021-02-06", #delta
-    "Oman/rega-OM-89/2021" : "2021-01-06", #delta
-    "Oman/rega-OM-90/2021" : "2021-01-06", #delta
-    "Oman/rega-OM-91/2021" : "2021-01-06", #delta
-    "Poland/WSSEGorzow-21S0298/2021" : "2021-01-09", #delta
-    "Russia/MOS-CRIE-L106A0093ubh/2021" : "2021-02-28", #delta
-    "Rwanda/CV2199/2021" : "2021-02-24", #delta
-    "Rwanda/CV2200/2021" : "2021-01-29", #delta
-    "Rwanda/CV2226/2021" : "2021-01-27", #delta
-    "Scotland/CVR7911/2021" : "2021-02-18", #delta
-    "Singapore/1444nan/2021" : "2021-02-06", #delta
-    "Slovakia/UVZ_PL36_A4_17796/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_A5_17804/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_A6_17812/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_B10_17961/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_B11_17969/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_B3_17789/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_B4_17797/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_B6_17813/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_B7_17907/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_C3_17790/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_C5_17806/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_C6_17814/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_C7_17910/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_D11_17986/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_D3_17791/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_D4_17799/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_D5_17807/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_D6_17815/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_D7_17911/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_D9_17955/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_E11_17987/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_E2_17784/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_E3_17792/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_E4_17800/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_E5_17808/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_E7_17913/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_E9_17956/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_F11_17988/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_F2_17785/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_F3_17793/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_F4_17801/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_F5_17809/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_F6_17903/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_F7_17921/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_F9_17957/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_G10_17966/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_G11_17989/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_G2_17786/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_G3_17794/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_G4_17802/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_G5_17810/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_G6_17904/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_G9_17958/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_H2_17787/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_H3_17795/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_H4_17803/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_H5_17811/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_H6_17905/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_H9_17959/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL37_A2_18007/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL37_A8_18061/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL37_B8_18062/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL37_C8_18063/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL37_D8_18064/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL37_E1_18003/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL37_E8_18065/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL37_F1_18004/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL37_F7_18058/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL37_F8_18066/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL37_G1_18005/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL37_G7_18059/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL37_G8_18067/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL37_H7_18060/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL37_H8_18068/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL40_A3_19181/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL40_B3_19182/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL40_C4_18365/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL40_E11_18455/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL40_F11_18456/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL40_F8_18400/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL40_F9_18440/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL40_G2_19179/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL40_G4_18369/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL40_H2_19180/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL46_A11_19348/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL46_C11_19350/2021" : "2021-01-09", #delta
-    "Slovenia/08-006923-MB/2021" : "2021-01-07", #delta
-    "SouthAfrica/NICD-N15251/2021" : "2021-01-19", #delta
-    "SouthAfrica/NICD-N16641/2021" : "2021-02-26", #delta
-    "SouthAfrica/NICD-N9212/2021" : "2021-01-12", #delta
-    "SouthAfrica/NICD-R11251/2021" : "2021-01-28", #delta
-    "Spain/CT-LabRefCat-751420/2021" : "2021-01-29", #delta
-    "Spain/MD-HGUGM-5702992/2021" : "2021-02-09", #delta
-    "Switzerland/AG-UHB-43144757/2021" : "2021-01-02", #delta
-    "Switzerland/BE-IFIK-210906_os-89/2021" : "2021-01-08", #delta
-    "Switzerland/BE-UHB-43000628/2021" : "2021-02-13", #delta
-    "Switzerland/GE-HUG-35467598/2021" : "2021-02-11", #delta
-    "Switzerland/LU-UHB-43144767/2021" : "2021-01-02", #delta
-    "Thailand/DMSc-02063/2021" : "2021-01-09", #delta
-    "Thailand/DMSc-02065/2021" : "2021-01-09", #delta
-    "Thailand/DMSc-02067/2021" : "2021-01-09", #delta
-    "Timor-Leste/TL1011/2021" : "2021-01-08", #delta
-    "Timor-Leste/TL1013/2021" : "2021-02-08", #delta
-    "Timor-Leste/TL1015/2021" : "2021-02-08", #delta
-    "Timor-Leste/TL1017/2021" : "2021-02-08", #delta
-    "Timor-Leste/TL979/2021" : "2021-01-08", #delta
-    "Timor-Leste/TL981/2021" : "2021-01-08", #delta
-    "Timor-Leste/TL983/2021" : "2021-01-08", #delta
-    "Timor-Leste/TL985/2021" : "2021-01-08", #delta
-    "Timor-Leste/TL987/2021" : "2021-01-08", #delta
-    "USA/AZ-ASU10204/2021" : "2021-01-30", #delta
-    "USA/AZ-ASU19232/2021" : "2021-02-01", #delta
-    "USA/AZ-ASU7883/2021" : "2021-02-09", #delta
-    "USA/AZ-ASU7899/2021" : "2021-02-10", #delta
-    "USA/CA-ACPHD-00570/2021" : "2021-01-24", #delta
-    "USA/CA-CDPH-UCSF-CC100/2021" : "2021-02-04", #delta
-    "USA/FL-BPHL-8934/2021" : "2021-01-14", #delta
-    "USA/IA-SHL-1780926/2021" : "2021-02-08", #delta
-    "USA/ID-IBL-759328/2021" : "2021-01-02", #delta
-    "USA/ID-IBL-760105/2021" : "2021-02-23", #delta
-    "USA/ID-IBL-760128/2021" : "2021-01-02", #delta
-    "USA/ID-IBL-771950/2021" : "2021-01-10", #delta
-    "USA/IL-S21WGS5409/2021" : "2021-01-10", #delta
-    "USA/KS-KHEL-6411/2021" : "2021-01-15", #delta
-    "USA/NV-NSPHL-392347/2021" : "2021-02-03", #delta
-    "USA/TN-SPHL-0094/2021" : "2021-01-19", #delta
-    "USA/TN-SPHL-0261/2021" : "2021-02-24", #delta
-    "USA/TN-SPHL-0517/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0539/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0587/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0588/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0606/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0610/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0617/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0622/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0749/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0750/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0788/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0800/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0805/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0861/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0953/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0961/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0964/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0967/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0979/2021" : "2021-01-14", #delta
-    "USA/UT-UPHL-210624251315/2021" : "2021-01-04", #delta
-    "USA/UT-UPHL-210624490751/2021" : "2021-01-04", #delta
-    "USA/UT-UPHL-210723256386/2021" : "2021-01-05", #delta
-    "USA/WA-PHL-006485/2021" : "2021-01-06", #delta
-    "env/Austria/CeMM18535/2021" : "2021-01-17", #delta
-    "BurkinaFaso/CV1847/2020" : "2020-12-18", #delta
-    "BurkinaFaso/CV1908/2020" : "2020-12-07", #delta
-    "BurkinaFaso/CV1909/2020" : "2020-12-03", #delta
-    "BurkinaFaso/CV1910/2020" : "2020-12-03", #delta
-    "BurkinaFaso/CV1911/2020" : "2020-12-03", #delta
-    "BurkinaFaso/CV1920/2020" : "2020-09-16", #delta
-    "BurkinaFaso/CV1921/2020" : "2020-09-18", #delta
-    "BurkinaFaso/CV1922/2020" : "2020-12-21", #delta
-    "BurkinaFaso/CV1923/2020" : "2020-12-21", #delta
-    "BurkinaFaso/CV1943/2020" : "2020-12-08", #delta
-    "BurkinaFaso/CV1944/2020" : "2020-12-18", #delta
-    "BurkinaFaso/CV1945/2020" : "2020-12-18", #delta
-    "BurkinaFaso/CV1946/2020" : "2020-12-18", #delta
-    "BurkinaFaso/CV1947/2020" : "2020-12-18", #delta
-    "BurkinaFaso/CV1955/2020" : "2020-12-27", #delta
-    "BurkinaFaso/CV1956/2020" : "2020-12-27", #delta
-    "BurkinaFaso/CV1957/2020" : "2020-12-17", #delta
-    "Canada/QC-1nMCY-S6293264/2020" : "2020-10-29", #delta
-    "England/MILK-18DD450/2020" : "2020-11-04", #delta
-    "England/NORT-YYNW7P/2020" : "2020-10-27", #delta
-    "England/NORW-30146BA/2020" : "2020-11-15", #delta
-    "England/PHEP-YYBYUTJ/2020" : "2020-08-03", #delta
-    "Fiji/FJ493/2020" : "2020-08-25", #delta
-    "Indonesia/JA-GS-EIJK-RSRM-0168/2020" : "2020-07-29", #delta
-    "Indonesia/JA-GS-EIJK-RSRM-0169/2020" : "2020-07-29", #delta
-    "Indonesia/JA-GS-EIJK-RSRM-0170/2020" : "2020-07-29", #delta
-    "Indonesia/JA-GS-EIJK-RSRM-0172/2020" : "2020-07-29", #delta
-    "Indonesia/JA-GS-EIJK-RSRM-0200/2020" : "2020-07-29", #delta
-    "Mexico/AGU-InDRE_FB18599_S4467/2020" : "2020-09-22", #delta
-    "PapuaNewGuinea/PNG4040/2020" : "2020-08-01", #delta
-    "Rwanda/CV2197/2020" : "2020-09-10", #delta
-    "Rwanda/CV2223/2020" : "2020-12-21", #delta
-    "Scotland/CVR8617/2020" : "2020-12-27", #delta
-    "Slovenia/08-082640-MB/2020" : "2020-11-02", #delta
-    "Slovenia/08-113788-MB/2020" : "2020-11-23", #delta
-    "Slovenia/08-134502-MB/2020" : "2020-12-04", #delta
-    "Slovenia/17-047667-CE/2020" : "2020-11-13", #delta
-    "Slovenia/17-073336-CE/2020" : "2020-12-31", #delta
-    "Slovenia/251283/2020" : "2020-12-04", #delta
-    "SouthAfrica/NICD-N19840/2020" : "2020-07-07", #delta
-    "SouthAfrica/NICD-N19863/2020" : "2020-06-26", #delta
-    "Spain/CT-HUGTiPM043JX9G11/2020" : "2020-11-03", #delta
-    "Spain/MD-HRYC-1052050/2020" : "2020-11-18", #delta
-    "Sweden/10097141/2020" : "2020-11-19", #delta
-    "USA/CA-CDPH-MC2409222/2020" : "2020-10-10", #delta
-    "USA/CA-LACPHL-AF03229/2020" : "2020-08-12", #delta
-    "USA/CA-SEARCH-109796/2020" : "2020-08-31", #delta
-    "USA/MD-HP20064-PIDZAEYGDO/2020" : "2020-11-03", #delta
-    "USA/ND-NDDH-4397/2020" : "2020-09-09", #delta
-    "USA/NY-NYCPHL-005674/2020" : "2020-11-20", #delta
-    "USA/NY-WMC2021-152/2020" : "2020-03-12", #delta
-    "USA/TX-HHD-210729KVI6183/2020" : "2020-12-26", #delta
-    "USA/TX-HMH-MCoV-48794/2020" : "2020-07-15", #delta
-    "USA/TX-HMH-MCoV-49501/2020" : "2020-07-13", #delta
-    "USA/TX-HMH-MCoV-49803/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49806/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49808/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49809/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49814/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49815/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49816/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49817/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49827/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49831/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49836/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49838/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49840/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49841/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49851/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49852/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49854/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49855/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49859/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49862/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49866/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49873/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49874/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49876/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49878/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49880/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49881/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49883/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49888/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49889/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49892/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49894/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49896/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49898/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49899/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49901/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49905/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49911/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49913/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49915/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49917/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49919/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49920/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49922/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49923/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49924/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49925/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49928/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49930/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49933/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49935/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49937/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49938/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49939/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49946/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49948/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49951/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49953/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49958/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49959/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49963/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49966/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49969/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49973/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49975/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49976/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49978/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49982/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49984/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49985/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49988/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49989/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49994/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50010/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50013/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50024/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50028/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50034/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50045/2020" : "2020-07-15", #delta
-    "USA/TX-HMH-MCoV-50046/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50048/2020" : "2020-07-20", #delta
-    "USA/TX-HMH-MCoV-50050/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50067/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50068/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50082/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50084/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-50486/2020" : "2020-07-17", #delta
-    "USA/TX-HMH-MCoV-50493/2020" : "2020-07-17", #delta
-    "USA/TX-HMH-MCoV-50501/2020" : "2020-07-17", #delta
-    "USA/TX-HMH-MCoV-50519/2020" : "2020-07-17", #delta
-    "USA/TX-HMH-MCoV-50545/2020" : "2020-07-17", #delta
-    "USA/TX-HMH-MCoV-50566/2020" : "2020-07-17", #delta
-    "USA/TX-HMH-MCoV-49945/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49931/2020" : "2020-07-16", #delta
-    "USA/TX-HMH-MCoV-49934/2020" : "2020-07-16", #delta
-    "USA/TX-Noblis-S709B19/2020" : "2020-12-03", #delta
-    "USA/TX-Noblis-S710B20/2020" : "2020-12-03", #delta
-    "USA/TX-HMH-MCoV-48613/2020" : "2020-07-14", #delta
-    "USA/NM-UNM-TC222973/2020" : "2020-08-20", #delta
-    "Slovenia/147626/2020" : "2020-10-21", #delta
-    "USA/UT-UPHL-210729652440/2020" : "2020-12-16", #delta
-    "USA/VI-Yale-10210/2020" : "2020-08-21", #delta
-    "USA/VI-Yale-10211/2020" : "2020-08-21", #delta
-    "USA/WV-WVU-WV121217/2020" : "2020-07-21", #delta
-    "USA/WY-WYPHL-20167074/2020" : "2020-12-16", #delta
-    "USA/WY-WYPHL-21070660/2020" : "2020-09-02", #delta
-    "Australia/NSW-R0499/2021" : "2021-02-07", #delta
-    "Australia/NSW-R0501/2021" : "2021-02-07", #delta
-    "Australia/NSW-R0503/2021" : "2021-02-07", #delta
-    "Australia/NSW-R0504/2021" : "2021-02-07", #delta
-    "Australia/NSW-R0509/2021" : "2021-02-07", #delta
-    "Australia/VIC18503/2021" : "2021-02-08", #delta
-    "Belize/CML-101/2021" : "2021-01-07", #delta
-    "Belize/CML-102/2021" : "2021-01-07", #delta
-    "Belize/CML-92/2021" : "2021-02-07", #delta
-    "Canada/QC-1nEAQ-0667616/2021" : "2021-01-26", #delta
-    "CzechRepublic/CSQ1259/2021" : "2021-01-28", #delta
-    "CzechRepublic/NRL_10092/2021" : "2021-02-12", #delta
-    "CzechRepublic/NRL_13299/2021" : "2021-02-08", #delta
-    "CzechRepublic/NRL_13887/2021" : "2021-02-24", #delta
-    "CzechRepublic/NRL_9986/2021" : "2021-02-11", #delta
-    "England/LOND-13670C5/2021" : "2021-02-17", #delta
-    "England/LOND-13679CA/2021" : "2021-02-19", #delta
-    "England/NEWC-2729532/2021" : "2021-01-09", #delta
-    "England/NORT-1BF0F53/2021" : "2021-01-21", #delta
-    "England/NORT-1BF4BE2/2021" : "2021-01-24", #delta
-    "England/NORT-1BF6E50/2021" : "2021-01-27", #delta
-    "England/NORT-1BF71A1/2021" : "2021-01-29", #delta
-    "England/NORT-YYBGBS/2021" : "2021-01-26", #delta
-    "England/NORT-YYBI4W/2021" : "2021-02-27", #delta
-    "England/NORW-13F3969/2021" : "2021-02-20", #delta
-    "England/NORW-13F67E4/2021" : "2021-01-22", #delta
-    "England/NORW-13F8560/2021" : "2021-02-27", #delta
-    "England/NORW-306189D/2021" : "2021-02-09", #delta
-    "England/NORW-3079BFC/2021" : "2021-01-14", #delta
-    "England/NORW-30902CC/2021" : "2021-01-21", #delta
-    "England/NORW-309F9F0/2021" : "2021-02-04", #delta
-    "England/NORW-30A0375/2021" : "2021-02-04", #delta
-    "England/PHEC-3504B7/2021" : "2021-01-27", #delta
-    "England/PHEP-006474/2021" : "2021-02-06", #delta
-    "England/PHEP-262264/2021" : "2021-01-11", #delta
-    "Ethiopia/CERI-KRISP-K025808/2021" : "2021-02-11", #delta
-    "France/BFC-HMN-21082040163/2021" : "2021-02-27", #delta
-    "France/GES-HCL0211536735/2021" : "2021-01-16", #delta
-    "Gambia/PF0203/2021" : "2021-02-08", #delta
-    "Gambia/PF6266/2021" : "2021-02-08", #delta
-    "Germany/BW-RKI-I-184553/2021" : "2021-02-07", #delta
-    "Germany/BW-RKI-I-268125/2021" : "2021-02-21", #delta
-    "Germany/BY-MVP-000008310/2021" : "2021-01-16", #delta
-    "Germany/BY-MVP-000008357/2021" : "2021-01-18", #delta
-    "Germany/BY-MVP-000008382/2021" : "2021-01-24", #delta
-    "Germany/BY-MVP-000008450/2021" : "2021-01-24", #delta
-    "Germany/BY-MVP-000008452/2021" : "2021-01-23", #delta
-    "Indonesia/JA-GS-EIJK-RSRM-0203/2021" : "2021-02-01", #delta
-    "Indonesia/JK-NIHRD-WGS00007/2021" : "2021-01-07", #delta
-    "Indonesia/SS-NIHRD-WGS002218/2021" : "2021-01-15", #delta
-    "Indonesia/SS-NIHRD-WGS00441/2021" : "2021-01-08", #delta
-    "Indonesia/SS-NIHRD-WGS00445/2021" : "2021-01-12", #delta
-    "Israel/CVL-22307/2021" : "2021-01-30", #delta
-    "Israel/CVL-22309/2021" : "2021-01-02", #delta
-    "Israel/CVL-22311/2021" : "2021-01-07", #delta
-    "Israel/CVL-22314/2021" : "2021-01-09", #delta
-    "Israel/CVL-22316/2021" : "2021-01-08", #delta
-    "Israel/CVL-22319/2021" : "2021-01-03", #delta
-    "Italy/SIC_CQRC_2726144/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2726239/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2726263/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2727245/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2727475/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2727482/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2727983/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2728951/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2729676/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2731727/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2736383/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2737746/2021" : "2021-01-11", #delta
-    "Italy/SIC_CQRC_2737781/2021" : "2021-01-11", #delta
-    "Italy/TUS-AOUC-40/2021" : "2021-01-24", #delta
-    "Kenya/ILRI_COVM01044/2021" : "2021-01-07", #delta
-    "Kenya/ILRI_COVM01048/2021" : "2021-01-07", #delta
-    "Kenya/ILRI_COVM01050/2021" : "2021-01-07", #delta
-    "Kenya/ILRI_COVM01069/2021" : "2021-01-07", #delta
-    "Kenya/ILRI_COVM01233/2021" : "2021-01-21", #delta
-    "Kenya/ILRI_COVM01347/2021" : "2021-01-09", #delta
-    "Kenya/SS1398/2021" : "2021-02-08", #delta
-    "Kenya/SS1399/2021" : "2021-02-08", #delta
-    "Malaysia/UNIMAS-GHML323/2021" : "2021-02-09", #delta
-    "Malaysia/UNIMAS-GHML325/2021" : "2021-02-09", #delta
-    "Mexico/AGU_InDRE_FB29455_S6243/2021" : "2021-01-27", #delta
-    "Mexico/BCN-SEARCH-104131/2021" : "2021-02-04", #delta
-    "Mexico/CMX-InDRE_FD78180_S4428/2021" : "2021-02-26", #delta
-    "Mexico/MOR_IBT_SSMor_11/2021" : "2021-01-21", #delta
-    "Mexico/MOR_IBT_SSMor_12/2021" : "2021-01-21", #delta
-    "Monaco/IPP14905/2021" : "2021-02-22", #delta
-    "Norway/24584/2021" : "2021-01-21", #delta
-    "Poland/WSSEGorzow-21S0298/2021" : "2021-01-09", #delta
-    "Russia/MOS-CRIE-L106A0093ubh/2021" : "2021-02-28", #delta
-    "Rwanda/CV2199/2021" : "2021-02-24", #delta
-    "Rwanda/CV2200/2021" : "2021-01-29", #delta
-    "Rwanda/CV2226/2021" : "2021-01-27", #delta
-    "Scotland/CVR7911/2021" : "2021-02-18", #delta
-    "Singapore/1444nan/2021" : "2021-02-06", #delta
-    "Slovakia/UVZ_PL36_A4_17796/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_A5_17804/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_A6_17812/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_B10_17961/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_B11_17969/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_B3_17789/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_B4_17797/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_B6_17813/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_B7_17907/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_C3_17790/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_C5_17806/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_C6_17814/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_C7_17910/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_D11_17986/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_D3_17791/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_D4_17799/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_D5_17807/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_D6_17815/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_D7_17911/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_D9_17955/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_E11_17987/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_E2_17784/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_E3_17792/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_E4_17800/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_E5_17808/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_E7_17913/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_E9_17956/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_F11_17988/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_F2_17785/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_F3_17793/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_F4_17801/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_F5_17809/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_F6_17903/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_F7_17921/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_F9_17957/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_G10_17966/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_G11_17989/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_G2_17786/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_G3_17794/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_G4_17802/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_G5_17810/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_G6_17904/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_G9_17958/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_H2_17787/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_H3_17795/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_H4_17803/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL36_H5_17811/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_H6_17905/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL36_H9_17959/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL37_A2_18007/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL37_A8_18061/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL37_B8_18062/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL37_C8_18063/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL37_D8_18064/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL37_E1_18003/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL37_E8_18065/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL37_F1_18004/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL37_F7_18058/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL37_F8_18066/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL37_G1_18005/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL37_G7_18059/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL37_G8_18067/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL37_H7_18060/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL37_H8_18068/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL40_A3_19181/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL40_B3_19182/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL40_C4_18365/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL40_E11_18455/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL40_F11_18456/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL40_F8_18400/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL40_F9_18440/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL40_G2_19179/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL40_G4_18369/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL40_H2_19180/2021" : "2021-02-09", #delta
-    "Slovakia/UVZ_PL46_A11_19348/2021" : "2021-01-09", #delta
-    "Slovakia/UVZ_PL46_C11_19350/2021" : "2021-01-09", #delta
-    "Spain/CT-LabRefCat-751420/2021" : "2021-01-29", #delta
-    "Spain/MD-HGUGM-5702992/2021" : "2021-02-09", #delta
-    "Switzerland/AG-UHB-43144757/2021" : "2021-01-02", #delta
-    "Switzerland/BE-IFIK-210906_os-89/2021" : "2021-01-08", #delta
-    "Switzerland/BE-UHB-43000628/2021" : "2021-02-13", #delta
-    "Switzerland/GE-HUG-35467598/2021" : "2021-02-11", #delta
-    "Switzerland/LU-UHB-43144767/2021" : "2021-01-02", #delta
-    "Thailand/DMSc-02063/2021" : "2021-01-09", #delta
-    "Thailand/DMSc-02065/2021" : "2021-01-09", #delta
-    "Thailand/DMSc-02067/2021" : "2021-01-09", #delta
-    "Timor-Leste/TL1011/2021" : "2021-01-08", #delta
-    "Timor-Leste/TL1013/2021" : "2021-02-08", #delta
-    "Timor-Leste/TL1015/2021" : "2021-02-08", #delta
-    "Timor-Leste/TL1017/2021" : "2021-02-08", #delta
-    "Timor-Leste/TL979/2021" : "2021-01-08", #delta
-    "Timor-Leste/TL981/2021" : "2021-01-08", #delta
-    "Timor-Leste/TL983/2021" : "2021-01-08", #delta
-    "Timor-Leste/TL985/2021" : "2021-01-08", #delta
-    "Timor-Leste/TL987/2021" : "2021-01-08", #delta
-    "USA/AZ-ASU10204/2021" : "2021-01-30", #delta
-    "USA/AZ-ASU19232/2021" : "2021-02-01", #delta
-    "USA/AZ-ASU7883/2021" : "2021-02-09", #delta
-    "USA/AZ-ASU7899/2021" : "2021-02-10", #delta
-    "USA/CA-ACPHD-00570/2021" : "2021-01-24", #delta
-    "USA/CA-CDPH-UCSF-CC100/2021" : "2021-02-04", #delta
-    "USA/FL-BPHL-8934/2021" : "2021-01-14", #delta
-    "USA/IA-SHL-1780926/2021" : "2021-02-08", #delta
-    "USA/ID-IBL-759328/2021" : "2021-01-02", #delta
-    "USA/ID-IBL-760105/2021" : "2021-02-23", #delta
-    "USA/ID-IBL-760128/2021" : "2021-01-02", #delta
-    "USA/ID-IBL-771950/2021" : "2021-01-10", #delta
-    "USA/IL-S21WGS5409/2021" : "2021-01-10", #delta
-    "USA/KS-KHEL-6411/2021" : "2021-01-15", #delta
-    "USA/NV-NSPHL-392347/2021" : "2021-02-03", #delta
-    "USA/TN-SPHL-0094/2021" : "2021-01-19", #delta
-    "USA/TN-SPHL-0261/2021" : "2021-02-24", #delta
-    "USA/TN-SPHL-0517/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0539/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0587/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0588/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0606/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0610/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0617/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0622/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0749/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0750/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0788/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0800/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0805/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0861/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0953/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0961/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0964/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0967/2021" : "2021-01-14", #delta
-    "USA/TN-SPHL-0979/2021" : "2021-01-14", #delta
-    "USA/UT-UPHL-210624251315/2021" : "2021-01-04", #delta
-    "USA/UT-UPHL-210624490751/2021" : "2021-01-04", #delta
-    "USA/UT-UPHL-210723256386/2021" : "2021-01-05", #delta
-    "env/Austria/CeMM18535/2021" : "2021-01-17", #delta
-    "USA/TX-HMH-MCoV-40891/2020" : "2020-07-22", #alpha
-    "USA/TX-HMH-MCoV-40953/2020" : "2020-07-22", #alpha
-    "USA/TX-HMH-MCoV-50516/2020" : "2020-07-18", #delta
-    "USA/TX-HMH-MCoV-49926/2020" : "2020-07-16", #delta
-    "SouthAfrica/NHLS-UCT-GP-M115/2021" : "2021-06-17", #omicron
-    "SouthAfrica/NHLS-UCT-GP-M140/2021" : "2021-06-18", #omicron
-    "Kenya/K15865/2020" : "2020-06-23", #kappa
-    "USA/WY-WYPHL-20125142/2020" : "2020-11-07", #delta
-    "USA/WY-WYPHL-20133773/2020" : "2020-11-12", #delta
-    "USA/TX-HMH-MCoV-50548/2020" : "2020-07-17", #delta
-    "Canada/QC-1nIEOQ-15782162/2020" : "2020-06-02", #alpha
-    "Canada/QC-1nIUM-T5101165/2020" : "2020-07-10", #alpha
-    "Canada/QC-1nMCY-S1130690/2020" : "2020-05-13", #alpha
-    "Canada/QC-1nMCY-S1142592/2020" : "2020-05-14", #alpha
-    "Canada/QC-1nMCY-S1180495/2020" : "2020-05-18", #alpha
-    "Canada/QC-1nIOU-98053431/2020" : "2020-06-05", #EU2
-    "USA/TX-HMH-MCoV-44786/2020" : "2020-07-27", #alpha
-    "USA/TX-HMH-MCoV-45577/2020" : "2020-07-30", #alpha
-    "USA/TX-HMH-MCoV-50489/2020" : "2020-07-18", #delta
-    "USA/TX-HMH-MCoV-49627/2020" : "2020-07-13", #delta
-    "USA/TX-HMH-MCoV-50577/2020" : "2020-07-17", #delta
-    "Belgium/rega-0912938/2020" : "2020-09-12", #delta
-    "USA/LA-FUS0021A33/2020" : "2020-05-12", #delta
-    "USA/CA-SEARCH-58495/2020" : "2020-10-06", #delta
-    "USA/CA-SEARCH-58338/2020" : "2020-01-26", #epsilon
-    "USA/TX-HMH-MCoV-50023/2020" : "2020-07-16", #delta
-
-    #Omicron with bad dates
-    "Italy/LOM_Policlinico_Milano_18972196/2021" : "2021-10-13", #omicron
-    "Italy/LOM_Policlinico_Milano_18972245/2021" : "2021-10-13", #omicron
+    "Australia/VIC18503/2021": "2021-02-08",  # delta
+    "Belize/CML-101/2021": "2021-01-07",  # delta
+    "Belize/CML-102/2021": "2021-01-07",  # delta
+    "Belize/CML-92/2021": "2021-02-07",  # delta
+    "Canada/QC-1nEAQ-0667616/2021": "2021-01-26",  # delta
+    "CzechRepublic/CSQ1259/2021": "2021-01-28",  # delta
+    "CzechRepublic/NRL_10092/2021": "2021-02-12",  # delta
+    "CzechRepublic/NRL_13299/2021": "2021-02-08",  # delta
+    "CzechRepublic/NRL_13887/2021": "2021-02-24",  # delta
+    "CzechRepublic/NRL_9986/2021": "2021-02-11",  # delta
+    "England/LOND-13670C5/2021": "2021-02-17",  # delta
+    "England/LOND-13679CA/2021": "2021-02-19",  # delta
+    "England/NEWC-2729532/2021": "2021-01-09",  # delta
+    "England/NORT-1BF0F53/2021": "2021-01-21",  # delta
+    "England/NORT-1BF4BE2/2021": "2021-01-24",  # delta
+    "England/NORT-1BF6E50/2021": "2021-01-27",  # delta
+    "England/NORT-1BF71A1/2021": "2021-01-29",  # delta
+    "England/NORT-YYBGBS/2021": "2021-01-26",  # delta
+    "England/NORT-YYBI4W/2021": "2021-02-27",  # delta
+    "England/NORT-YYWTNN/2021": "2021-01-01",  # delta
+    "England/NORW-13F3969/2021": "2021-02-20",  # delta
+    "England/NORW-13F67E4/2021": "2021-01-22",  # delta
+    "England/NORW-13F8560/2021": "2021-02-27",  # delta
+    "England/NORW-306189D/2021": "2021-02-09",  # delta
+    "England/NORW-3079BFC/2021": "2021-01-14",  # delta
+    "England/NORW-30902CC/2021": "2021-01-21",  # delta
+    "England/NORW-309F9F0/2021": "2021-02-04",  # delta
+    "England/NORW-30A0375/2021": "2021-02-04",  # delta
+    "England/PHEC-3504B7/2021": "2021-01-27",  # delta
+    "England/PHEP-006474/2021": "2021-02-06",  # delta
+    "England/PHEP-262264/2021": "2021-01-11",  # delta
+    "Ethiopia/CERI-KRISP-K025808/2021": "2021-02-11",  # delta
+    "France/BFC-HMN-21082040163/2021": "2021-02-27",  # delta
+    "France/GES-HCL0211536735/2021": "2021-01-16",  # delta
+    "Gambia/PF0203/2021": "2021-02-08",  # delta
+    "Gambia/PF6266/2021": "2021-02-08",  # delta
+    "Indonesia/JA-GS-EIJK-RSRM-0203/2021": "2021-02-01",  # delta
+    "Indonesia/JK-NIHRD-WGS00007/2021": "2021-01-07",  # delta
+    "Indonesia/KS-NIHRD-WGS12290/2021": "2021-01-09",  # delta
+    "Indonesia/KS-NIHRD-WGS12291/2021": "2021-01-09",  # delta
+    "Indonesia/KS-NIHRD-WGS12292/2021": "2021-02-09",  # delta
+    "Indonesia/SS-NIHRD-WGS002218/2021": "2021-01-15",  # delta
+    "Indonesia/SS-NIHRD-WGS00441/2021": "2021-01-08",  # delta
+    "Indonesia/SS-NIHRD-WGS00445/2021": "2021-01-12",  # delta
+    "Israel/CVL-22307/2021": "2021-01-30",  # delta
+    "Israel/CVL-22309/2021": "2021-01-02",  # delta
+    "Israel/CVL-22311/2021": "2021-01-07",  # delta
+    "Israel/CVL-22314/2021": "2021-01-09",  # delta
+    "Israel/CVL-22316/2021": "2021-01-08",  # delta
+    "Israel/CVL-22319/2021": "2021-01-03",  # delta
+    "Italy/SIC_CQRC_2726144/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2726239/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2726263/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2727245/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2727475/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2727482/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2727983/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2728951/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2729676/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2731727/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2736383/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2737746/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2737781/2021": "2021-01-11",  # delta
+    "Italy/TUS-AOUC-40/2021": "2021-01-24",  # delta
+    "Kenya/ILRI_COVM01044/2021": "2021-01-07",  # delta
+    "Kenya/ILRI_COVM01048/2021": "2021-01-07",  # delta
+    "Kenya/ILRI_COVM01050/2021": "2021-01-07",  # delta
+    "Kenya/ILRI_COVM01069/2021": "2021-01-07",  # delta
+    "Kenya/ILRI_COVM01233/2021": "2021-01-21",  # delta
+    "Kenya/ILRI_COVM01347/2021": "2021-01-09",  # delta
+    "Kenya/SS1398/2021": "2021-02-08",  # delta
+    "Kenya/SS1399/2021": "2021-02-08",  # delta
+    "Malaysia/UNIMAS-GHML323/2021": "2021-02-09",  # delta
+    "Malaysia/UNIMAS-GHML324/2021": "2021-02-09",  # delta
+    "Malaysia/UNIMAS-GHML325/2021": "2021-02-09",  # delta
+    "Malaysia/UNIMAS-GHML326/2021": "2021-02-09",  # delta
+    "Malaysia/UNIMAS-GHML327/2021": "2021-02-09",  # delta
+    "Malaysia/UNIMAS-GHML328/2021": "2021-02-09",  # delta
+    "Mexico/AGU_InDRE_FB29455_S6243/2021": "2021-01-27",  # delta
+    "Mexico/BCN-SEARCH-104131/2021": "2021-02-04",  # delta
+    "Mexico/CMX-InDRE_FD78180_S4428/2021": "2021-02-26",  # delta
+    "Mexico/MOR_IBT_SSMor_11/2021": "2021-01-21",  # delta
+    "Mexico/MOR_IBT_SSMor_12/2021": "2021-01-21",  # delta
+    "Monaco/IPP14905/2021": "2021-02-22",  # delta
+    "Norway/24584/2021": "2021-01-21",  # delta
+    "Norway/26496/2021": "2021-01-11",  # delta
+    "Oman/rega-OM-232/2021": "2021-02-06",  # delta
+    "Oman/rega-OM-89/2021": "2021-01-06",  # delta
+    "Oman/rega-OM-90/2021": "2021-01-06",  # delta
+    "Oman/rega-OM-91/2021": "2021-01-06",  # delta
+    "Poland/WSSEGorzow-21S0298/2021": "2021-01-09",  # delta
+    "Russia/MOS-CRIE-L106A0093ubh/2021": "2021-02-28",  # delta
+    "Rwanda/CV2199/2021": "2021-02-24",  # delta
+    "Rwanda/CV2200/2021": "2021-01-29",  # delta
+    "Rwanda/CV2226/2021": "2021-01-27",  # delta
+    "Scotland/CVR7911/2021": "2021-02-18",  # delta
+    "Singapore/1444nan/2021": "2021-02-06",  # delta
+    "Slovakia/UVZ_PL36_A4_17796/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_A5_17804/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_A6_17812/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_B10_17961/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_B11_17969/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_B3_17789/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_B4_17797/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_B6_17813/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_B7_17907/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_C3_17790/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_C5_17806/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_C6_17814/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_C7_17910/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_D11_17986/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_D3_17791/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_D4_17799/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_D5_17807/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_D6_17815/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_D7_17911/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_D9_17955/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_E11_17987/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_E2_17784/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_E3_17792/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_E4_17800/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_E5_17808/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_E7_17913/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_E9_17956/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_F11_17988/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_F2_17785/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_F3_17793/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_F4_17801/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_F5_17809/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_F6_17903/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_F7_17921/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_F9_17957/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_G10_17966/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_G11_17989/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_G2_17786/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_G3_17794/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_G4_17802/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_G5_17810/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_G6_17904/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_G9_17958/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_H2_17787/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_H3_17795/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_H4_17803/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_H5_17811/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_H6_17905/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_H9_17959/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL37_A2_18007/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL37_A8_18061/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL37_B8_18062/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL37_C8_18063/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL37_D8_18064/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL37_E1_18003/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL37_E8_18065/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL37_F1_18004/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL37_F7_18058/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL37_F8_18066/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL37_G1_18005/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL37_G7_18059/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL37_G8_18067/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL37_H7_18060/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL37_H8_18068/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL40_A3_19181/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL40_B3_19182/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL40_C4_18365/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL40_E11_18455/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL40_F11_18456/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL40_F8_18400/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL40_F9_18440/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL40_G2_19179/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL40_G4_18369/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL40_H2_19180/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL46_A11_19348/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL46_C11_19350/2021": "2021-01-09",  # delta
+    "Slovenia/08-006923-MB/2021": "2021-01-07",  # delta
+    "SouthAfrica/NICD-N15251/2021": "2021-01-19",  # delta
+    "SouthAfrica/NICD-N16641/2021": "2021-02-26",  # delta
+    "SouthAfrica/NICD-N9212/2021": "2021-01-12",  # delta
+    "SouthAfrica/NICD-R11251/2021": "2021-01-28",  # delta
+    "Spain/CT-LabRefCat-751420/2021": "2021-01-29",  # delta
+    "Spain/MD-HGUGM-5702992/2021": "2021-02-09",  # delta
+    "Switzerland/AG-UHB-43144757/2021": "2021-01-02",  # delta
+    "Switzerland/BE-IFIK-210906_os-89/2021": "2021-01-08",  # delta
+    "Switzerland/BE-UHB-43000628/2021": "2021-02-13",  # delta
+    "Switzerland/GE-HUG-35467598/2021": "2021-02-11",  # delta
+    "Switzerland/LU-UHB-43144767/2021": "2021-01-02",  # delta
+    "Thailand/DMSc-02063/2021": "2021-01-09",  # delta
+    "Thailand/DMSc-02065/2021": "2021-01-09",  # delta
+    "Thailand/DMSc-02067/2021": "2021-01-09",  # delta
+    "Timor-Leste/TL1011/2021": "2021-01-08",  # delta
+    "Timor-Leste/TL1013/2021": "2021-02-08",  # delta
+    "Timor-Leste/TL1015/2021": "2021-02-08",  # delta
+    "Timor-Leste/TL1017/2021": "2021-02-08",  # delta
+    "Timor-Leste/TL979/2021": "2021-01-08",  # delta
+    "Timor-Leste/TL981/2021": "2021-01-08",  # delta
+    "Timor-Leste/TL983/2021": "2021-01-08",  # delta
+    "Timor-Leste/TL985/2021": "2021-01-08",  # delta
+    "Timor-Leste/TL987/2021": "2021-01-08",  # delta
+    "USA/AZ-ASU10204/2021": "2021-01-30",  # delta
+    "USA/AZ-ASU19232/2021": "2021-02-01",  # delta
+    "USA/AZ-ASU7883/2021": "2021-02-09",  # delta
+    "USA/AZ-ASU7899/2021": "2021-02-10",  # delta
+    "USA/CA-ACPHD-00570/2021": "2021-01-24",  # delta
+    "USA/CA-CDPH-UCSF-CC100/2021": "2021-02-04",  # delta
+    "USA/FL-BPHL-8934/2021": "2021-01-14",  # delta
+    "USA/IA-SHL-1780926/2021": "2021-02-08",  # delta
+    "USA/ID-IBL-759328/2021": "2021-01-02",  # delta
+    "USA/ID-IBL-760105/2021": "2021-02-23",  # delta
+    "USA/ID-IBL-760128/2021": "2021-01-02",  # delta
+    "USA/ID-IBL-771950/2021": "2021-01-10",  # delta
+    "USA/IL-S21WGS5409/2021": "2021-01-10",  # delta
+    "USA/KS-KHEL-6411/2021": "2021-01-15",  # delta
+    "USA/NV-NSPHL-392347/2021": "2021-02-03",  # delta
+    "USA/TN-SPHL-0094/2021": "2021-01-19",  # delta
+    "USA/TN-SPHL-0261/2021": "2021-02-24",  # delta
+    "USA/TN-SPHL-0517/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0539/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0587/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0588/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0606/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0610/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0617/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0622/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0749/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0750/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0788/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0800/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0805/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0861/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0953/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0961/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0964/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0967/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0979/2021": "2021-01-14",  # delta
+    "USA/UT-UPHL-210624251315/2021": "2021-01-04",  # delta
+    "USA/UT-UPHL-210624490751/2021": "2021-01-04",  # delta
+    "USA/UT-UPHL-210723256386/2021": "2021-01-05",  # delta
+    "USA/WA-PHL-006485/2021": "2021-01-06",  # delta
+    "env/Austria/CeMM18535/2021": "2021-01-17",  # delta
+    "BurkinaFaso/CV1847/2020": "2020-12-18",  # delta
+    "BurkinaFaso/CV1908/2020": "2020-12-07",  # delta
+    "BurkinaFaso/CV1909/2020": "2020-12-03",  # delta
+    "BurkinaFaso/CV1910/2020": "2020-12-03",  # delta
+    "BurkinaFaso/CV1911/2020": "2020-12-03",  # delta
+    "BurkinaFaso/CV1920/2020": "2020-09-16",  # delta
+    "BurkinaFaso/CV1921/2020": "2020-09-18",  # delta
+    "BurkinaFaso/CV1922/2020": "2020-12-21",  # delta
+    "BurkinaFaso/CV1923/2020": "2020-12-21",  # delta
+    "BurkinaFaso/CV1943/2020": "2020-12-08",  # delta
+    "BurkinaFaso/CV1944/2020": "2020-12-18",  # delta
+    "BurkinaFaso/CV1945/2020": "2020-12-18",  # delta
+    "BurkinaFaso/CV1946/2020": "2020-12-18",  # delta
+    "BurkinaFaso/CV1947/2020": "2020-12-18",  # delta
+    "BurkinaFaso/CV1955/2020": "2020-12-27",  # delta
+    "BurkinaFaso/CV1956/2020": "2020-12-27",  # delta
+    "BurkinaFaso/CV1957/2020": "2020-12-17",  # delta
+    "Canada/QC-1nMCY-S6293264/2020": "2020-10-29",  # delta
+    "England/MILK-18DD450/2020": "2020-11-04",  # delta
+    "England/NORT-YYNW7P/2020": "2020-10-27",  # delta
+    "England/NORW-30146BA/2020": "2020-11-15",  # delta
+    "England/PHEP-YYBYUTJ/2020": "2020-08-03",  # delta
+    "Fiji/FJ493/2020": "2020-08-25",  # delta
+    "Indonesia/JA-GS-EIJK-RSRM-0168/2020": "2020-07-29",  # delta
+    "Indonesia/JA-GS-EIJK-RSRM-0169/2020": "2020-07-29",  # delta
+    "Indonesia/JA-GS-EIJK-RSRM-0170/2020": "2020-07-29",  # delta
+    "Indonesia/JA-GS-EIJK-RSRM-0172/2020": "2020-07-29",  # delta
+    "Indonesia/JA-GS-EIJK-RSRM-0200/2020": "2020-07-29",  # delta
+    "Mexico/AGU-InDRE_FB18599_S4467/2020": "2020-09-22",  # delta
+    "PapuaNewGuinea/PNG4040/2020": "2020-08-01",  # delta
+    "Rwanda/CV2197/2020": "2020-09-10",  # delta
+    "Rwanda/CV2223/2020": "2020-12-21",  # delta
+    "Scotland/CVR8617/2020": "2020-12-27",  # delta
+    "Slovenia/08-082640-MB/2020": "2020-11-02",  # delta
+    "Slovenia/08-113788-MB/2020": "2020-11-23",  # delta
+    "Slovenia/08-134502-MB/2020": "2020-12-04",  # delta
+    "Slovenia/17-047667-CE/2020": "2020-11-13",  # delta
+    "Slovenia/17-073336-CE/2020": "2020-12-31",  # delta
+    "Slovenia/251283/2020": "2020-12-04",  # delta
+    "SouthAfrica/NICD-N19840/2020": "2020-07-07",  # delta
+    "SouthAfrica/NICD-N19863/2020": "2020-06-26",  # delta
+    "Spain/CT-HUGTiPM043JX9G11/2020": "2020-11-03",  # delta
+    "Spain/MD-HRYC-1052050/2020": "2020-11-18",  # delta
+    "Sweden/10097141/2020": "2020-11-19",  # delta
+    "USA/CA-CDPH-MC2409222/2020": "2020-10-10",  # delta
+    "USA/CA-LACPHL-AF03229/2020": "2020-08-12",  # delta
+    "USA/CA-SEARCH-109796/2020": "2020-08-31",  # delta
+    "USA/MD-HP20064-PIDZAEYGDO/2020": "2020-11-03",  # delta
+    "USA/ND-NDDH-4397/2020": "2020-09-09",  # delta
+    "USA/NY-NYCPHL-005674/2020": "2020-11-20",  # delta
+    "USA/NY-WMC2021-152/2020": "2020-03-12",  # delta
+    "USA/TX-HHD-210729KVI6183/2020": "2020-12-26",  # delta
+    "USA/TX-HMH-MCoV-48794/2020": "2020-07-15",  # delta
+    "USA/TX-HMH-MCoV-49501/2020": "2020-07-13",  # delta
+    "USA/TX-HMH-MCoV-49803/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49806/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49808/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49809/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49814/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49815/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49816/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49817/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49827/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49831/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49836/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49838/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49840/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49841/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49851/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49852/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49854/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49855/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49859/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49862/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49866/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49873/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49874/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49876/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49878/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49880/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49881/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49883/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49888/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49889/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49892/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49894/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49896/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49898/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49899/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49901/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49905/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49911/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49913/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49915/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49917/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49919/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49920/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49922/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49923/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49924/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49925/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49928/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49930/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49933/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49935/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49937/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49938/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49939/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49946/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49948/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49951/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49953/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49958/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49959/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49963/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49966/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49969/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49973/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49975/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49976/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49978/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49982/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49984/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49985/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49988/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49989/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49994/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50010/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50013/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50024/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50028/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50034/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50045/2020": "2020-07-15",  # delta
+    "USA/TX-HMH-MCoV-50046/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50048/2020": "2020-07-20",  # delta
+    "USA/TX-HMH-MCoV-50050/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50067/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50068/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50082/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50084/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-50486/2020": "2020-07-17",  # delta
+    "USA/TX-HMH-MCoV-50493/2020": "2020-07-17",  # delta
+    "USA/TX-HMH-MCoV-50501/2020": "2020-07-17",  # delta
+    "USA/TX-HMH-MCoV-50519/2020": "2020-07-17",  # delta
+    "USA/TX-HMH-MCoV-50545/2020": "2020-07-17",  # delta
+    "USA/TX-HMH-MCoV-50566/2020": "2020-07-17",  # delta
+    "USA/TX-HMH-MCoV-49945/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49931/2020": "2020-07-16",  # delta
+    "USA/TX-HMH-MCoV-49934/2020": "2020-07-16",  # delta
+    "USA/TX-Noblis-S709B19/2020": "2020-12-03",  # delta
+    "USA/TX-Noblis-S710B20/2020": "2020-12-03",  # delta
+    "USA/TX-HMH-MCoV-48613/2020": "2020-07-14",  # delta
+    "USA/NM-UNM-TC222973/2020": "2020-08-20",  # delta
+    "Slovenia/147626/2020": "2020-10-21",  # delta
+    "USA/UT-UPHL-210729652440/2020": "2020-12-16",  # delta
+    "USA/VI-Yale-10210/2020": "2020-08-21",  # delta
+    "USA/VI-Yale-10211/2020": "2020-08-21",  # delta
+    "USA/WV-WVU-WV121217/2020": "2020-07-21",  # delta
+    "USA/WY-WYPHL-20167074/2020": "2020-12-16",  # delta
+    "USA/WY-WYPHL-21070660/2020": "2020-09-02",  # delta
+    "Australia/NSW-R0499/2021": "2021-02-07",  # delta
+    "Australia/NSW-R0501/2021": "2021-02-07",  # delta
+    "Australia/NSW-R0503/2021": "2021-02-07",  # delta
+    "Australia/NSW-R0504/2021": "2021-02-07",  # delta
+    "Australia/NSW-R0509/2021": "2021-02-07",  # delta
+    "Australia/VIC18503/2021": "2021-02-08",  # delta
+    "Belize/CML-101/2021": "2021-01-07",  # delta
+    "Belize/CML-102/2021": "2021-01-07",  # delta
+    "Belize/CML-92/2021": "2021-02-07",  # delta
+    "Canada/QC-1nEAQ-0667616/2021": "2021-01-26",  # delta
+    "CzechRepublic/CSQ1259/2021": "2021-01-28",  # delta
+    "CzechRepublic/NRL_10092/2021": "2021-02-12",  # delta
+    "CzechRepublic/NRL_13299/2021": "2021-02-08",  # delta
+    "CzechRepublic/NRL_13887/2021": "2021-02-24",  # delta
+    "CzechRepublic/NRL_9986/2021": "2021-02-11",  # delta
+    "England/LOND-13670C5/2021": "2021-02-17",  # delta
+    "England/LOND-13679CA/2021": "2021-02-19",  # delta
+    "England/NEWC-2729532/2021": "2021-01-09",  # delta
+    "England/NORT-1BF0F53/2021": "2021-01-21",  # delta
+    "England/NORT-1BF4BE2/2021": "2021-01-24",  # delta
+    "England/NORT-1BF6E50/2021": "2021-01-27",  # delta
+    "England/NORT-1BF71A1/2021": "2021-01-29",  # delta
+    "England/NORT-YYBGBS/2021": "2021-01-26",  # delta
+    "England/NORT-YYBI4W/2021": "2021-02-27",  # delta
+    "England/NORW-13F3969/2021": "2021-02-20",  # delta
+    "England/NORW-13F67E4/2021": "2021-01-22",  # delta
+    "England/NORW-13F8560/2021": "2021-02-27",  # delta
+    "England/NORW-306189D/2021": "2021-02-09",  # delta
+    "England/NORW-3079BFC/2021": "2021-01-14",  # delta
+    "England/NORW-30902CC/2021": "2021-01-21",  # delta
+    "England/NORW-309F9F0/2021": "2021-02-04",  # delta
+    "England/NORW-30A0375/2021": "2021-02-04",  # delta
+    "England/PHEC-3504B7/2021": "2021-01-27",  # delta
+    "England/PHEP-006474/2021": "2021-02-06",  # delta
+    "England/PHEP-262264/2021": "2021-01-11",  # delta
+    "Ethiopia/CERI-KRISP-K025808/2021": "2021-02-11",  # delta
+    "France/BFC-HMN-21082040163/2021": "2021-02-27",  # delta
+    "France/GES-HCL0211536735/2021": "2021-01-16",  # delta
+    "Gambia/PF0203/2021": "2021-02-08",  # delta
+    "Gambia/PF6266/2021": "2021-02-08",  # delta
+    "Germany/BW-RKI-I-184553/2021": "2021-02-07",  # delta
+    "Germany/BW-RKI-I-268125/2021": "2021-02-21",  # delta
+    "Germany/BY-MVP-000008310/2021": "2021-01-16",  # delta
+    "Germany/BY-MVP-000008357/2021": "2021-01-18",  # delta
+    "Germany/BY-MVP-000008382/2021": "2021-01-24",  # delta
+    "Germany/BY-MVP-000008450/2021": "2021-01-24",  # delta
+    "Germany/BY-MVP-000008452/2021": "2021-01-23",  # delta
+    "Indonesia/JA-GS-EIJK-RSRM-0203/2021": "2021-02-01",  # delta
+    "Indonesia/JK-NIHRD-WGS00007/2021": "2021-01-07",  # delta
+    "Indonesia/SS-NIHRD-WGS002218/2021": "2021-01-15",  # delta
+    "Indonesia/SS-NIHRD-WGS00441/2021": "2021-01-08",  # delta
+    "Indonesia/SS-NIHRD-WGS00445/2021": "2021-01-12",  # delta
+    "Israel/CVL-22307/2021": "2021-01-30",  # delta
+    "Israel/CVL-22309/2021": "2021-01-02",  # delta
+    "Israel/CVL-22311/2021": "2021-01-07",  # delta
+    "Israel/CVL-22314/2021": "2021-01-09",  # delta
+    "Israel/CVL-22316/2021": "2021-01-08",  # delta
+    "Israel/CVL-22319/2021": "2021-01-03",  # delta
+    "Italy/SIC_CQRC_2726144/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2726239/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2726263/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2727245/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2727475/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2727482/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2727983/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2728951/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2729676/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2731727/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2736383/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2737746/2021": "2021-01-11",  # delta
+    "Italy/SIC_CQRC_2737781/2021": "2021-01-11",  # delta
+    "Italy/TUS-AOUC-40/2021": "2021-01-24",  # delta
+    "Kenya/ILRI_COVM01044/2021": "2021-01-07",  # delta
+    "Kenya/ILRI_COVM01048/2021": "2021-01-07",  # delta
+    "Kenya/ILRI_COVM01050/2021": "2021-01-07",  # delta
+    "Kenya/ILRI_COVM01069/2021": "2021-01-07",  # delta
+    "Kenya/ILRI_COVM01233/2021": "2021-01-21",  # delta
+    "Kenya/ILRI_COVM01347/2021": "2021-01-09",  # delta
+    "Kenya/SS1398/2021": "2021-02-08",  # delta
+    "Kenya/SS1399/2021": "2021-02-08",  # delta
+    "Malaysia/UNIMAS-GHML323/2021": "2021-02-09",  # delta
+    "Malaysia/UNIMAS-GHML325/2021": "2021-02-09",  # delta
+    "Mexico/AGU_InDRE_FB29455_S6243/2021": "2021-01-27",  # delta
+    "Mexico/BCN-SEARCH-104131/2021": "2021-02-04",  # delta
+    "Mexico/CMX-InDRE_FD78180_S4428/2021": "2021-02-26",  # delta
+    "Mexico/MOR_IBT_SSMor_11/2021": "2021-01-21",  # delta
+    "Mexico/MOR_IBT_SSMor_12/2021": "2021-01-21",  # delta
+    "Monaco/IPP14905/2021": "2021-02-22",  # delta
+    "Norway/24584/2021": "2021-01-21",  # delta
+    "Poland/WSSEGorzow-21S0298/2021": "2021-01-09",  # delta
+    "Russia/MOS-CRIE-L106A0093ubh/2021": "2021-02-28",  # delta
+    "Rwanda/CV2199/2021": "2021-02-24",  # delta
+    "Rwanda/CV2200/2021": "2021-01-29",  # delta
+    "Rwanda/CV2226/2021": "2021-01-27",  # delta
+    "Scotland/CVR7911/2021": "2021-02-18",  # delta
+    "Singapore/1444nan/2021": "2021-02-06",  # delta
+    "Slovakia/UVZ_PL36_A4_17796/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_A5_17804/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_A6_17812/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_B10_17961/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_B11_17969/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_B3_17789/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_B4_17797/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_B6_17813/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_B7_17907/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_C3_17790/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_C5_17806/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_C6_17814/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_C7_17910/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_D11_17986/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_D3_17791/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_D4_17799/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_D5_17807/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_D6_17815/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_D7_17911/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_D9_17955/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_E11_17987/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_E2_17784/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_E3_17792/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_E4_17800/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_E5_17808/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_E7_17913/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_E9_17956/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_F11_17988/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_F2_17785/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_F3_17793/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_F4_17801/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_F5_17809/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_F6_17903/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_F7_17921/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_F9_17957/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_G10_17966/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_G11_17989/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_G2_17786/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_G3_17794/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_G4_17802/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_G5_17810/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_G6_17904/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_G9_17958/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_H2_17787/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_H3_17795/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_H4_17803/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL36_H5_17811/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_H6_17905/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL36_H9_17959/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL37_A2_18007/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL37_A8_18061/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL37_B8_18062/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL37_C8_18063/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL37_D8_18064/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL37_E1_18003/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL37_E8_18065/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL37_F1_18004/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL37_F7_18058/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL37_F8_18066/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL37_G1_18005/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL37_G7_18059/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL37_G8_18067/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL37_H7_18060/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL37_H8_18068/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL40_A3_19181/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL40_B3_19182/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL40_C4_18365/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL40_E11_18455/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL40_F11_18456/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL40_F8_18400/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL40_F9_18440/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL40_G2_19179/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL40_G4_18369/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL40_H2_19180/2021": "2021-02-09",  # delta
+    "Slovakia/UVZ_PL46_A11_19348/2021": "2021-01-09",  # delta
+    "Slovakia/UVZ_PL46_C11_19350/2021": "2021-01-09",  # delta
+    "Spain/CT-LabRefCat-751420/2021": "2021-01-29",  # delta
+    "Spain/MD-HGUGM-5702992/2021": "2021-02-09",  # delta
+    "Switzerland/AG-UHB-43144757/2021": "2021-01-02",  # delta
+    "Switzerland/BE-IFIK-210906_os-89/2021": "2021-01-08",  # delta
+    "Switzerland/BE-UHB-43000628/2021": "2021-02-13",  # delta
+    "Switzerland/GE-HUG-35467598/2021": "2021-02-11",  # delta
+    "Switzerland/LU-UHB-43144767/2021": "2021-01-02",  # delta
+    "Thailand/DMSc-02063/2021": "2021-01-09",  # delta
+    "Thailand/DMSc-02065/2021": "2021-01-09",  # delta
+    "Thailand/DMSc-02067/2021": "2021-01-09",  # delta
+    "Timor-Leste/TL1011/2021": "2021-01-08",  # delta
+    "Timor-Leste/TL1013/2021": "2021-02-08",  # delta
+    "Timor-Leste/TL1015/2021": "2021-02-08",  # delta
+    "Timor-Leste/TL1017/2021": "2021-02-08",  # delta
+    "Timor-Leste/TL979/2021": "2021-01-08",  # delta
+    "Timor-Leste/TL981/2021": "2021-01-08",  # delta
+    "Timor-Leste/TL983/2021": "2021-01-08",  # delta
+    "Timor-Leste/TL985/2021": "2021-01-08",  # delta
+    "Timor-Leste/TL987/2021": "2021-01-08",  # delta
+    "USA/AZ-ASU10204/2021": "2021-01-30",  # delta
+    "USA/AZ-ASU19232/2021": "2021-02-01",  # delta
+    "USA/AZ-ASU7883/2021": "2021-02-09",  # delta
+    "USA/AZ-ASU7899/2021": "2021-02-10",  # delta
+    "USA/CA-ACPHD-00570/2021": "2021-01-24",  # delta
+    "USA/CA-CDPH-UCSF-CC100/2021": "2021-02-04",  # delta
+    "USA/FL-BPHL-8934/2021": "2021-01-14",  # delta
+    "USA/IA-SHL-1780926/2021": "2021-02-08",  # delta
+    "USA/ID-IBL-759328/2021": "2021-01-02",  # delta
+    "USA/ID-IBL-760105/2021": "2021-02-23",  # delta
+    "USA/ID-IBL-760128/2021": "2021-01-02",  # delta
+    "USA/ID-IBL-771950/2021": "2021-01-10",  # delta
+    "USA/IL-S21WGS5409/2021": "2021-01-10",  # delta
+    "USA/KS-KHEL-6411/2021": "2021-01-15",  # delta
+    "USA/NV-NSPHL-392347/2021": "2021-02-03",  # delta
+    "USA/TN-SPHL-0094/2021": "2021-01-19",  # delta
+    "USA/TN-SPHL-0261/2021": "2021-02-24",  # delta
+    "USA/TN-SPHL-0517/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0539/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0587/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0588/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0606/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0610/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0617/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0622/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0749/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0750/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0788/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0800/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0805/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0861/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0953/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0961/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0964/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0967/2021": "2021-01-14",  # delta
+    "USA/TN-SPHL-0979/2021": "2021-01-14",  # delta
+    "USA/UT-UPHL-210624251315/2021": "2021-01-04",  # delta
+    "USA/UT-UPHL-210624490751/2021": "2021-01-04",  # delta
+    "USA/UT-UPHL-210723256386/2021": "2021-01-05",  # delta
+    "env/Austria/CeMM18535/2021": "2021-01-17",  # delta
+    "USA/TX-HMH-MCoV-40891/2020": "2020-07-22",  # alpha
+    "USA/TX-HMH-MCoV-40953/2020": "2020-07-22",  # alpha
+    "USA/TX-HMH-MCoV-50516/2020": "2020-07-18",  # delta
+    "USA/TX-HMH-MCoV-49926/2020": "2020-07-16",  # delta
+    "SouthAfrica/NHLS-UCT-GP-M115/2021": "2021-06-17",  # omicron
+    "SouthAfrica/NHLS-UCT-GP-M140/2021": "2021-06-18",  # omicron
+    "Kenya/K15865/2020": "2020-06-23",  # kappa
+    "USA/WY-WYPHL-20125142/2020": "2020-11-07",  # delta
+    "USA/WY-WYPHL-20133773/2020": "2020-11-12",  # delta
+    "USA/TX-HMH-MCoV-50548/2020": "2020-07-17",  # delta
+    "Canada/QC-1nIEOQ-15782162/2020": "2020-06-02",  # alpha
+    "Canada/QC-1nIUM-T5101165/2020": "2020-07-10",  # alpha
+    "Canada/QC-1nMCY-S1130690/2020": "2020-05-13",  # alpha
+    "Canada/QC-1nMCY-S1142592/2020": "2020-05-14",  # alpha
+    "Canada/QC-1nMCY-S1180495/2020": "2020-05-18",  # alpha
+    "Canada/QC-1nIOU-98053431/2020": "2020-06-05",  # EU2
+    "USA/TX-HMH-MCoV-44786/2020": "2020-07-27",  # alpha
+    "USA/TX-HMH-MCoV-45577/2020": "2020-07-30",  # alpha
+    "USA/TX-HMH-MCoV-50489/2020": "2020-07-18",  # delta
+    "USA/TX-HMH-MCoV-49627/2020": "2020-07-13",  # delta
+    "USA/TX-HMH-MCoV-50577/2020": "2020-07-17",  # delta
+    "Belgium/rega-0912938/2020": "2020-09-12",  # delta
+    "USA/LA-FUS0021A33/2020": "2020-05-12",  # delta
+    "USA/CA-SEARCH-58495/2020": "2020-10-06",  # delta
+    "USA/CA-SEARCH-58338/2020": "2020-01-26",  # epsilon
+    "USA/TX-HMH-MCoV-50023/2020": "2020-07-16",  # delta
+    # Omicron with bad dates
+    "Italy/LOM_Policlinico_Milano_18972196/2021": "2021-10-13",  # omicron
+    "Italy/LOM_Policlinico_Milano_18972245/2021": "2021-10-13",  # omicron
     # Omicron with maybe? bad date:
-    "SouthAfrica/NICD-N01333/2021" : "2021-01-05", #omicron
-    "SouthAfrica/NICD-N22599/2021" : "2021-09-04", #omicron
-    "SouthAfrica/NICD-N22601/2021" : "2021-08-16", #omicron
-    "SouthAfrica/NICD-N22603/2021" : "2021-08-16", #omicron
-    "SouthAfrica/NICD-N22621/2021" : "2021-09-30", #omicron
-    "SouthAfrica/NICD-N22894/2021" : "2021-10-12", #omicron
-    #Omicron with very suspicous dates - month-day mixup?
-    "Brazil/SP-IAL-7587/2021" : "2021-10-12", #omicron
-    "Portugal/PT23485/2021" : "2021-02-13", #omicron
-    "Portugal/PT23486/2021" : "2021-02-13", #omicron
-    "Portugal/PT23487/2021" : "2021-02-13", #omicron
-    "Zambia/ZMB-128118/2021" : "2021-02-12", #omicron
-    "Zambia/ZMB-128132/2021" : "2021-02-12", #omicron
-    "Zambia/ZMB-128338/2021" : "2021-01-12", #omicron
-    "Zambia/ZMB-128347/2021" : "2021-02-12", #omicron
-    "Zambia/ZMB-128414/2021" : "2021-02-12", #omicron
-    "Zambia/ZMB-128476/2021" : "2021-07-12", #omicron
-    "Zambia/ZMB-128620/2021" : "2021-08-12", #omicron
-    "Zambia/ZMB-128629/2021" : "2021-06-12", #omicron
-    "Zambia/ZMB-128631/2021" : "2021-07-12", #omicron
-    "Zambia/ZMB-128632/2021" : "2021-08-12", #omicron
-    "Zambia/ZMB-128638/2021" : "2021-08-12", #omicron
-    "Zambia/ZMB-128639/2021" : "2021-09-12", #omicron
-    "Zambia/ZMB-128641/2021" : "2021-05-12", #omicron
-    "Zambia/ZMB-128642/2021" : "2021-05-12", #omicron
-    "Zambia/ZMB-128645/2021" : "2021-09-12", #omicron
-    "Zambia/ZMB-128656/2021" : "2021-09-12", #omicron
-    "Zambia/ZMB-128657/2021" : "2021-09-12", #omicron
-    "Zambia/ZMB-128678/2021" : "2021-09-12", #omicron
-    "Zambia/ZMB-128680/2021" : "2021-09-12", #omicron
-    "Zambia/ZMB-128843/2021" : "2021-07-12", #omicron
-    "Zambia/ZMB-128868/2021" : "2021-04-12", #omicron
-    "Zambia/ZMB-128870/2021" : "2021-07-12", #omicron
-    "Zambia/ZMB-128871/2021" : "2021-06-12", #omicron
-    "Zambia/ZMB-129008/2021" : "2021-10-12", #omicron
-    "Zambia/ZMB-129024/2021" : "2021-10-12", #omicron
-    "Zambia/ZMB-129057/2021" : "2021-07-12", #omicron
-    "Zambia/ZMB-129064/2021" : "2021-09-12", #omicron
-    "Zambia/ZMB-129159/2021" : "2021-10-12", #omicron
-    "Zambia/ZMB-129162/2021" : "2021-10-12", #omicron
-
+    "SouthAfrica/NICD-N01333/2021": "2021-01-05",  # omicron
+    "SouthAfrica/NICD-N22599/2021": "2021-09-04",  # omicron
+    "SouthAfrica/NICD-N22601/2021": "2021-08-16",  # omicron
+    "SouthAfrica/NICD-N22603/2021": "2021-08-16",  # omicron
+    "SouthAfrica/NICD-N22621/2021": "2021-09-30",  # omicron
+    "SouthAfrica/NICD-N22894/2021": "2021-10-12",  # omicron
+    # Omicron with very suspicous dates - month-day mixup?
+    "Brazil/SP-IAL-7587/2021": "2021-10-12",  # omicron
+    "Portugal/PT23485/2021": "2021-02-13",  # omicron
+    "Portugal/PT23486/2021": "2021-02-13",  # omicron
+    "Portugal/PT23487/2021": "2021-02-13",  # omicron
+    "Zambia/ZMB-128118/2021": "2021-02-12",  # omicron
+    "Zambia/ZMB-128132/2021": "2021-02-12",  # omicron
+    "Zambia/ZMB-128338/2021": "2021-01-12",  # omicron
+    "Zambia/ZMB-128347/2021": "2021-02-12",  # omicron
+    "Zambia/ZMB-128414/2021": "2021-02-12",  # omicron
+    "Zambia/ZMB-128476/2021": "2021-07-12",  # omicron
+    "Zambia/ZMB-128620/2021": "2021-08-12",  # omicron
+    "Zambia/ZMB-128629/2021": "2021-06-12",  # omicron
+    "Zambia/ZMB-128631/2021": "2021-07-12",  # omicron
+    "Zambia/ZMB-128632/2021": "2021-08-12",  # omicron
+    "Zambia/ZMB-128638/2021": "2021-08-12",  # omicron
+    "Zambia/ZMB-128639/2021": "2021-09-12",  # omicron
+    "Zambia/ZMB-128641/2021": "2021-05-12",  # omicron
+    "Zambia/ZMB-128642/2021": "2021-05-12",  # omicron
+    "Zambia/ZMB-128645/2021": "2021-09-12",  # omicron
+    "Zambia/ZMB-128656/2021": "2021-09-12",  # omicron
+    "Zambia/ZMB-128657/2021": "2021-09-12",  # omicron
+    "Zambia/ZMB-128678/2021": "2021-09-12",  # omicron
+    "Zambia/ZMB-128680/2021": "2021-09-12",  # omicron
+    "Zambia/ZMB-128843/2021": "2021-07-12",  # omicron
+    "Zambia/ZMB-128868/2021": "2021-04-12",  # omicron
+    "Zambia/ZMB-128870/2021": "2021-07-12",  # omicron
+    "Zambia/ZMB-128871/2021": "2021-06-12",  # omicron
+    "Zambia/ZMB-129008/2021": "2021-10-12",  # omicron
+    "Zambia/ZMB-129024/2021": "2021-10-12",  # omicron
+    "Zambia/ZMB-129057/2021": "2021-07-12",  # omicron
+    "Zambia/ZMB-129064/2021": "2021-09-12",  # omicron
+    "Zambia/ZMB-129159/2021": "2021-10-12",  # omicron
+    "Zambia/ZMB-129162/2021": "2021-10-12",  # omicron
     # Bad sequences from Germany - supposedly Delta in Oct 2020 - unlikely
-    "Germany/NW-RKI-I-291769/2020" : "2020-10-13", #delta
-    "Germany/NW-RKI-I-291770/2020" : "2020-10-13", #delta
-    "Germany/NW-RKI-I-291771/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291772/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291773/2020" : "2020-10-17", #delta
-    "Germany/NW-RKI-I-291774/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291775/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291776/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291777/2020" : "2020-10-17", #delta
-    "Germany/NW-RKI-I-291778/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291779/2020" : "2020-10-17", #delta
-    "Germany/NW-RKI-I-291780/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291781/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291782/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291783/2020" : "2020-10-13", #delta
-    "Germany/NW-RKI-I-291784/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291786/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291788/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291789/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291790/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291791/2020" : "2020-10-16", #delta
-    "Germany/NW-RKI-I-291792/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291793/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291794/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291795/2020" : "2020-10-17", #delta
-    "Germany/NW-RKI-I-291796/2020" : "2020-10-13", #delta
-    "Germany/NW-RKI-I-291797/2020" : "2020-10-16", #delta
-    "Germany/NW-RKI-I-291798/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291799/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291800/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291801/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291802/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291803/2020" : "2020-10-17", #delta
-    "Germany/NW-RKI-I-291804/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291805/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291806/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291808/2020" : "2020-10-14", #delta
-    "Germany/NW-RKI-I-291809/2020" : "2020-10-16", #delta
-    "Germany/NW-RKI-I-291810/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291811/2020" : "2020-10-15", #delta
-    "Germany/NW-RKI-I-291812/2020" : "2020-10-16", #delta
-    "Germany/NW-RKI-I-307383/2020" : "2020-10-26", #delta
-    "Germany/NW-RKI-I-307384/2020" : "2020-10-28", #delta
-    "Germany/NW-RKI-I-307386/2020" : "2020-10-26", #delta
-    "Germany/NW-RKI-I-307387/2020" : "2020-10-28", #delta
-    "Germany/NW-RKI-I-307388/2020" : "2020-10-26", #delta
-    "Germany/NW-RKI-I-307389/2020" : "2020-10-26", #delta
-    "Germany/NW-RKI-I-307391/2020" : "2020-10-27", #delta
-    "Germany/NW-RKI-I-307392/2020" : "2020-10-26", #delta
-    "Germany/NW-RKI-I-307393/2020" : "2020-10-26", #delta
-    "Germany/NW-RKI-I-307394/2020" : "2020-10-26", #delta
-    "Germany/NW-RKI-I-307395/2020" : "2020-10-26", #delta
-    "Germany/NW-RKI-I-307396/2020" : "2020-10-27", #delta
-    "Germany/NW-RKI-I-307397/2020" : "2020-10-28", #delta
-    "Germany/NW-RKI-I-307398/2020" : "2020-10-27", #delta
-    "Germany/NW-RKI-I-307399/2020" : "2020-10-27", #delta
-    "Germany/NW-RKI-I-307400/2020" : "2020-10-28", #delta
-    "Germany/NW-RKI-I-307401/2020" : "2020-10-28", #delta
-    "Germany/NW-RKI-I-307402/2020" : "2020-10-26", #delta
-    "Germany/NW-RKI-I-307403/2020" : "2020-10-28", #delta
-    "Germany/NW-RKI-I-307404/2020" : "2020-10-27", #delta
-    "Germany/NW-RKI-I-307405/2020" : "2020-10-26", #delta
-    "Germany/NW-RKI-I-307407/2020" : "2020-10-26", #delta
-    "Germany/NW-RKI-I-307408/2020" : "2020-10-27", #delta
-    "Germany/NW-RKI-I-307409/2020" : "2020-10-28", #delta
-    "Germany/NW-RKI-I-307410/2020" : "2020-10-26", #delta
-    "Germany/NW-RKI-I-307411/2020" : "2020-10-25", #delta
-    "Germany/NW-RKI-I-307412/2020" : "2020-10-25", #delta
-    "Germany/NW-RKI-I-307413/2020" : "2020-10-28", #delta
-    "Germany/NW-RKI-I-307414/2020" : "2020-10-26", #delta
-    "Germany/NW-RKI-I-307415/2020" : "2020-10-27", #delta
-    "Germany/NW-RKI-I-307416/2020" : "2020-10-26", #delta
-    "Germany/NW-RKI-I-307417/2020" : "2020-10-28", #delta
-    "Germany/NW-RKI-I-307418/2020" : "2020-10-26", #delta
-    "Germany/NW-RKI-I-307419/2020" : "2020-10-26", #delta
-    "Germany/NW-RKI-I-307420/2020" : "2020-10-26", #delta
-    "Germany/NW-RKI-I-307421/2020" : "2020-10-26", #delta
-    "Germany/NW-RKI-I-307422/2020" : "2020-10-28", #delta
-    "Germany/NW-RKI-I-307423/2020" : "2020-10-26", #delta
-    "Germany/NW-RKI-I-307424/2020" : "2020-10-28", #delta
-    "Germany/NW-RKI-I-307425/2020" : "2020-10-27", #delta
-    "Germany/NW-RKI-I-307426/2020" : "2020-10-26", #delta
-    "Germany/NW-RKI-I-307427/2020" : "2020-10-28", #delta
-    "Germany/SL-RKI-I-297962/2020" : "2020-10-17", #delta
-    "Germany/SN-RKI-I-213505/2020" : "2020-08-21", #delta
-    #and german seqs from even earlier.
-    "Germany/NW-RKI-I-323116/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323117/2020" : "2020-05-11", #delta
-    "Germany/NW-RKI-I-323118/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323119/2020" : "2020-05-11", #delta
-    "Germany/NW-RKI-I-323120/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323121/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323122/2020" : "2020-05-11", #delta
-    "Germany/NW-RKI-I-323123/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323124/2020" : "2020-06-11", #delta
-    "Germany/NW-RKI-I-323125/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323126/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323127/2020" : "2020-05-11", #delta
-    "Germany/NW-RKI-I-323128/2020" : "2020-06-11", #delta
-    "Germany/NW-RKI-I-323129/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323130/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323131/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323132/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323133/2020" : "2020-07-11", #delta
-    "Germany/NW-RKI-I-323134/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323135/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323136/2020" : "2020-07-11", #delta
-    "Germany/NW-RKI-I-323137/2020" : "2020-10-11", #delta
-    "Germany/NW-RKI-I-323138/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323139/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323140/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323141/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323142/2020" : "2020-05-11", #delta
-    "Germany/NW-RKI-I-323143/2020" : "2020-05-11", #delta
-    "Germany/NW-RKI-I-323144/2020" : "2020-05-11", #delta
-    "Germany/NW-RKI-I-323145/2020" : "2020-05-11", #delta
-    "Germany/NW-RKI-I-323146/2020" : "2020-05-11", #delta
-    "Germany/NW-RKI-I-323147/2020" : "2020-05-11", #delta
-    "Germany/NW-RKI-I-323148/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323149/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323150/2020" : "2020-05-11", #delta
-    "Germany/NW-RKI-I-323151/2020" : "2020-05-11", #delta
-    "Germany/NW-RKI-I-323152/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323153/2020" : "2020-05-11", #delta
-    "Germany/NW-RKI-I-323154/2020" : "2020-05-11", #delta
-    "Germany/NW-RKI-I-323155/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323156/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323157/2020" : "2020-06-11", #delta
-    "Germany/NW-RKI-I-323158/2020" : "2020-05-11", #delta
-    "Germany/NW-RKI-I-323159/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323160/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323161/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323162/2020" : "2020-05-11", #delta
-    "Germany/NW-RKI-I-323163/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323164/2020" : "2020-07-11", #delta
-    "Germany/NW-RKI-I-323165/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323166/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323167/2020" : "2020-10-11", #delta
-    "Germany/NW-RKI-I-323168/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323169/2020" : "2020-10-11", #delta
-    "Germany/NW-RKI-I-323170/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323171/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323172/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323173/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323174/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323175/2020" : "2020-10-11", #delta
-    "Germany/NW-RKI-I-323176/2020" : "2020-10-11", #delta
-    "Germany/NW-RKI-I-323177/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323178/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323179/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323180/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323181/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323182/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323183/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323184/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323185/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323186/2020" : "2020-10-11", #delta
-    "Germany/NW-RKI-I-323187/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323189/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323190/2020" : "2020-05-11", #delta
-    "Germany/NW-RKI-I-323191/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323192/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323193/2020" : "2020-10-11", #delta
-    "Germany/NW-RKI-I-323194/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323195/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323196/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323197/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323198/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323199/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323200/2020" : "2020-08-11", #delta
-    "Germany/NW-RKI-I-323201/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323202/2020" : "2020-05-11", #delta
-    "Germany/NW-RKI-I-323203/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323204/2020" : "2020-06-11", #delta
-    "Germany/NW-RKI-I-323205/2020" : "2020-09-11", #delta
-    "Germany/NW-RKI-I-323206/2020" : "2020-06-11", #delta
-    "Germany/SL-RKI-I-297962/2020" : "2020-10-17", #delta
-    "Germany/SN-RKI-I-213505/2020" : "2020-08-21", #delta
-
-    #bunch of bad sequences from the UK which are supposedly Delta,
-    #from April 2020...
-    "USA/CA-LACPHL-AF03229/2020" : "2020-08-12",
-    "USA/ID-IBL-638513/2020" : "2020-08-03",
-    "England/MILK-202F06F/2020" : "2020-04-17",
-    "England/MILK-2018157/2020" : "2020-04-17",
-    "England/MILK-2018193/2020" : "2020-04-17",
-    "England/MILK-20182CD/2020" : "2020-04-17",
-    "England/MILK-2018333/2020" : "2020-04-18",
-    "England/MILK-2018351/2020" : "2020-04-17",
-    "England/MILK-20183AC/2020" : "2020-04-19",
-    "England/MILK-20183D9/2020" : "2020-04-17",
-    "England/MILK-2018412/2020" : "2020-04-17",
-    "England/MILK-20184D6/2020" : "2020-04-18",
-    "England/MILK-2018500/2020" : "2020-04-18",
-    "England/MILK-20185D3/2020" : "2020-04-18",
-    "England/MILK-20186A3/2020" : "2020-04-18",
-    "England/MILK-202E7A7/2020" : "2020-04-17",
-    "England/MILK-202E877/2020" : "2020-04-17",
-    "England/MILK-202E8E0/2020" : "2020-04-17",
-    "England/MILK-202E91A/2020" : "2020-04-17",
-    "England/MILK-202E956/2020" : "2020-04-17",
-    "England/MILK-202E992/2020" : "2020-04-17",
-    "England/MILK-202E9ED/2020" : "2020-04-17",
-    "England/MILK-202EA17/2020" : "2020-04-17",
-    "England/MILK-202EA53/2020" : "2020-04-17",
-    "England/MILK-202EA62/2020" : "2020-04-17",
-    "England/MILK-202EABD/2020" : "2020-04-17",
-    "England/MILK-202EB05/2020" : "2020-04-17",
-    "England/MILK-202EB41/2020" : "2020-04-17",
-    "England/MILK-202EB8D/2020" : "2020-04-17",
-    "England/MILK-202EC3F/2020" : "2020-04-17",
-    "England/MILK-202EC5D/2020" : "2020-04-17",
-    "England/MILK-202EC6C/2020" : "2020-04-17",
-    "England/MILK-202EC7B/2020" : "2020-04-17",
-    "England/MILK-202EC99/2020" : "2020-04-17",
-    "England/MILK-202ED0F/2020" : "2020-04-17",
-    "England/MILK-202ED96/2020" : "2020-04-17",
-    "England/MILK-202EDB4/2020" : "2020-04-17",
-    "England/MILK-202EDF0/2020" : "2020-04-17",
-    "England/MILK-202EE75/2020" : "2020-04-17",
-    "England/MILK-202EE84/2020" : "2020-04-17",
-    "England/MILK-202EEA2/2020" : "2020-04-17",
-    "England/MILK-202EEEE/2020" : "2020-04-17",
-    "England/MILK-202EF09/2020" : "2020-04-17",
-    "England/MILK-202EF18/2020" : "2020-04-17",
-    "England/MILK-202EF45/2020" : "2020-04-19",
-    "England/MILK-202EF54/2020" : "2020-04-17",
-    "England/MILK-202EF90/2020" : "2020-04-17",
-    "England/MILK-202EFAF/2020" : "2020-04-17",
-    "England/MILK-202F014/2020" : "2020-04-17",
-    "England/MILK-202F023/2020" : "2020-04-17",
-    "England/MILK-202F032/2020" : "2020-04-17",
-    "England/MILK-202F041/2020" : "2020-04-17",
-    "England/MILK-202F050/2020" : "2020-04-17",
-    "England/MILK-202F0C9/2020" : "2020-04-17",
-    "England/MILK-202F0D8/2020" : "2020-04-17",
-    "England/MILK-202F0E7/2020" : "2020-04-17",
-    "England/MILK-202F14E/2020" : "2020-04-17",
-    "England/MILK-202F15D/2020" : "2020-04-17",
-    "England/MILK-202F16C/2020" : "2020-04-17",
-    "England/MILK-202F17B/2020" : "2020-04-17",
-    "England/MILK-202F1D5/2020" : "2020-04-17",
-    "England/MILK-202F1F3/2020" : "2020-04-17",
-    "England/MILK-202F23C/2020" : "2020-04-17",
-    "England/MILK-202F24B/2020" : "2020-04-17",
-    "England/MILK-202F278/2020" : "2020-04-17",
-    "England/MILK-202F287/2020" : "2020-04-17",
-    "England/MILK-202F296/2020" : "2020-04-17",
-    "England/MILK-202F30C/2020" : "2020-04-17",
-    "England/MILK-202F32A/2020" : "2020-04-17",
-    "England/MILK-20181C0/2020" : "2020-04-17",
-    "England/MILK-1FFA395/2020" : "2020-04-16",
-    "England/MILK-1FFBC5D/2020" : "2020-04-20",
-    "England/MILK-1FFC8FE/2020" : "2020-04-17",
-    "England/MILK-1FFC9A0/2020" : "2020-04-17",
-    "England/MILK-1FFCA25/2020" : "2020-04-17",
-    "England/MILK-1FFCAF8/2020" : "2020-04-17",
-    "England/MILK-1FFCB40/2020" : "2020-04-17",
-    "England/MILK-1FFCB8C/2020" : "2020-04-17",
-    "England/MILK-1FFCB9B/2020" : "2020-04-17",
-    "England/MILK-1FFCC01/2020" : "2020-04-17",
-    "England/MILK-1FFCC2F/2020" : "2020-04-17",
-    "England/MILK-1FFCCD4/2020" : "2020-04-17",
-    "England/MILK-1FFCCE3/2020" : "2020-04-17",
-    "England/MILK-1FFCD59/2020" : "2020-04-17",
-    "England/MILK-1FFCD68/2020" : "2020-04-17",
-    "England/MILK-1FFCD77/2020" : "2020-04-17",
-    "England/MILK-1FFCDC2/2020" : "2020-04-17",
-    "England/MILK-1FFCE0B/2020" : "2020-04-17",
-    "England/MILK-1FFCE1A/2020" : "2020-04-17",
-    "England/MILK-1FFD462/2020" : "2020-04-17",
-    "England/MILK-1FFD4BD/2020" : "2020-04-17",
-    "England/MILK-1FFD58D/2020" : "2020-04-17",
-    "England/MILK-1FFD72D/2020" : "2020-04-17",
-    "England/MILK-1FFD778/2020" : "2020-04-17",
-    "England/MILK-1FFD796/2020" : "2020-04-17",
-    "England/MILK-1FFD7D2/2020" : "2020-04-18",
-    "England/MILK-1FFD7E1/2020" : "2020-04-17",
-    "England/MILK-1FFD80C/2020" : "2020-04-17",
-    "England/MILK-1FFD848/2020" : "2020-04-17",
-    "England/MILK-1FFD857/2020" : "2020-04-17",
-    "England/MILK-1FFD884/2020" : "2020-04-17",
-    "England/MILK-1FFD8FD/2020" : "2020-04-17",
-    "England/MILK-1FFD945/2020" : "2020-04-17",
-    "England/MILK-1FFD9FA/2020" : "2020-04-17",
-    "England/MILK-1FFDA15/2020" : "2020-04-19",
-    "England/MILK-2001801/2020" : "2020-04-14",
-    "England/MILK-20018F2/2020" : "2020-04-14",
-    "England/MILK-2001A92/2020" : "2020-04-14",
-    "England/MILK-2003D00/2020" : "2020-04-19",
-    "England/MILK-2003D2E/2020" : "2020-04-19",
-    "England/MILK-2003D4C/2020" : "2020-04-15",
-    "England/MILK-2003DC4/2020" : "2020-04-15",
-    "England/MILK-2003E49/2020" : "2020-04-15",
-    "England/MILK-2003E94/2020" : "2020-04-19",
-    "England/MILK-2003EC1/2020" : "2020-04-15",
-    "England/MILK-2003EEF/2020" : "2020-04-15",
-    "England/MILK-2003EFE/2020" : "2020-04-15",
-    "England/MILK-2003F28/2020" : "2020-04-15",
-    "England/MILK-2003F82/2020" : "2020-04-15",
-    "England/MILK-2003FBF/2020" : "2020-04-15",
-    "England/MILK-2004015/2020" : "2020-04-15",
-    "England/MILK-2004103/2020" : "2020-04-15",
-    "England/MILK-200415E/2020" : "2020-04-15",
-    "England/MILK-2005D86/2020" : "2020-04-15",
-    "England/MILK-2005E47/2020" : "2020-04-15",
-    "England/MILK-2005EB0/2020" : "2020-04-15",
-    "England/MILK-2005F71/2020" : "2020-04-15",
-    "England/MILK-2005F9F/2020" : "2020-04-15",
-    "England/MILK-2005FBD/2020" : "2020-04-15",
-    "England/MILK-2005FDB/2020" : "2020-04-15",
-    "England/MILK-2005FF9/2020" : "2020-04-15",
-    "England/MILK-2006022/2020" : "2020-04-16",
-    "England/MILK-2006101/2020" : "2020-04-15",
-    "England/MILK-2017589/2020" : "2020-04-18",
-    "England/MILK-2017598/2020" : "2020-04-18",
-    "England/MILK-201763B/2020" : "2020-04-18",
-    "England/MILK-20176C2/2020" : "2020-04-18",
-    "England/MILK-201771A/2020" : "2020-04-18",
-    "England/MILK-2017738/2020" : "2020-04-18",
-    "England/MILK-2017756/2020" : "2020-04-18",
-    "England/MILK-20177B0/2020" : "2020-04-18",
-    "England/MILK-20177CF/2020" : "2020-04-18",
-    "England/MILK-20177FC/2020" : "2020-04-18",
-    "England/MILK-2017808/2020" : "2020-04-18",
-    "England/MILK-2017817/2020" : "2020-04-18",
-    "England/MILK-2017844/2020" : "2020-04-18",
-    "England/MILK-2017853/2020" : "2020-04-18",
-    "England/MILK-20178AE/2020" : "2020-04-18",
-    "England/MILK-2018D53/2020" : "2020-04-19",
-    "England/MILK-2018DF9/2020" : "2020-04-18",
-    "England/MILK-2019332/2020" : "2020-04-18",
-    "England/MILK-20195B4/2020" : "2020-04-22",
-    "England/MILK-2019790/2020" : "2020-04-18",
-    "England/MILK-20197FA/2020" : "2020-04-18",
-    "England/MILK-2019EC8/2020" : "2020-04-18",
-    "England/MILK-2019ED7/2020" : "2020-04-18",
-    "England/MILK-2019F2F/2020" : "2020-04-18",
-    "England/MILK-2019F6B/2020" : "2020-04-18",
-    "England/MILK-201A058/2020" : "2020-04-18",
-    "England/MILK-201A155/2020" : "2020-04-20",
-    "England/MILK-201A164/2020" : "2020-04-18",
-    "England/MILK-201A207/2020" : "2020-04-18",
-    "England/MILK-201A261/2020" : "2020-04-18",
-    "England/MILK-201A2CB/2020" : "2020-04-18",
-    "England/MILK-201A44D/2020" : "2020-04-18",
-    "England/MILK-201A45C/2020" : "2020-04-18",
-    "England/MILK-201A46B/2020" : "2020-04-18",
-    "England/MILK-201A47A/2020" : "2020-04-18",
-    "England/MILK-201C311/2020" : "2020-04-18",
-    "England/MILK-201C38A/2020" : "2020-04-18",
-    "England/MILK-201C3B7/2020" : "2020-04-18",
-    "England/MILK-201C3D5/2020" : "2020-04-18",
-    "England/MILK-201C43C/2020" : "2020-04-18",
-    "England/MILK-201C44B/2020" : "2020-04-18",
-    "England/MILK-201C627/2020" : "2020-04-19",
-    "England/MILK-201C645/2020" : "2020-04-18",
-    "England/MILK-201C724/2020" : "2020-04-18",
-    "England/MILK-201C733/2020" : "2020-04-18",
-    "England/MILK-201D40E/2020" : "2020-04-19",
-    "England/MILK-201D4D1/2020" : "2020-04-19",
-    "England/MILK-201D4FF/2020" : "2020-04-19",
-    "England/MILK-201D50B/2020" : "2020-04-19",
-    "England/MILK-201D565/2020" : "2020-04-19",
-    "England/MILK-201D5A1/2020" : "2020-04-19",
-    "England/MILK-201D617/2020" : "2020-04-19",
-    "England/MILK-201D6BD/2020" : "2020-04-19",
-    "England/MILK-201D6EA/2020" : "2020-04-19",
-    "England/MILK-201D750/2020" : "2020-04-19",
-    "England/MILK-201D76F/2020" : "2020-04-19",
-    "England/MILK-201D78D/2020" : "2020-04-19",
-    "England/MILK-201D7C9/2020" : "2020-04-19",
-    "England/MILK-201D802/2020" : "2020-04-19",
-    "England/MILK-201D811/2020" : "2020-04-19",
-    "England/MILK-201D820/2020" : "2020-04-19",
-    "England/MILK-201D83F/2020" : "2020-04-19",
-    "England/MILK-201D8B7/2020" : "2020-04-19",
-    "England/MILK-201FDB6/2020" : "2020-04-19",
-    "England/MILK-201FDC5/2020" : "2020-04-19",
-    "England/MILK-201FDE3/2020" : "2020-04-19",
-    "England/MILK-201FE68/2020" : "2020-04-19",
-    "England/MILK-201FE77/2020" : "2020-04-19",
-    "England/MILK-201FE95/2020" : "2020-04-19",
-    "England/MILK-201FED1/2020" : "2020-04-19",
-    "England/MILK-201FEFF/2020" : "2020-04-19",
-    "England/MILK-201FF0B/2020" : "2020-04-19",
-    "England/MILK-201FF56/2020" : "2020-04-19",
-    "England/MILK-201FF65/2020" : "2020-04-19",
-    "England/MILK-201FFA1/2020" : "2020-04-19",
-    "England/MILK-2020022/2020" : "2020-04-19",
-    "England/MILK-202007D/2020" : "2020-04-19",
-    "England/MILK-202009B/2020" : "2020-04-19",
-    "England/MILK-202012F/2020" : "2020-04-19",
-    "England/MILK-202016B/2020" : "2020-04-19",
-    "England/MILK-2022002/2020" : "2020-04-19",
-    "England/MILK-20220C6/2020" : "2020-04-19",
-    "England/MILK-20220D5/2020" : "2020-04-19",
-    "England/MILK-20221A5/2020" : "2020-04-19",
-    "England/MILK-20221B4/2020" : "2020-04-19",
-    "England/MILK-20222B1/2020" : "2020-04-19",
-    "England/MILK-20222C0/2020" : "2020-04-19",
-    "England/MILK-2022318/2020" : "2020-04-19",
-    "England/MILK-2022336/2020" : "2020-04-19",
-    "England/MILK-2022390/2020" : "2020-04-19",
-    "England/MILK-2023195/2020" : "2020-04-19",
-    "England/MILK-20231A4/2020" : "2020-04-19",
-    "England/MILK-202321A/2020" : "2020-04-19",
-    "England/MILK-20232A1/2020" : "2020-04-20",
-    "England/MILK-20232B0/2020" : "2020-04-20",
-    "England/MILK-20233AE/2020" : "2020-04-20",
-    "England/MILK-20233BD/2020" : "2020-04-20",
-    "England/MILK-2023423/2020" : "2020-04-19",
-    "England/MILK-2023432/2020" : "2020-04-20",
-    "England/MILK-2023441/2020" : "2020-04-20",
-    "England/MILK-202349C/2020" : "2020-04-20",
-    "England/MILK-20234C9/2020" : "2020-04-20",
-    "England/MILK-2023511/2020" : "2020-04-20",
-    "England/MILK-202365A/2020" : "2020-04-20",
-    "England/MILK-20236D2/2020" : "2020-04-20",
-    "England/MILK-20254E5/2020" : "2020-04-19",
-    "England/MILK-20255B5/2020" : "2020-04-19",
-    "England/MILK-20255C4/2020" : "2020-04-19",
-    "England/MILK-2027902/2020" : "2020-04-20",
-    "England/MILK-202793F/2020" : "2020-04-20",
-    "England/MILK-2027AF0/2020" : "2020-04-20",
-    "England/MILK-2027B2A/2020" : "2020-04-20",
-    "England/MILK-2027B93/2020" : "2020-04-20",
-    "England/MILK-2027C72/2020" : "2020-04-20",
-    "England/MILK-2027D60/2020" : "2020-04-20",
-    "England/MILK-2027D7F/2020" : "2020-04-20",
-    "England/MILK-2027DAC/2020" : "2020-04-20",
-    "England/MILK-203004D/2020" : "2020-04-19",
-    "England/MILK-203005C/2020" : "2020-04-19",
-    "England/MILK-2030159/2020" : "2020-04-18",
-    "England/MILK-203020B/2020" : "2020-04-18",
-    "England/MILK-2030247/2020" : "2020-04-18",
-    "England/MILK-2030256/2020" : "2020-04-18",
-    "England/MILK-20302CF/2020" : "2020-04-18",
-    "England/MILK-20302DE/2020" : "2020-04-18",
-    "England/MILK-2030326/2020" : "2020-04-18",
-    "England/MILK-2030362/2020" : "2020-04-18",
-    "England/MILK-20303AE/2020" : "2020-04-18",
-    "England/MILK-20303BD/2020" : "2020-04-18",
-    "England/MILK-20303CC/2020" : "2020-04-18",
-    "England/MILK-2030423/2020" : "2020-04-18",
-    "England/MILK-203046F/2020" : "2020-04-18",
-    "England/MILK-20304C9/2020" : "2020-04-18",
-    "England/MILK-2030CB2/2020" : "2020-04-19",
-    "England/MILK-2030D0A/2020" : "2020-04-19",
-    "England/MILK-2030D19/2020" : "2020-04-19",
-    "England/MILK-2030D46/2020" : "2020-04-19",
-    "England/MILK-2030D82/2020" : "2020-04-19",
-    "England/MILK-2030E34/2020" : "2020-04-19",
-    "England/MILK-2030E8F/2020" : "2020-04-20",
-    "England/MILK-2030F31/2020" : "2020-04-19",
-    "England/MILK-2030FD7/2020" : "2020-04-19",
-    "England/MILK-2032861/2020" : "2020-04-19",
-    "England/MILK-20328AD/2020" : "2020-04-19",
-    "England/MILK-203297D/2020" : "2020-04-19",
-    "England/MILK-203299B/2020" : "2020-04-19",
-    "England/MILK-20329F5/2020" : "2020-04-19",
-    "England/MILK-2032A4D/2020" : "2020-04-19",
-    "England/MILK-2032AA7/2020" : "2020-04-19",
-    "England/MILK-2032BB3/2020" : "2020-04-19",
-    "England/MILK-2032BC2/2020" : "2020-04-19",
-    "England/MILK-2032BFF/2020" : "2020-04-19",
-    "England/MILK-2032C38/2020" : "2020-04-19",
-    "England/MILK-2032C47/2020" : "2020-04-19",
-    "England/MILK-2032CB0/2020" : "2020-04-19",
-    "England/MILK-2032D17/2020" : "2020-04-19",
-    "England/MILK-2032D44/2020" : "2020-04-19",
-    "England/MILK-2032D71/2020" : "2020-04-19",
-    "England/MILK-2032DAE/2020" : "2020-04-19",
-    "England/MILK-2032DEA/2020" : "2020-04-18",
-    "England/MILK-2032DF9/2020" : "2020-04-18",
-    "England/MILK-2032E32/2020" : "2020-04-18",
-    "England/MILK-2032EAB/2020" : "2020-04-18",
-    "England/MILK-2032EBA/2020" : "2020-04-18",
-    "England/MILK-2032F20/2020" : "2020-04-18",
-    "England/MILK-2032FE4/2020" : "2020-04-18",
-    "England/MILK-203301D/2020" : "2020-04-18",
-    "England/MILK-203302C/2020" : "2020-04-18",
-    "England/MILK-203304A/2020" : "2020-04-18",
-    "England/MILK-2033129/2020" : "2020-04-18",
-    "England/MILK-20331FC/2020" : "2020-04-18",
-    "England/MILK-2033217/2020" : "2020-04-18",
-    "England/MILK-2033226/2020" : "2020-04-18",
-    "England/MILK-20332BD/2020" : "2020-04-18",
-    "England/MILK-20332F9/2020" : "2020-04-18",
-    "England/MILK-2033305/2020" : "2020-04-18",
-    "England/MILK-2033921/2020" : "2020-04-18",
-    "England/MILK-2033930/2020" : "2020-04-18",
-    "England/MILK-203395E/2020" : "2020-04-18",
-    "England/MILK-20339A9/2020" : "2020-04-18",
-    "England/MILK-20339B8/2020" : "2020-04-18",
-    "England/MILK-20339D6/2020" : "2020-04-18",
-    "England/MILK-2034270/2020" : "2020-04-19",
-    "England/MILK-20342BC/2020" : "2020-04-19",
-    "England/MILK-2034410/2020" : "2020-04-19",
-    "England/MILK-2034498/2020" : "2020-04-19",
-    "England/MILK-20344B6/2020" : "2020-04-19",
-    "England/MILK-20344C5/2020" : "2020-04-19",
-    "England/MILK-203451D/2020" : "2020-04-19",
-    "England/MILK-203452C/2020" : "2020-04-19",
-    "England/MILK-203588C/2020" : "2020-04-20",
-    "England/MILK-20358C8/2020" : "2020-04-19",
-    "England/MILK-203593E/2020" : "2020-04-19",
-    "England/MILK-203596B/2020" : "2020-04-19",
-    "England/MILK-20359E3/2020" : "2020-04-19",
-    "England/MILK-2035AA4/2020" : "2020-04-19",
-    "England/MILK-2035B65/2020" : "2020-04-19",
-    "England/MILK-2035C71/2020" : "2020-04-19",
-    "England/MILK-2035C9F/2020" : "2020-04-19",
-    "England/MILK-2036302/2020" : "2020-04-19",
-    "England/MILK-203636C/2020" : "2020-04-19",
-    "England/MILK-2036399/2020" : "2020-04-19",
-    "England/MILK-203641E/2020" : "2020-04-19",
-    "England/MILK-203644B/2020" : "2020-04-19",
-    "England/MILK-203645A/2020" : "2020-04-19",
-    "England/MILK-2036469/2020" : "2020-04-19",
-    "England/MILK-2036487/2020" : "2020-04-19",
-    "England/MILK-20364F0/2020" : "2020-04-19",
-    "England/MILK-203652A/2020" : "2020-04-19",
-    "England/MILK-2036548/2020" : "2020-04-19",
-    "England/MILK-20365C0/2020" : "2020-04-19",
-    "England/MILK-20365FD/2020" : "2020-04-19",
-    "England/MILK-2036609/2020" : "2020-04-19",
-    "England/MILK-2036672/2020" : "2020-04-19",
-    "England/MILK-2036681/2020" : "2020-04-19",
-    "England/MILK-20368B8/2020" : "2020-04-19",
-    "England/MILK-20368C7/2020" : "2020-04-20",
-    "England/MILK-2036F77/2020" : "2020-04-19",
-    "England/MILK-2036F86/2020" : "2020-04-19",
-    "England/MILK-2036FC2/2020" : "2020-04-19",
-    "England/MILK-2037055/2020" : "2020-04-19",
-    "England/MILK-2037125/2020" : "2020-04-19",
-    "England/MILK-2037161/2020" : "2020-04-20",
-    "England/MILK-20371AD/2020" : "2020-04-19",
-    "England/MILK-20372B9/2020" : "2020-04-19",
-    "England/MILK-20372C8/2020" : "2020-04-19",
-    "England/MILK-20372D7/2020" : "2020-04-19",
-    "England/MILK-2037301/2020" : "2020-04-19",
-    "England/MILK-203733E/2020" : "2020-04-19",
-    "England/MILK-2037477/2020" : "2020-04-19",
-    "England/MILK-2038C32/2020" : "2020-04-19",
-    "England/MILK-2038C50/2020" : "2020-04-19",
-    "England/MILK-2038C9C/2020" : "2020-04-19",
-    "England/MILK-2038D4E/2020" : "2020-04-19",
-    "England/MILK-2038D6C/2020" : "2020-04-19",
-    "England/MILK-2038D8A/2020" : "2020-04-19",
-    "England/MILK-2038DA8/2020" : "2020-04-19",
-    "England/MILK-2038DC6/2020" : "2020-04-19",
-    "England/MILK-2038E1E/2020" : "2020-04-19",
-    "England/MILK-2038E4B/2020" : "2020-04-19",
-    "England/MILK-2038EF0/2020" : "2020-04-21",
-    "England/MILK-2038F1B/2020" : "2020-04-21",
-    "England/MILK-2038F48/2020" : "2020-04-21",
-    "England/MILK-2038F84/2020" : "2020-04-21",
-    "England/MILK-2038F93/2020" : "2020-04-21",
-    "England/MILK-2038FB1/2020" : "2020-04-21",
-    "England/MILK-2039062/2020" : "2020-04-21",
-    "England/MILK-2039071/2020" : "2020-04-21",
-    "England/MILK-20390AE/2020" : "2020-04-21",
-    "England/MILK-20390CC/2020" : "2020-04-21",
-    "England/MILK-203917E/2020" : "2020-04-21",
-    "England/MILK-203919C/2020" : "2020-04-21",
-    "England/MILK-20391BA/2020" : "2020-04-21",
-    "England/MILK-20391D8/2020" : "2020-04-21",
-    "England/MILK-203A3C2/2020" : "2020-04-22",
-    "England/MILK-203A483/2020" : "2020-04-22",
-    "England/MILK-203A492/2020" : "2020-04-22",
-    "England/MILK-203A4B0/2020" : "2020-04-22",
-    "England/MILK-203A4ED/2020" : "2020-04-22",
-    "England/MILK-203A571/2020" : "2020-04-22",
-    "England/MILK-203A5BD/2020" : "2020-04-22",
-    "England/MILK-203A623/2020" : "2020-04-22",
-    "England/MILK-203A650/2020" : "2020-04-22",
-    "England/MILK-203A66F/2020" : "2020-04-22",
-    "England/MILK-203A6AB/2020" : "2020-04-22",
-    "England/MILK-203A6BA/2020" : "2020-04-22",
-    "England/MILK-203A6C9/2020" : "2020-04-22",
-    "England/MILK-203A7A8/2020" : "2020-04-22",
-    "England/MILK-203A7F3/2020" : "2020-04-22",
-    "England/MILK-203A81E/2020" : "2020-04-22",
-    "England/MILK-203A887/2020" : "2020-04-22",
-    "England/MILK-203A8C3/2020" : "2020-04-22",
-    "England/MILK-203A8D2/2020" : "2020-04-22",
-    "England/MILK-203A90C/2020" : "2020-04-22",
-    "England/MILK-203A9EE/2020" : "2020-04-22",
-    "England/MILK-203AA72/2020" : "2020-04-22",
-    "England/MILK-203AA81/2020" : "2020-04-22",
-    "England/MILK-203AA90/2020" : "2020-04-22",
-    "England/MILK-203AACD/2020" : "2020-04-22",
-    "England/MILK-203AADC/2020" : "2020-04-22",
-    "England/MILK-203AB15/2020" : "2020-04-22",
-    "England/MILK-203AB42/2020" : "2020-04-22",
-    "England/MILK-203AB8E/2020" : "2020-04-22",
-    "England/MILK-203ABAC/2020" : "2020-04-22",
-    "England/MILK-203ABF7/2020" : "2020-04-22",
-    "England/MILK-203AC7C/2020" : "2020-04-22",
-    "England/MILK-203ACE5/2020" : "2020-04-22",
-    "England/MILK-203AD00/2020" : "2020-04-22",
-    "England/MILK-203AD2E/2020" : "2020-04-22",
-    "England/MILK-203AD5B/2020" : "2020-04-22",
-    "England/MILK-203AD79/2020" : "2020-04-22",
-    "England/MILK-203AE1C/2020" : "2020-04-22",
-    "England/MILK-203AE49/2020" : "2020-04-22",
-    "England/MILK-203AEFE/2020" : "2020-04-22",
-    "England/MILK-203AF46/2020" : "2020-04-22",
-    "England/MILK-203B552/2020" : "2020-04-22",
-    "England/MILK-203B59E/2020" : "2020-04-22",
-    "England/MILK-203B5AD/2020" : "2020-04-22",
-    "England/MILK-203B5F8/2020" : "2020-04-22",
-    "England/MILK-203B613/2020" : "2020-04-22",
-    "England/MILK-203B640/2020" : "2020-04-21",
-    "England/MILK-203B67D/2020" : "2020-04-22",
-    "England/MILK-203B68C/2020" : "2020-04-22",
-    "England/MILK-203B73E/2020" : "2020-04-22",
-    "England/MILK-203B75C/2020" : "2020-04-22",
-    "England/MILK-203B7B6/2020" : "2020-04-22",
-    "England/MILK-203B7D4/2020" : "2020-04-22",
-    "England/MILK-203B877/2020" : "2020-04-22",
-    "England/MILK-203B886/2020" : "2020-04-22",
-    "England/MILK-203B90B/2020" : "2020-04-22",
-    "England/MILK-203BA35/2020" : "2020-04-22",
-    "England/MILK-203BAF9/2020" : "2020-04-22",
-    "England/MILK-203CCF2/2020" : "2020-04-21",
-    "England/MILK-203CD0E/2020" : "2020-04-21",
-    "England/MILK-203CD4A/2020" : "2020-04-21",
-    "England/MILK-203CD68/2020" : "2020-04-21",
-    "England/MILK-203CD77/2020" : "2020-04-21",
-    "England/MILK-203CDB3/2020" : "2020-04-22",
-    "England/MILK-203CDD1/2020" : "2020-04-21",
-    "England/MILK-203CE0B/2020" : "2020-04-21",
-    "England/MILK-203CE38/2020" : "2020-04-21",
-    "England/MILK-203CE47/2020" : "2020-04-21",
-    "England/MILK-203CEA1/2020" : "2020-04-21",
-    "England/MILK-203CEFC/2020" : "2020-04-21",
-    "England/MILK-203CF08/2020" : "2020-04-21",
-    "England/MILK-203CF62/2020" : "2020-04-21",
-    "England/MILK-203CF71/2020" : "2020-04-21",
-    "England/MILK-203D013/2020" : "2020-04-21",
-    "England/MILK-203D12F/2020" : "2020-04-21",
-    "England/MILK-203D1A7/2020" : "2020-04-21",
-    "England/MILK-203D2B3/2020" : "2020-04-21",
-    "England/MILK-203D338/2020" : "2020-04-21",
-    "England/MILK-203D3CF/2020" : "2020-04-21",
-    "England/MILK-203D444/2020" : "2020-04-21",
-    "England/MILK-203D462/2020" : "2020-04-21",
-    "England/MILK-203D49F/2020" : "2020-04-21",
-    "England/MILK-203D4EA/2020" : "2020-04-21",
-    "England/MILK-203D541/2020" : "2020-04-22",
-    "England/MILK-203D550/2020" : "2020-04-22",
-    "England/MILK-203D5BA/2020" : "2020-04-22",
-    "England/MILK-203D620/2020" : "2020-04-22",
-    "England/MILK-203D82A/2020" : "2020-04-22",
-    "England/MILK-203D848/2020" : "2020-04-22",
-    "England/MILK-203F002/2020" : "2020-04-21",
-    "England/MILK-203F04E/2020" : "2020-04-21",
-    "England/MILK-203F0E4/2020" : "2020-04-21",
-    "England/MILK-203F503/2020" : "2020-04-21",
-    "England/MILK-203F521/2020" : "2020-04-21",
-
-    #These are sequences submitted where collection date seems incorrect:
-    #https://twitter.com/flodebarre/status/1414868236823318530
+    "Germany/NW-RKI-I-291769/2020": "2020-10-13",  # delta
+    "Germany/NW-RKI-I-291770/2020": "2020-10-13",  # delta
+    "Germany/NW-RKI-I-291771/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291772/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291773/2020": "2020-10-17",  # delta
+    "Germany/NW-RKI-I-291774/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291775/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291776/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291777/2020": "2020-10-17",  # delta
+    "Germany/NW-RKI-I-291778/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291779/2020": "2020-10-17",  # delta
+    "Germany/NW-RKI-I-291780/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291781/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291782/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291783/2020": "2020-10-13",  # delta
+    "Germany/NW-RKI-I-291784/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291786/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291788/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291789/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291790/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291791/2020": "2020-10-16",  # delta
+    "Germany/NW-RKI-I-291792/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291793/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291794/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291795/2020": "2020-10-17",  # delta
+    "Germany/NW-RKI-I-291796/2020": "2020-10-13",  # delta
+    "Germany/NW-RKI-I-291797/2020": "2020-10-16",  # delta
+    "Germany/NW-RKI-I-291798/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291799/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291800/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291801/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291802/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291803/2020": "2020-10-17",  # delta
+    "Germany/NW-RKI-I-291804/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291805/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291806/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291808/2020": "2020-10-14",  # delta
+    "Germany/NW-RKI-I-291809/2020": "2020-10-16",  # delta
+    "Germany/NW-RKI-I-291810/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291811/2020": "2020-10-15",  # delta
+    "Germany/NW-RKI-I-291812/2020": "2020-10-16",  # delta
+    "Germany/NW-RKI-I-307383/2020": "2020-10-26",  # delta
+    "Germany/NW-RKI-I-307384/2020": "2020-10-28",  # delta
+    "Germany/NW-RKI-I-307386/2020": "2020-10-26",  # delta
+    "Germany/NW-RKI-I-307387/2020": "2020-10-28",  # delta
+    "Germany/NW-RKI-I-307388/2020": "2020-10-26",  # delta
+    "Germany/NW-RKI-I-307389/2020": "2020-10-26",  # delta
+    "Germany/NW-RKI-I-307391/2020": "2020-10-27",  # delta
+    "Germany/NW-RKI-I-307392/2020": "2020-10-26",  # delta
+    "Germany/NW-RKI-I-307393/2020": "2020-10-26",  # delta
+    "Germany/NW-RKI-I-307394/2020": "2020-10-26",  # delta
+    "Germany/NW-RKI-I-307395/2020": "2020-10-26",  # delta
+    "Germany/NW-RKI-I-307396/2020": "2020-10-27",  # delta
+    "Germany/NW-RKI-I-307397/2020": "2020-10-28",  # delta
+    "Germany/NW-RKI-I-307398/2020": "2020-10-27",  # delta
+    "Germany/NW-RKI-I-307399/2020": "2020-10-27",  # delta
+    "Germany/NW-RKI-I-307400/2020": "2020-10-28",  # delta
+    "Germany/NW-RKI-I-307401/2020": "2020-10-28",  # delta
+    "Germany/NW-RKI-I-307402/2020": "2020-10-26",  # delta
+    "Germany/NW-RKI-I-307403/2020": "2020-10-28",  # delta
+    "Germany/NW-RKI-I-307404/2020": "2020-10-27",  # delta
+    "Germany/NW-RKI-I-307405/2020": "2020-10-26",  # delta
+    "Germany/NW-RKI-I-307407/2020": "2020-10-26",  # delta
+    "Germany/NW-RKI-I-307408/2020": "2020-10-27",  # delta
+    "Germany/NW-RKI-I-307409/2020": "2020-10-28",  # delta
+    "Germany/NW-RKI-I-307410/2020": "2020-10-26",  # delta
+    "Germany/NW-RKI-I-307411/2020": "2020-10-25",  # delta
+    "Germany/NW-RKI-I-307412/2020": "2020-10-25",  # delta
+    "Germany/NW-RKI-I-307413/2020": "2020-10-28",  # delta
+    "Germany/NW-RKI-I-307414/2020": "2020-10-26",  # delta
+    "Germany/NW-RKI-I-307415/2020": "2020-10-27",  # delta
+    "Germany/NW-RKI-I-307416/2020": "2020-10-26",  # delta
+    "Germany/NW-RKI-I-307417/2020": "2020-10-28",  # delta
+    "Germany/NW-RKI-I-307418/2020": "2020-10-26",  # delta
+    "Germany/NW-RKI-I-307419/2020": "2020-10-26",  # delta
+    "Germany/NW-RKI-I-307420/2020": "2020-10-26",  # delta
+    "Germany/NW-RKI-I-307421/2020": "2020-10-26",  # delta
+    "Germany/NW-RKI-I-307422/2020": "2020-10-28",  # delta
+    "Germany/NW-RKI-I-307423/2020": "2020-10-26",  # delta
+    "Germany/NW-RKI-I-307424/2020": "2020-10-28",  # delta
+    "Germany/NW-RKI-I-307425/2020": "2020-10-27",  # delta
+    "Germany/NW-RKI-I-307426/2020": "2020-10-26",  # delta
+    "Germany/NW-RKI-I-307427/2020": "2020-10-28",  # delta
+    "Germany/SL-RKI-I-297962/2020": "2020-10-17",  # delta
+    "Germany/SN-RKI-I-213505/2020": "2020-08-21",  # delta
+    # and german seqs from even earlier.
+    "Germany/NW-RKI-I-323116/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323117/2020": "2020-05-11",  # delta
+    "Germany/NW-RKI-I-323118/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323119/2020": "2020-05-11",  # delta
+    "Germany/NW-RKI-I-323120/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323121/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323122/2020": "2020-05-11",  # delta
+    "Germany/NW-RKI-I-323123/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323124/2020": "2020-06-11",  # delta
+    "Germany/NW-RKI-I-323125/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323126/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323127/2020": "2020-05-11",  # delta
+    "Germany/NW-RKI-I-323128/2020": "2020-06-11",  # delta
+    "Germany/NW-RKI-I-323129/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323130/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323131/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323132/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323133/2020": "2020-07-11",  # delta
+    "Germany/NW-RKI-I-323134/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323135/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323136/2020": "2020-07-11",  # delta
+    "Germany/NW-RKI-I-323137/2020": "2020-10-11",  # delta
+    "Germany/NW-RKI-I-323138/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323139/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323140/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323141/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323142/2020": "2020-05-11",  # delta
+    "Germany/NW-RKI-I-323143/2020": "2020-05-11",  # delta
+    "Germany/NW-RKI-I-323144/2020": "2020-05-11",  # delta
+    "Germany/NW-RKI-I-323145/2020": "2020-05-11",  # delta
+    "Germany/NW-RKI-I-323146/2020": "2020-05-11",  # delta
+    "Germany/NW-RKI-I-323147/2020": "2020-05-11",  # delta
+    "Germany/NW-RKI-I-323148/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323149/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323150/2020": "2020-05-11",  # delta
+    "Germany/NW-RKI-I-323151/2020": "2020-05-11",  # delta
+    "Germany/NW-RKI-I-323152/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323153/2020": "2020-05-11",  # delta
+    "Germany/NW-RKI-I-323154/2020": "2020-05-11",  # delta
+    "Germany/NW-RKI-I-323155/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323156/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323157/2020": "2020-06-11",  # delta
+    "Germany/NW-RKI-I-323158/2020": "2020-05-11",  # delta
+    "Germany/NW-RKI-I-323159/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323160/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323161/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323162/2020": "2020-05-11",  # delta
+    "Germany/NW-RKI-I-323163/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323164/2020": "2020-07-11",  # delta
+    "Germany/NW-RKI-I-323165/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323166/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323167/2020": "2020-10-11",  # delta
+    "Germany/NW-RKI-I-323168/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323169/2020": "2020-10-11",  # delta
+    "Germany/NW-RKI-I-323170/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323171/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323172/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323173/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323174/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323175/2020": "2020-10-11",  # delta
+    "Germany/NW-RKI-I-323176/2020": "2020-10-11",  # delta
+    "Germany/NW-RKI-I-323177/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323178/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323179/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323180/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323181/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323182/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323183/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323184/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323185/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323186/2020": "2020-10-11",  # delta
+    "Germany/NW-RKI-I-323187/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323189/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323190/2020": "2020-05-11",  # delta
+    "Germany/NW-RKI-I-323191/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323192/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323193/2020": "2020-10-11",  # delta
+    "Germany/NW-RKI-I-323194/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323195/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323196/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323197/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323198/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323199/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323200/2020": "2020-08-11",  # delta
+    "Germany/NW-RKI-I-323201/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323202/2020": "2020-05-11",  # delta
+    "Germany/NW-RKI-I-323203/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323204/2020": "2020-06-11",  # delta
+    "Germany/NW-RKI-I-323205/2020": "2020-09-11",  # delta
+    "Germany/NW-RKI-I-323206/2020": "2020-06-11",  # delta
+    "Germany/SL-RKI-I-297962/2020": "2020-10-17",  # delta
+    "Germany/SN-RKI-I-213505/2020": "2020-08-21",  # delta
+    # bunch of bad sequences from the UK which are supposedly Delta,
+    # from April 2020...
+    "USA/CA-LACPHL-AF03229/2020": "2020-08-12",
+    "USA/ID-IBL-638513/2020": "2020-08-03",
+    "England/MILK-202F06F/2020": "2020-04-17",
+    "England/MILK-2018157/2020": "2020-04-17",
+    "England/MILK-2018193/2020": "2020-04-17",
+    "England/MILK-20182CD/2020": "2020-04-17",
+    "England/MILK-2018333/2020": "2020-04-18",
+    "England/MILK-2018351/2020": "2020-04-17",
+    "England/MILK-20183AC/2020": "2020-04-19",
+    "England/MILK-20183D9/2020": "2020-04-17",
+    "England/MILK-2018412/2020": "2020-04-17",
+    "England/MILK-20184D6/2020": "2020-04-18",
+    "England/MILK-2018500/2020": "2020-04-18",
+    "England/MILK-20185D3/2020": "2020-04-18",
+    "England/MILK-20186A3/2020": "2020-04-18",
+    "England/MILK-202E7A7/2020": "2020-04-17",
+    "England/MILK-202E877/2020": "2020-04-17",
+    "England/MILK-202E8E0/2020": "2020-04-17",
+    "England/MILK-202E91A/2020": "2020-04-17",
+    "England/MILK-202E956/2020": "2020-04-17",
+    "England/MILK-202E992/2020": "2020-04-17",
+    "England/MILK-202E9ED/2020": "2020-04-17",
+    "England/MILK-202EA17/2020": "2020-04-17",
+    "England/MILK-202EA53/2020": "2020-04-17",
+    "England/MILK-202EA62/2020": "2020-04-17",
+    "England/MILK-202EABD/2020": "2020-04-17",
+    "England/MILK-202EB05/2020": "2020-04-17",
+    "England/MILK-202EB41/2020": "2020-04-17",
+    "England/MILK-202EB8D/2020": "2020-04-17",
+    "England/MILK-202EC3F/2020": "2020-04-17",
+    "England/MILK-202EC5D/2020": "2020-04-17",
+    "England/MILK-202EC6C/2020": "2020-04-17",
+    "England/MILK-202EC7B/2020": "2020-04-17",
+    "England/MILK-202EC99/2020": "2020-04-17",
+    "England/MILK-202ED0F/2020": "2020-04-17",
+    "England/MILK-202ED96/2020": "2020-04-17",
+    "England/MILK-202EDB4/2020": "2020-04-17",
+    "England/MILK-202EDF0/2020": "2020-04-17",
+    "England/MILK-202EE75/2020": "2020-04-17",
+    "England/MILK-202EE84/2020": "2020-04-17",
+    "England/MILK-202EEA2/2020": "2020-04-17",
+    "England/MILK-202EEEE/2020": "2020-04-17",
+    "England/MILK-202EF09/2020": "2020-04-17",
+    "England/MILK-202EF18/2020": "2020-04-17",
+    "England/MILK-202EF45/2020": "2020-04-19",
+    "England/MILK-202EF54/2020": "2020-04-17",
+    "England/MILK-202EF90/2020": "2020-04-17",
+    "England/MILK-202EFAF/2020": "2020-04-17",
+    "England/MILK-202F014/2020": "2020-04-17",
+    "England/MILK-202F023/2020": "2020-04-17",
+    "England/MILK-202F032/2020": "2020-04-17",
+    "England/MILK-202F041/2020": "2020-04-17",
+    "England/MILK-202F050/2020": "2020-04-17",
+    "England/MILK-202F0C9/2020": "2020-04-17",
+    "England/MILK-202F0D8/2020": "2020-04-17",
+    "England/MILK-202F0E7/2020": "2020-04-17",
+    "England/MILK-202F14E/2020": "2020-04-17",
+    "England/MILK-202F15D/2020": "2020-04-17",
+    "England/MILK-202F16C/2020": "2020-04-17",
+    "England/MILK-202F17B/2020": "2020-04-17",
+    "England/MILK-202F1D5/2020": "2020-04-17",
+    "England/MILK-202F1F3/2020": "2020-04-17",
+    "England/MILK-202F23C/2020": "2020-04-17",
+    "England/MILK-202F24B/2020": "2020-04-17",
+    "England/MILK-202F278/2020": "2020-04-17",
+    "England/MILK-202F287/2020": "2020-04-17",
+    "England/MILK-202F296/2020": "2020-04-17",
+    "England/MILK-202F30C/2020": "2020-04-17",
+    "England/MILK-202F32A/2020": "2020-04-17",
+    "England/MILK-20181C0/2020": "2020-04-17",
+    "England/MILK-1FFA395/2020": "2020-04-16",
+    "England/MILK-1FFBC5D/2020": "2020-04-20",
+    "England/MILK-1FFC8FE/2020": "2020-04-17",
+    "England/MILK-1FFC9A0/2020": "2020-04-17",
+    "England/MILK-1FFCA25/2020": "2020-04-17",
+    "England/MILK-1FFCAF8/2020": "2020-04-17",
+    "England/MILK-1FFCB40/2020": "2020-04-17",
+    "England/MILK-1FFCB8C/2020": "2020-04-17",
+    "England/MILK-1FFCB9B/2020": "2020-04-17",
+    "England/MILK-1FFCC01/2020": "2020-04-17",
+    "England/MILK-1FFCC2F/2020": "2020-04-17",
+    "England/MILK-1FFCCD4/2020": "2020-04-17",
+    "England/MILK-1FFCCE3/2020": "2020-04-17",
+    "England/MILK-1FFCD59/2020": "2020-04-17",
+    "England/MILK-1FFCD68/2020": "2020-04-17",
+    "England/MILK-1FFCD77/2020": "2020-04-17",
+    "England/MILK-1FFCDC2/2020": "2020-04-17",
+    "England/MILK-1FFCE0B/2020": "2020-04-17",
+    "England/MILK-1FFCE1A/2020": "2020-04-17",
+    "England/MILK-1FFD462/2020": "2020-04-17",
+    "England/MILK-1FFD4BD/2020": "2020-04-17",
+    "England/MILK-1FFD58D/2020": "2020-04-17",
+    "England/MILK-1FFD72D/2020": "2020-04-17",
+    "England/MILK-1FFD778/2020": "2020-04-17",
+    "England/MILK-1FFD796/2020": "2020-04-17",
+    "England/MILK-1FFD7D2/2020": "2020-04-18",
+    "England/MILK-1FFD7E1/2020": "2020-04-17",
+    "England/MILK-1FFD80C/2020": "2020-04-17",
+    "England/MILK-1FFD848/2020": "2020-04-17",
+    "England/MILK-1FFD857/2020": "2020-04-17",
+    "England/MILK-1FFD884/2020": "2020-04-17",
+    "England/MILK-1FFD8FD/2020": "2020-04-17",
+    "England/MILK-1FFD945/2020": "2020-04-17",
+    "England/MILK-1FFD9FA/2020": "2020-04-17",
+    "England/MILK-1FFDA15/2020": "2020-04-19",
+    "England/MILK-2001801/2020": "2020-04-14",
+    "England/MILK-20018F2/2020": "2020-04-14",
+    "England/MILK-2001A92/2020": "2020-04-14",
+    "England/MILK-2003D00/2020": "2020-04-19",
+    "England/MILK-2003D2E/2020": "2020-04-19",
+    "England/MILK-2003D4C/2020": "2020-04-15",
+    "England/MILK-2003DC4/2020": "2020-04-15",
+    "England/MILK-2003E49/2020": "2020-04-15",
+    "England/MILK-2003E94/2020": "2020-04-19",
+    "England/MILK-2003EC1/2020": "2020-04-15",
+    "England/MILK-2003EEF/2020": "2020-04-15",
+    "England/MILK-2003EFE/2020": "2020-04-15",
+    "England/MILK-2003F28/2020": "2020-04-15",
+    "England/MILK-2003F82/2020": "2020-04-15",
+    "England/MILK-2003FBF/2020": "2020-04-15",
+    "England/MILK-2004015/2020": "2020-04-15",
+    "England/MILK-2004103/2020": "2020-04-15",
+    "England/MILK-200415E/2020": "2020-04-15",
+    "England/MILK-2005D86/2020": "2020-04-15",
+    "England/MILK-2005E47/2020": "2020-04-15",
+    "England/MILK-2005EB0/2020": "2020-04-15",
+    "England/MILK-2005F71/2020": "2020-04-15",
+    "England/MILK-2005F9F/2020": "2020-04-15",
+    "England/MILK-2005FBD/2020": "2020-04-15",
+    "England/MILK-2005FDB/2020": "2020-04-15",
+    "England/MILK-2005FF9/2020": "2020-04-15",
+    "England/MILK-2006022/2020": "2020-04-16",
+    "England/MILK-2006101/2020": "2020-04-15",
+    "England/MILK-2017589/2020": "2020-04-18",
+    "England/MILK-2017598/2020": "2020-04-18",
+    "England/MILK-201763B/2020": "2020-04-18",
+    "England/MILK-20176C2/2020": "2020-04-18",
+    "England/MILK-201771A/2020": "2020-04-18",
+    "England/MILK-2017738/2020": "2020-04-18",
+    "England/MILK-2017756/2020": "2020-04-18",
+    "England/MILK-20177B0/2020": "2020-04-18",
+    "England/MILK-20177CF/2020": "2020-04-18",
+    "England/MILK-20177FC/2020": "2020-04-18",
+    "England/MILK-2017808/2020": "2020-04-18",
+    "England/MILK-2017817/2020": "2020-04-18",
+    "England/MILK-2017844/2020": "2020-04-18",
+    "England/MILK-2017853/2020": "2020-04-18",
+    "England/MILK-20178AE/2020": "2020-04-18",
+    "England/MILK-2018D53/2020": "2020-04-19",
+    "England/MILK-2018DF9/2020": "2020-04-18",
+    "England/MILK-2019332/2020": "2020-04-18",
+    "England/MILK-20195B4/2020": "2020-04-22",
+    "England/MILK-2019790/2020": "2020-04-18",
+    "England/MILK-20197FA/2020": "2020-04-18",
+    "England/MILK-2019EC8/2020": "2020-04-18",
+    "England/MILK-2019ED7/2020": "2020-04-18",
+    "England/MILK-2019F2F/2020": "2020-04-18",
+    "England/MILK-2019F6B/2020": "2020-04-18",
+    "England/MILK-201A058/2020": "2020-04-18",
+    "England/MILK-201A155/2020": "2020-04-20",
+    "England/MILK-201A164/2020": "2020-04-18",
+    "England/MILK-201A207/2020": "2020-04-18",
+    "England/MILK-201A261/2020": "2020-04-18",
+    "England/MILK-201A2CB/2020": "2020-04-18",
+    "England/MILK-201A44D/2020": "2020-04-18",
+    "England/MILK-201A45C/2020": "2020-04-18",
+    "England/MILK-201A46B/2020": "2020-04-18",
+    "England/MILK-201A47A/2020": "2020-04-18",
+    "England/MILK-201C311/2020": "2020-04-18",
+    "England/MILK-201C38A/2020": "2020-04-18",
+    "England/MILK-201C3B7/2020": "2020-04-18",
+    "England/MILK-201C3D5/2020": "2020-04-18",
+    "England/MILK-201C43C/2020": "2020-04-18",
+    "England/MILK-201C44B/2020": "2020-04-18",
+    "England/MILK-201C627/2020": "2020-04-19",
+    "England/MILK-201C645/2020": "2020-04-18",
+    "England/MILK-201C724/2020": "2020-04-18",
+    "England/MILK-201C733/2020": "2020-04-18",
+    "England/MILK-201D40E/2020": "2020-04-19",
+    "England/MILK-201D4D1/2020": "2020-04-19",
+    "England/MILK-201D4FF/2020": "2020-04-19",
+    "England/MILK-201D50B/2020": "2020-04-19",
+    "England/MILK-201D565/2020": "2020-04-19",
+    "England/MILK-201D5A1/2020": "2020-04-19",
+    "England/MILK-201D617/2020": "2020-04-19",
+    "England/MILK-201D6BD/2020": "2020-04-19",
+    "England/MILK-201D6EA/2020": "2020-04-19",
+    "England/MILK-201D750/2020": "2020-04-19",
+    "England/MILK-201D76F/2020": "2020-04-19",
+    "England/MILK-201D78D/2020": "2020-04-19",
+    "England/MILK-201D7C9/2020": "2020-04-19",
+    "England/MILK-201D802/2020": "2020-04-19",
+    "England/MILK-201D811/2020": "2020-04-19",
+    "England/MILK-201D820/2020": "2020-04-19",
+    "England/MILK-201D83F/2020": "2020-04-19",
+    "England/MILK-201D8B7/2020": "2020-04-19",
+    "England/MILK-201FDB6/2020": "2020-04-19",
+    "England/MILK-201FDC5/2020": "2020-04-19",
+    "England/MILK-201FDE3/2020": "2020-04-19",
+    "England/MILK-201FE68/2020": "2020-04-19",
+    "England/MILK-201FE77/2020": "2020-04-19",
+    "England/MILK-201FE95/2020": "2020-04-19",
+    "England/MILK-201FED1/2020": "2020-04-19",
+    "England/MILK-201FEFF/2020": "2020-04-19",
+    "England/MILK-201FF0B/2020": "2020-04-19",
+    "England/MILK-201FF56/2020": "2020-04-19",
+    "England/MILK-201FF65/2020": "2020-04-19",
+    "England/MILK-201FFA1/2020": "2020-04-19",
+    "England/MILK-2020022/2020": "2020-04-19",
+    "England/MILK-202007D/2020": "2020-04-19",
+    "England/MILK-202009B/2020": "2020-04-19",
+    "England/MILK-202012F/2020": "2020-04-19",
+    "England/MILK-202016B/2020": "2020-04-19",
+    "England/MILK-2022002/2020": "2020-04-19",
+    "England/MILK-20220C6/2020": "2020-04-19",
+    "England/MILK-20220D5/2020": "2020-04-19",
+    "England/MILK-20221A5/2020": "2020-04-19",
+    "England/MILK-20221B4/2020": "2020-04-19",
+    "England/MILK-20222B1/2020": "2020-04-19",
+    "England/MILK-20222C0/2020": "2020-04-19",
+    "England/MILK-2022318/2020": "2020-04-19",
+    "England/MILK-2022336/2020": "2020-04-19",
+    "England/MILK-2022390/2020": "2020-04-19",
+    "England/MILK-2023195/2020": "2020-04-19",
+    "England/MILK-20231A4/2020": "2020-04-19",
+    "England/MILK-202321A/2020": "2020-04-19",
+    "England/MILK-20232A1/2020": "2020-04-20",
+    "England/MILK-20232B0/2020": "2020-04-20",
+    "England/MILK-20233AE/2020": "2020-04-20",
+    "England/MILK-20233BD/2020": "2020-04-20",
+    "England/MILK-2023423/2020": "2020-04-19",
+    "England/MILK-2023432/2020": "2020-04-20",
+    "England/MILK-2023441/2020": "2020-04-20",
+    "England/MILK-202349C/2020": "2020-04-20",
+    "England/MILK-20234C9/2020": "2020-04-20",
+    "England/MILK-2023511/2020": "2020-04-20",
+    "England/MILK-202365A/2020": "2020-04-20",
+    "England/MILK-20236D2/2020": "2020-04-20",
+    "England/MILK-20254E5/2020": "2020-04-19",
+    "England/MILK-20255B5/2020": "2020-04-19",
+    "England/MILK-20255C4/2020": "2020-04-19",
+    "England/MILK-2027902/2020": "2020-04-20",
+    "England/MILK-202793F/2020": "2020-04-20",
+    "England/MILK-2027AF0/2020": "2020-04-20",
+    "England/MILK-2027B2A/2020": "2020-04-20",
+    "England/MILK-2027B93/2020": "2020-04-20",
+    "England/MILK-2027C72/2020": "2020-04-20",
+    "England/MILK-2027D60/2020": "2020-04-20",
+    "England/MILK-2027D7F/2020": "2020-04-20",
+    "England/MILK-2027DAC/2020": "2020-04-20",
+    "England/MILK-203004D/2020": "2020-04-19",
+    "England/MILK-203005C/2020": "2020-04-19",
+    "England/MILK-2030159/2020": "2020-04-18",
+    "England/MILK-203020B/2020": "2020-04-18",
+    "England/MILK-2030247/2020": "2020-04-18",
+    "England/MILK-2030256/2020": "2020-04-18",
+    "England/MILK-20302CF/2020": "2020-04-18",
+    "England/MILK-20302DE/2020": "2020-04-18",
+    "England/MILK-2030326/2020": "2020-04-18",
+    "England/MILK-2030362/2020": "2020-04-18",
+    "England/MILK-20303AE/2020": "2020-04-18",
+    "England/MILK-20303BD/2020": "2020-04-18",
+    "England/MILK-20303CC/2020": "2020-04-18",
+    "England/MILK-2030423/2020": "2020-04-18",
+    "England/MILK-203046F/2020": "2020-04-18",
+    "England/MILK-20304C9/2020": "2020-04-18",
+    "England/MILK-2030CB2/2020": "2020-04-19",
+    "England/MILK-2030D0A/2020": "2020-04-19",
+    "England/MILK-2030D19/2020": "2020-04-19",
+    "England/MILK-2030D46/2020": "2020-04-19",
+    "England/MILK-2030D82/2020": "2020-04-19",
+    "England/MILK-2030E34/2020": "2020-04-19",
+    "England/MILK-2030E8F/2020": "2020-04-20",
+    "England/MILK-2030F31/2020": "2020-04-19",
+    "England/MILK-2030FD7/2020": "2020-04-19",
+    "England/MILK-2032861/2020": "2020-04-19",
+    "England/MILK-20328AD/2020": "2020-04-19",
+    "England/MILK-203297D/2020": "2020-04-19",
+    "England/MILK-203299B/2020": "2020-04-19",
+    "England/MILK-20329F5/2020": "2020-04-19",
+    "England/MILK-2032A4D/2020": "2020-04-19",
+    "England/MILK-2032AA7/2020": "2020-04-19",
+    "England/MILK-2032BB3/2020": "2020-04-19",
+    "England/MILK-2032BC2/2020": "2020-04-19",
+    "England/MILK-2032BFF/2020": "2020-04-19",
+    "England/MILK-2032C38/2020": "2020-04-19",
+    "England/MILK-2032C47/2020": "2020-04-19",
+    "England/MILK-2032CB0/2020": "2020-04-19",
+    "England/MILK-2032D17/2020": "2020-04-19",
+    "England/MILK-2032D44/2020": "2020-04-19",
+    "England/MILK-2032D71/2020": "2020-04-19",
+    "England/MILK-2032DAE/2020": "2020-04-19",
+    "England/MILK-2032DEA/2020": "2020-04-18",
+    "England/MILK-2032DF9/2020": "2020-04-18",
+    "England/MILK-2032E32/2020": "2020-04-18",
+    "England/MILK-2032EAB/2020": "2020-04-18",
+    "England/MILK-2032EBA/2020": "2020-04-18",
+    "England/MILK-2032F20/2020": "2020-04-18",
+    "England/MILK-2032FE4/2020": "2020-04-18",
+    "England/MILK-203301D/2020": "2020-04-18",
+    "England/MILK-203302C/2020": "2020-04-18",
+    "England/MILK-203304A/2020": "2020-04-18",
+    "England/MILK-2033129/2020": "2020-04-18",
+    "England/MILK-20331FC/2020": "2020-04-18",
+    "England/MILK-2033217/2020": "2020-04-18",
+    "England/MILK-2033226/2020": "2020-04-18",
+    "England/MILK-20332BD/2020": "2020-04-18",
+    "England/MILK-20332F9/2020": "2020-04-18",
+    "England/MILK-2033305/2020": "2020-04-18",
+    "England/MILK-2033921/2020": "2020-04-18",
+    "England/MILK-2033930/2020": "2020-04-18",
+    "England/MILK-203395E/2020": "2020-04-18",
+    "England/MILK-20339A9/2020": "2020-04-18",
+    "England/MILK-20339B8/2020": "2020-04-18",
+    "England/MILK-20339D6/2020": "2020-04-18",
+    "England/MILK-2034270/2020": "2020-04-19",
+    "England/MILK-20342BC/2020": "2020-04-19",
+    "England/MILK-2034410/2020": "2020-04-19",
+    "England/MILK-2034498/2020": "2020-04-19",
+    "England/MILK-20344B6/2020": "2020-04-19",
+    "England/MILK-20344C5/2020": "2020-04-19",
+    "England/MILK-203451D/2020": "2020-04-19",
+    "England/MILK-203452C/2020": "2020-04-19",
+    "England/MILK-203588C/2020": "2020-04-20",
+    "England/MILK-20358C8/2020": "2020-04-19",
+    "England/MILK-203593E/2020": "2020-04-19",
+    "England/MILK-203596B/2020": "2020-04-19",
+    "England/MILK-20359E3/2020": "2020-04-19",
+    "England/MILK-2035AA4/2020": "2020-04-19",
+    "England/MILK-2035B65/2020": "2020-04-19",
+    "England/MILK-2035C71/2020": "2020-04-19",
+    "England/MILK-2035C9F/2020": "2020-04-19",
+    "England/MILK-2036302/2020": "2020-04-19",
+    "England/MILK-203636C/2020": "2020-04-19",
+    "England/MILK-2036399/2020": "2020-04-19",
+    "England/MILK-203641E/2020": "2020-04-19",
+    "England/MILK-203644B/2020": "2020-04-19",
+    "England/MILK-203645A/2020": "2020-04-19",
+    "England/MILK-2036469/2020": "2020-04-19",
+    "England/MILK-2036487/2020": "2020-04-19",
+    "England/MILK-20364F0/2020": "2020-04-19",
+    "England/MILK-203652A/2020": "2020-04-19",
+    "England/MILK-2036548/2020": "2020-04-19",
+    "England/MILK-20365C0/2020": "2020-04-19",
+    "England/MILK-20365FD/2020": "2020-04-19",
+    "England/MILK-2036609/2020": "2020-04-19",
+    "England/MILK-2036672/2020": "2020-04-19",
+    "England/MILK-2036681/2020": "2020-04-19",
+    "England/MILK-20368B8/2020": "2020-04-19",
+    "England/MILK-20368C7/2020": "2020-04-20",
+    "England/MILK-2036F77/2020": "2020-04-19",
+    "England/MILK-2036F86/2020": "2020-04-19",
+    "England/MILK-2036FC2/2020": "2020-04-19",
+    "England/MILK-2037055/2020": "2020-04-19",
+    "England/MILK-2037125/2020": "2020-04-19",
+    "England/MILK-2037161/2020": "2020-04-20",
+    "England/MILK-20371AD/2020": "2020-04-19",
+    "England/MILK-20372B9/2020": "2020-04-19",
+    "England/MILK-20372C8/2020": "2020-04-19",
+    "England/MILK-20372D7/2020": "2020-04-19",
+    "England/MILK-2037301/2020": "2020-04-19",
+    "England/MILK-203733E/2020": "2020-04-19",
+    "England/MILK-2037477/2020": "2020-04-19",
+    "England/MILK-2038C32/2020": "2020-04-19",
+    "England/MILK-2038C50/2020": "2020-04-19",
+    "England/MILK-2038C9C/2020": "2020-04-19",
+    "England/MILK-2038D4E/2020": "2020-04-19",
+    "England/MILK-2038D6C/2020": "2020-04-19",
+    "England/MILK-2038D8A/2020": "2020-04-19",
+    "England/MILK-2038DA8/2020": "2020-04-19",
+    "England/MILK-2038DC6/2020": "2020-04-19",
+    "England/MILK-2038E1E/2020": "2020-04-19",
+    "England/MILK-2038E4B/2020": "2020-04-19",
+    "England/MILK-2038EF0/2020": "2020-04-21",
+    "England/MILK-2038F1B/2020": "2020-04-21",
+    "England/MILK-2038F48/2020": "2020-04-21",
+    "England/MILK-2038F84/2020": "2020-04-21",
+    "England/MILK-2038F93/2020": "2020-04-21",
+    "England/MILK-2038FB1/2020": "2020-04-21",
+    "England/MILK-2039062/2020": "2020-04-21",
+    "England/MILK-2039071/2020": "2020-04-21",
+    "England/MILK-20390AE/2020": "2020-04-21",
+    "England/MILK-20390CC/2020": "2020-04-21",
+    "England/MILK-203917E/2020": "2020-04-21",
+    "England/MILK-203919C/2020": "2020-04-21",
+    "England/MILK-20391BA/2020": "2020-04-21",
+    "England/MILK-20391D8/2020": "2020-04-21",
+    "England/MILK-203A3C2/2020": "2020-04-22",
+    "England/MILK-203A483/2020": "2020-04-22",
+    "England/MILK-203A492/2020": "2020-04-22",
+    "England/MILK-203A4B0/2020": "2020-04-22",
+    "England/MILK-203A4ED/2020": "2020-04-22",
+    "England/MILK-203A571/2020": "2020-04-22",
+    "England/MILK-203A5BD/2020": "2020-04-22",
+    "England/MILK-203A623/2020": "2020-04-22",
+    "England/MILK-203A650/2020": "2020-04-22",
+    "England/MILK-203A66F/2020": "2020-04-22",
+    "England/MILK-203A6AB/2020": "2020-04-22",
+    "England/MILK-203A6BA/2020": "2020-04-22",
+    "England/MILK-203A6C9/2020": "2020-04-22",
+    "England/MILK-203A7A8/2020": "2020-04-22",
+    "England/MILK-203A7F3/2020": "2020-04-22",
+    "England/MILK-203A81E/2020": "2020-04-22",
+    "England/MILK-203A887/2020": "2020-04-22",
+    "England/MILK-203A8C3/2020": "2020-04-22",
+    "England/MILK-203A8D2/2020": "2020-04-22",
+    "England/MILK-203A90C/2020": "2020-04-22",
+    "England/MILK-203A9EE/2020": "2020-04-22",
+    "England/MILK-203AA72/2020": "2020-04-22",
+    "England/MILK-203AA81/2020": "2020-04-22",
+    "England/MILK-203AA90/2020": "2020-04-22",
+    "England/MILK-203AACD/2020": "2020-04-22",
+    "England/MILK-203AADC/2020": "2020-04-22",
+    "England/MILK-203AB15/2020": "2020-04-22",
+    "England/MILK-203AB42/2020": "2020-04-22",
+    "England/MILK-203AB8E/2020": "2020-04-22",
+    "England/MILK-203ABAC/2020": "2020-04-22",
+    "England/MILK-203ABF7/2020": "2020-04-22",
+    "England/MILK-203AC7C/2020": "2020-04-22",
+    "England/MILK-203ACE5/2020": "2020-04-22",
+    "England/MILK-203AD00/2020": "2020-04-22",
+    "England/MILK-203AD2E/2020": "2020-04-22",
+    "England/MILK-203AD5B/2020": "2020-04-22",
+    "England/MILK-203AD79/2020": "2020-04-22",
+    "England/MILK-203AE1C/2020": "2020-04-22",
+    "England/MILK-203AE49/2020": "2020-04-22",
+    "England/MILK-203AEFE/2020": "2020-04-22",
+    "England/MILK-203AF46/2020": "2020-04-22",
+    "England/MILK-203B552/2020": "2020-04-22",
+    "England/MILK-203B59E/2020": "2020-04-22",
+    "England/MILK-203B5AD/2020": "2020-04-22",
+    "England/MILK-203B5F8/2020": "2020-04-22",
+    "England/MILK-203B613/2020": "2020-04-22",
+    "England/MILK-203B640/2020": "2020-04-21",
+    "England/MILK-203B67D/2020": "2020-04-22",
+    "England/MILK-203B68C/2020": "2020-04-22",
+    "England/MILK-203B73E/2020": "2020-04-22",
+    "England/MILK-203B75C/2020": "2020-04-22",
+    "England/MILK-203B7B6/2020": "2020-04-22",
+    "England/MILK-203B7D4/2020": "2020-04-22",
+    "England/MILK-203B877/2020": "2020-04-22",
+    "England/MILK-203B886/2020": "2020-04-22",
+    "England/MILK-203B90B/2020": "2020-04-22",
+    "England/MILK-203BA35/2020": "2020-04-22",
+    "England/MILK-203BAF9/2020": "2020-04-22",
+    "England/MILK-203CCF2/2020": "2020-04-21",
+    "England/MILK-203CD0E/2020": "2020-04-21",
+    "England/MILK-203CD4A/2020": "2020-04-21",
+    "England/MILK-203CD68/2020": "2020-04-21",
+    "England/MILK-203CD77/2020": "2020-04-21",
+    "England/MILK-203CDB3/2020": "2020-04-22",
+    "England/MILK-203CDD1/2020": "2020-04-21",
+    "England/MILK-203CE0B/2020": "2020-04-21",
+    "England/MILK-203CE38/2020": "2020-04-21",
+    "England/MILK-203CE47/2020": "2020-04-21",
+    "England/MILK-203CEA1/2020": "2020-04-21",
+    "England/MILK-203CEFC/2020": "2020-04-21",
+    "England/MILK-203CF08/2020": "2020-04-21",
+    "England/MILK-203CF62/2020": "2020-04-21",
+    "England/MILK-203CF71/2020": "2020-04-21",
+    "England/MILK-203D013/2020": "2020-04-21",
+    "England/MILK-203D12F/2020": "2020-04-21",
+    "England/MILK-203D1A7/2020": "2020-04-21",
+    "England/MILK-203D2B3/2020": "2020-04-21",
+    "England/MILK-203D338/2020": "2020-04-21",
+    "England/MILK-203D3CF/2020": "2020-04-21",
+    "England/MILK-203D444/2020": "2020-04-21",
+    "England/MILK-203D462/2020": "2020-04-21",
+    "England/MILK-203D49F/2020": "2020-04-21",
+    "England/MILK-203D4EA/2020": "2020-04-21",
+    "England/MILK-203D541/2020": "2020-04-22",
+    "England/MILK-203D550/2020": "2020-04-22",
+    "England/MILK-203D5BA/2020": "2020-04-22",
+    "England/MILK-203D620/2020": "2020-04-22",
+    "England/MILK-203D82A/2020": "2020-04-22",
+    "England/MILK-203D848/2020": "2020-04-22",
+    "England/MILK-203F002/2020": "2020-04-21",
+    "England/MILK-203F04E/2020": "2020-04-21",
+    "England/MILK-203F0E4/2020": "2020-04-21",
+    "England/MILK-203F503/2020": "2020-04-21",
+    "England/MILK-203F521/2020": "2020-04-21",
+    # These are sequences submitted where collection date seems incorrect:
+    # https://twitter.com/flodebarre/status/1414868236823318530
     # 2021-07-01 635
     # 2021-07-09 582
     # 2021-07-12 738
-    #meta <- read.csv("downloaded_gisaid.tsv", sep="\t", as.is=T)
-    #meta[which(meta$country=="France" & meta$date == "2021-07-01" & meta$authors == "Anthony LEVASSEUR et al"),]
-    #write.table(french3$strain, "french-07-01.txt", sep="\n", quote=F, row.names=F, col.names=F)
-    "France/PAC-IHU-14282-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14283-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14284-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14286-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14288-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14289-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14290-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14291-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14292-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14293-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14294-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14294-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-14296-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14298-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14299-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14300-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14301-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14302-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14303-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14304-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14305-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14306-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14307-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14308-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14309-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14310-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14311-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14312-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14314-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14316-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14317-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14318-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14319-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14320-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14321-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14322-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14323-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14324-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14327-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14328-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14329-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14330-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14331-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14332-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14333-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14334-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14335-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14337-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14338-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14339-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14340-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14341-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14341-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-14342-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-14343-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14345-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14347-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14348-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14349-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14350-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14353-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14355-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14356-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14357-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14358-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14360-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14361-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14362-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14363-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14364-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14365-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14366-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14367-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14368-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14369-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14370-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14373-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14373-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-14374-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14375-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14376-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14377-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14378-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14379-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14381-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14382-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14383-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14384-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14385-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14386-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14387-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14388-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14389-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14389-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-14393-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14394-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14395-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14396-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14398-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14469-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14470-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14471-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14472-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14473-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14474-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14475-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14477-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14478-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14479-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14480-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14481-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14482-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14483-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14484-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14486-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14487-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14488-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14489-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14490-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14491-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14492-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14493-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14494-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14495-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14497-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14498-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14500-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14502-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14503-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14504-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14505-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14506-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14507-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14508-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14509-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14510-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14511-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14512-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14513-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14514-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14515-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14516-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14517-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14518-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14519-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14520-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14521-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14522-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14523-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14524-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14525-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14526-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14527-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14529-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14530-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14531-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14532-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14533-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14534-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14535-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14536-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14537-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14538-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14539-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14540-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14541-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14542-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14543-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14544-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14545-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14546-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14547-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14548-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14549-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14550-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14551-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14552-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14553-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14555-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14556-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14557-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14558-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14559-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14560-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14561-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14562-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14564-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14565-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14566-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14567-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14568-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14569-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14570-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14571-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14572-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14573-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14574-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14575-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14576-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14577-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14578-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14579-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14580-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14581-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14582-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14583-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14584-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14585-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14586-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14587-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14588-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14589-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14590-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14591-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14592-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14593-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14594-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14595-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14597-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14598-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14599-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14600-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14601-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14602-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14603-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14604-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14605-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14606-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14607-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14609-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14610-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14611-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14613-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14614-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14616-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14617-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14618-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14619-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14620-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14621-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14622-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14623-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14624-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14625-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14626-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14627-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14629-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14630-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14633-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14634-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14635-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14636-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14637-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14638-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14639-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14640-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14641-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14642-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14643-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14645-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14646-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14647-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14648-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14649-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14650-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14651-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14652-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14653-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14654-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14656-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14657-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14658-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14660-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14662-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14663-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14664-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14665-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14666-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14667-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14668-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14670-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14671-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14672-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14673-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14674-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14675-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14676-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14677-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14678-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14679-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14680-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14682-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14683-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14684-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14685-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14687-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14688-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14690-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14691-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14692-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14693-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14694-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14697-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14698-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14699-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14701-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14702-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14703-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14704-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14705-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14707-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14708-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14709-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14710-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14712-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14713-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14714-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14715-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14716-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14719-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14720-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14721-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14722-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14723-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14724-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14725-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14726-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14727-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14728-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14729-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14730-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14731-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14732-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14733-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14734-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14736-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14737-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14738-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14739-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14740-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14741-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14742-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14743-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14744-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14745-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14746-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14747-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14748-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14749-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14750-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14752-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14753-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14754-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14755-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14757-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14758-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14759-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14760-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14761-Nova1E/2021" : "2021-07-01",
-    "France/PAC-IHU-14762-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14763-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14764-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14765-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14766-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14767-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14769-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14770-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14771-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14772-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14773-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14774-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14776-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14777-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14781-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14783-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14784-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14785-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14786-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14787-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14788-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14790-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14791-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14792-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14794-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14795-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14796-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14797-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14799-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14800-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14801-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14802-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14803-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14804-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14805-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14806-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14807-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14808-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14809-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14810-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14811-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14812-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14813-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14814-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14815-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14816-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14817-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14818-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14820-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14821-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14822-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14823-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14824-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14825-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14826-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14827-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14829-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14830-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14831-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14832-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14833-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14834-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14835-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14836-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14837-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14838-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14839-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14840-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14842-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14843-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14844-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14845-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14847-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14848-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14849-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14850-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14851-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14852-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14853-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14854-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14856-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14857-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14859-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14860-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14861-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14862-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14863-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14864-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14865-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14866-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14867-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14868-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14869-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14870-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14871-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14872-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14873-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14874-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14875-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14876-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14877-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14878-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14879-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14880-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14881-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14882-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14883-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14884-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14885-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14886-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14887-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14888-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14889-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14890-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14891-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14892-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14896-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14897-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14898-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14899-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14900-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14901-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14902-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14903-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14904-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14905-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14906-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14908-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14909-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14910-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14911-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14912-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14913-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14914-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14915-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14916-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14917-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14918-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14919-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14920-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14921-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14922-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14923-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14924-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14925-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14926-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14927-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14928-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14929-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14930-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14931-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14932-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14933-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14934-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14935-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14936-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14937-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14939-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14940-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14941-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14942-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14943-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14944-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14945-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14946-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14947-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14948-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14949-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14950-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14951-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14952-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14953-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14955-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14956-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14957-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14958-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14959-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14960-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14961-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14962-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14963-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14964-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14965-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14966-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14967-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14968-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14969-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14970-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14970-Nova2M/2021" : "2021-07-01",
-    "France/PAC-IHU-14970-Nova3M/2021" : "2021-07-01",
-    "France/PAC-IHU-14971-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14972-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14973-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14974-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14975-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14977-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14978-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14980-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14981-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14982-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14983-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14984-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14985-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14986-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14987-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14988-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14989-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14990-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14991-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14992-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14993-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14994-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-14996-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-15000-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-15001-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-15002-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-15003-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-15004-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-15005-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-15006-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-15007-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-15008-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-15009-Nova1M/2021" : "2021-07-01",
-    "France/PAC-IHU-15010-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15011-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15012-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15013-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15014-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15015-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15016-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15017-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15018-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15019-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15020-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15021-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15023-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15024-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15025-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15026-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15027-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15028-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15029-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15030-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15031-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15032-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15033-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15034-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15035-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15037-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15039-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15040-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15041-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15042-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15043-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15044-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15045-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15046-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15047-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15048-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-15050-N1/2021" : "2021-07-01",
-    "France/PAC-IHU-6872-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-7464-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-7607-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-7612-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-7619-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-7625-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-7626-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-7638-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-7639-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-7646-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-7663-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-7667-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-7668-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-7670-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-7671-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-7673-Nova2E/2021" : "2021-07-01",
-    "France/PAC-IHU-10453-Nova2A/2021" : "2021-07-09",
-    "France/PAC-IHU-14243-Nova2A/2021" : "2021-07-09",
-    "France/PAC-IHU-15080-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15081-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15082-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15083-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15086-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15087-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15088-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15089-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15090-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15091-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15092-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15093-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15094-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15095-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15096-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15097-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15098-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15099-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15101-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15102-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15104-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15105-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15106-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15107-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15108-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15109-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15110-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15111-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15112-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15113-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15114-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15115-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15116-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15117-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15118-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15119-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15121-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15123-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15124-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15125-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15126-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15127-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15128-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15129-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15130-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15131-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15132-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15133-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15134-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15135-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15136-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15137-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15138-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15139-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15140-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15141-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15142-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15143-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15144-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15145-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15146-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15147-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15148-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15149-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15150-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15151-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15152-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15153-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15154-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15155-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15156-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15157-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15158-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15159-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15160-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15161-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15162-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15163-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15164-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15166-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15167-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15168-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15169-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15170-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15171-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15172-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15173-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15174-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15175-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15176-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15177-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15178-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15180-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15181-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15182-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15183-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15184-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15185-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15186-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15187-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15188-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15189-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15190-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15191-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15192-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15193-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15194-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15195-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15197-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15198-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15199-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15200-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15201-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15202-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15203-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15204-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15205-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15206-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15207-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15208-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15209-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15210-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15211-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15212-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15213-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15215-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15216-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15217-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15218-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15219-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15220-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15221-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15222-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15223-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15224-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15225-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15226-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15227-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15228-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15229-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15230-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15231-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15232-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15234-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15235-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15236-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15237-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15238-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15239-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15240-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15241-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15242-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15243-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15244-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15246-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15248-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15249-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15250-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15251-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15252-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15253-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15254-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15255-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15256-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15257-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15258-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15259-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15260-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15261-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15262-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15263-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15264-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15266-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15267-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15268-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15269-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15270-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15272-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15273-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15274-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15275-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15276-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15277-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15278-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15281-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15282-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15283-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15286-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15287-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15288-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15289-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15291-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15292-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15293-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15294-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15295-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15296-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15297-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15299-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15300-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15301-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15302-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15303-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15304-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15305-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15306-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15307-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15308-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15309-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15311-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15312-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15314-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15315-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15316-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15318-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15319-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15320-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15321-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15322-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15323-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15324-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15325-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15326-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15327-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15328-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15329-Nova1E/2021" : "2021-07-09",
-    "France/PAC-IHU-15372-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15374-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15376-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15377-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15378-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15379-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15380-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15381-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15382-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15383-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15384-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15386-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15387-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15388-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15389-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15390-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15391-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15392-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15393-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15396-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15399-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15402-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15403-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15405-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15408-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15410-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15412-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15415-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15417-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15418-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15419-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15420-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15421-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15422-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15423-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15424-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15425-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15433-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15435-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15436-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15438-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15439-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15440-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15443-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15444-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15445-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15446-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15448-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15450-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15451-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15452-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15453-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15454-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15456-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15457-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15458-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15460-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15463-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15464-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15466-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15467-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15468-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15470-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15471-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15472-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15473-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15474-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15475-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15476-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15478-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15479-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15480-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15481-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15482-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15483-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15484-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15485-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15487-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15488-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15489-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15490-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15491-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15493-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15494-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15496-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15497-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15498-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15499-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15500-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15501-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15502-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15503-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15504-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15505-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15507-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15508-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15510-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15512-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15513-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15514-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15516-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15517-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15519-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15520-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15521-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15522-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15523-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15526-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15528-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15529-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15530-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15532-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15533-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15534-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15536-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15537-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15538-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15541-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15543-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15544-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15546-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15547-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15548-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15549-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15550-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15551-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15552-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15553-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15554-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15555-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15557-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15558-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15559-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15560-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15561-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15562-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15563-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15564-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15565-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15566-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15567-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15568-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15569-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15570-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15573-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15574-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15575-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15576-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15577-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15578-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15580-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15581-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15582-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15584-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15587-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15588-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15589-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15590-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15591-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15592-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15593-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15595-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15596-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15597-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15598-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15599-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15601-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15602-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15604-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15605-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15607-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15608-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15609-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15610-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15611-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15612-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15613-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15614-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15615-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15617-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15618-Nova1A/2021" : "2021-07-09",
-    "France/PAC-IHU-15620-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15621-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15622-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15624-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15625-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15626-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15627-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15628-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15629-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15631-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15632-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15633-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15634-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15635-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15636-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15637-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15638-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15639-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15640-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15641-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15642-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15643-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15644-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15645-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15646-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15647-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15648-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15649-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15650-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15651-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15652-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15653-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15654-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15655-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15656-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15657-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15658-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15659-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15660-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15661-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15662-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15663-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15664-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15665-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15666-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15667-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15668-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15669-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15670-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15672-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15673-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15674-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15675-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15676-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15677-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15678-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15680-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15682-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15683-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15684-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15685-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15686-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15687-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15688-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15689-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15690-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15691-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15692-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15694-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15695-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15697-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15698-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15699-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15700-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15701-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15702-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15703-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15704-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15705-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15706-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15707-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15708-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15709-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15710-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15711-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15712-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15714-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15715-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15716-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15717-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15718-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15719-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15720-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15722-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15723-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15724-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15725-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15728-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15729-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15730-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15731-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15732-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15733-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15734-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15736-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15737-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15739-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15741-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15744-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15745-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15749-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15752-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15754-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15755-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15757-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15758-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15760-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15762-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15763-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15764-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15765-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15766-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15767-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15768-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15769-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15770-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15772-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15773-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15774-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15775-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15777-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15779-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15780-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15781-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15784-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15788-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15789-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15790-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15791-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15793-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15795-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15796-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15800-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15802-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15803-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15805-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15806-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15809-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15810-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15811-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15812-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15817-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15822-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15823-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15827-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15830-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15831-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15832-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15834-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15836-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15842-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15847-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15848-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15850-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15856-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15859-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15860-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15861-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15862-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15863-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15864-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15869-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15870-Nova1M/2021" : "2021-07-09",
-    "France/PAC-IHU-15871-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15872-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15873-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15874-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15875-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15876-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15877-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15878-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15879-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15880-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15881-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15882-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15883-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15884-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15885-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15886-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15887-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15888-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15890-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15892-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15893-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15894-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15895-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15896-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15897-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15898-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15899-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15900-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15901-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15902-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15904-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15905-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15906-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15908-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15909-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15910-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15911-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15912-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15914-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15916-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15917-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15918-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15919-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15920-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15921-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15922-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15925-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15926-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15927-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15928-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15929-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15930-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15931-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15937-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15938-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15939-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15940-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15944-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15945-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15946-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15948-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15949-N1/2021" : "2021-07-12",
-    "France/PAC-IHU-15990-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-15991-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-15992-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-15993-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-15994-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-15995-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-15996-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-15997-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-15998-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-15999-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16000-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16001-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16002-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16003-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16004-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16005-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16006-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16008-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16009-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16010-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16011-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16012-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16013-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16014-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16015-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16016-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16017-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16018-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16019-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16020-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16021-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16022-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16023-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16024-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16025-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16026-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16027-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16028-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16029-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16030-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16031-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16033-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16034-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16035-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16036-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16037-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16038-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16040-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16041-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16042-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16043-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16044-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16045-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16046-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16047-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16048-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16049-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16050-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16051-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16053-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16054-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16055-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16055-NovaE2/2021" : "2021-07-12",
-    "France/PAC-IHU-16056-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16056-NovaE2/2021" : "2021-07-12",
-    "France/PAC-IHU-16057-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16058-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16059-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16060-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16061-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16065-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16066-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16067-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16068-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16069-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16070-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16071-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16072-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16073-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16074-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16075-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16076-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16077-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16078-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16079-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16080-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16081-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16082-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16083-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16084-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16085-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16086-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16087-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16088-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16089-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16090-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16091-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16092-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16093-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16094-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16095-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16096-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16097-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16098-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16099-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16100-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16101-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16102-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16103-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16104-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16106-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16107-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16108-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16109-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16110-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16113-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16114-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16115-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16116-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16117-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16118-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16119-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16120-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16121-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16122-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16123-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16125-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16126-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16127-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16128-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16129-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16131-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16132-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16133-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16134-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16135-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16136-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16137-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16138-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16139-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16142-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16143-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16144-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16145-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16146-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16147-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16148-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16149-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16150-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16151-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16152-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16153-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16154-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16155-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16156-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16157-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16158-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16159-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16160-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16161-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16162-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16164-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16166-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16167-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16168-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16169-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16170-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16171-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16172-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16173-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16174-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16176-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16177-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16178-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16179-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16180-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16181-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16182-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16183-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16184-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16185-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16187-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16188-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16189-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16190-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16191-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16193-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16196-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16197-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16199-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16200-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16202-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16204-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16205-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16207-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16208-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16209-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16210-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16211-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16212-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16213-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16214-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16215-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16217-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16218-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16219-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16220-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16221-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16222-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16223-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16224-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16225-Nova2A/2021" : "2021-07-12",
-    "France/PAC-IHU-16225-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16226-Nova2A/2021" : "2021-07-12",
-    "France/PAC-IHU-16226-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16227-Nova2A/2021" : "2021-07-12",
-    "France/PAC-IHU-16227-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16228-Nova2A/2021" : "2021-07-12",
-    "France/PAC-IHU-16228-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16229-Nova2A/2021" : "2021-07-12",
-    "France/PAC-IHU-16229-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16230-Nova2A/2021" : "2021-07-12",
-    "France/PAC-IHU-16230-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16231-Nova2A/2021" : "2021-07-12",
-    "France/PAC-IHU-16231-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16232-Nova2A/2021" : "2021-07-12",
-    "France/PAC-IHU-16232-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16233-Nova2A/2021" : "2021-07-12",
-    "France/PAC-IHU-16233-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16235-Nova2A/2021" : "2021-07-12",
-    "France/PAC-IHU-16235-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16236-Nova2A/2021" : "2021-07-12",
-    "France/PAC-IHU-16236-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16237-Nova2A/2021" : "2021-07-12",
-    "France/PAC-IHU-16237-NovaE1/2021" : "2021-07-12",
-    "France/PAC-IHU-16239-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16240-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16242-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16243-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16244-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16245-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16246-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16248-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16249-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16250-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16251-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16252-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16253-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16254-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16256-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16257-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16258-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16259-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16260-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16261-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16262-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16263-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16264-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16265-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16266-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16267-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16268-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16269-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16270-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16271-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16272-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16273-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16274-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16275-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16276-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16277-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16279-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16280-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16281-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16282-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16283-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16284-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16285-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16286-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16287-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16288-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16289-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16290-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16293-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16294-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16295-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16297-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16298-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16299-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16300-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16301-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16302-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16303-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16304-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16305-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16306-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16307-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16308-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16310-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16311-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16312-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16313-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16314-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16315-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16316-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16317-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16319-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16320-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16321-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16322-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16323-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16324-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16325-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16326-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16327-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16328-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16329-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16330-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16331-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16332-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16334-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16335-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16336-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16337-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16339-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16340-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16341-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16343-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16344-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16345-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16346-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16347-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16348-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16349-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16350-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16351-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16352-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16353-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16354-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16355-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16356-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16357-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16358-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16359-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16360-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16361-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16362-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16363-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16364-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16365-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16366-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16367-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16368-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16369-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16370-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16371-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16372-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16373-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16374-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16375-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16376-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16377-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16378-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16379-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16380-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16381-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16382-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16383-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16384-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16385-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16386-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16387-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16388-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16389-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16390-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16391-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16392-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16393-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16394-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16395-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16396-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16397-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16398-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16399-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16400-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16401-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16402-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16403-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16404-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16405-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16406-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16407-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16408-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16409-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16410-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16411-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16412-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16413-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16414-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16415-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16416-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16417-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16418-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16419-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16420-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16421-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16422-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16423-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16424-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16425-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16426-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16427-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16428-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16429-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16430-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16431-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16432-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16433-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16434-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16435-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16436-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16437-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16438-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16439-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16440-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16441-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16442-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16443-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16444-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16445-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16446-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16448-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16449-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16450-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16451-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16452-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16453-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16454-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16455-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16456-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16457-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16459-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16460-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16461-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16462-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16463-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16464-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16466-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16467-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16468-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16469-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16470-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16471-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16472-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16473-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16475-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16476-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16477-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16478-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16479-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16480-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16481-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16482-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16483-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16484-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16485-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16486-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16487-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16488-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16489-Nova1M/2021" : "2021-07-12",
-    "France/PAC-IHU-16568-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16569-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16570-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16571-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16572-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16573-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16575-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16576-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16577-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16578-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16579-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16580-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16581-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16582-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16583-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16584-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16585-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16586-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16587-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16588-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16589-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16590-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16592-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16593-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16594-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16595-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16596-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16597-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16598-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16599-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16600-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16601-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16602-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16605-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16606-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16607-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16608-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16609-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16610-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16611-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16612-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16613-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16614-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16615-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16616-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16618-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16620-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16621-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16622-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16624-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16626-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16627-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16628-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16630-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16632-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16633-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16634-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16635-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16636-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16638-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16639-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16641-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16642-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16643-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16644-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16645-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16646-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16647-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16648-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16649-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16650-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16653-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16654-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16655-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16656-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16657-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16658-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16660-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16664-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16665-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16666-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16668-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16669-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16671-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16672-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16673-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16675-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16677-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16679-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16680-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16681-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16682-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16683-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16684-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16685-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16686-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16687-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16688-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16689-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16690-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16691-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16692-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16693-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16694-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16695-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16696-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16697-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16698-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16699-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16700-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16701-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16702-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16703-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16704-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16705-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16706-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16707-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16708-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16709-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16710-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16711-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16712-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16713-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16714-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16715-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16716-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16717-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16718-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16719-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16720-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16721-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16722-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16724-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16725-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16726-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16727-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16728-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16729-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16730-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16731-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16733-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16734-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16735-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16736-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16737-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16738-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16739-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16741-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16742-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16743-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16744-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16745-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16746-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16747-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16748-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16749-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16750-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16751-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16752-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16753-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16754-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16755-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16756-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16757-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16758-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16759-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16760-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16761-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16762-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16763-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16764-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16765-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16766-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16767-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16768-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16769-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16770-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16771-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16772-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16773-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16774-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16775-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16777-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16778-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16779-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16780-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16781-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16783-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16784-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16785-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16786-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16787-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16788-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16789-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16790-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16791-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16792-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16794-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16795-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16796-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16797-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16798-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16799-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16800-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16802-Nova1A/2021" : "2021-07-12",
-    "France/PAC-IHU-16803-Nova1A/2021" : "2021-07-12",
+    # meta <- read.csv("downloaded_gisaid.tsv", sep="\t", as.is=T)
+    # meta[which(meta$country=="France" & meta$date == "2021-07-01" & meta$authors == "Anthony LEVASSEUR et al"),]
+    # write.table(french3$strain, "french-07-01.txt", sep="\n", quote=F, row.names=F, col.names=F)
+    "France/PAC-IHU-14282-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14283-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14284-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14286-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14288-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14289-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14290-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14291-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14292-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14293-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14294-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14294-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-14296-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14298-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14299-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14300-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14301-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14302-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14303-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14304-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14305-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14306-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14307-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14308-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14309-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14310-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14311-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14312-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14314-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14316-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14317-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14318-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14319-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14320-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14321-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14322-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14323-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14324-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14327-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14328-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14329-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14330-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14331-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14332-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14333-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14334-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14335-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14337-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14338-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14339-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14340-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14341-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14341-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-14342-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-14343-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14345-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14347-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14348-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14349-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14350-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14353-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14355-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14356-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14357-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14358-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14360-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14361-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14362-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14363-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14364-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14365-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14366-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14367-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14368-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14369-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14370-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14373-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14373-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-14374-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14375-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14376-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14377-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14378-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14379-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14381-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14382-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14383-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14384-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14385-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14386-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14387-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14388-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14389-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14389-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-14393-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14394-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14395-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14396-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14398-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14469-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14470-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14471-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14472-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14473-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14474-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14475-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14477-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14478-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14479-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14480-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14481-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14482-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14483-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14484-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14486-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14487-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14488-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14489-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14490-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14491-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14492-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14493-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14494-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14495-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14497-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14498-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14500-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14502-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14503-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14504-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14505-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14506-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14507-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14508-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14509-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14510-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14511-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14512-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14513-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14514-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14515-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14516-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14517-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14518-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14519-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14520-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14521-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14522-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14523-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14524-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14525-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14526-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14527-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14529-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14530-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14531-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14532-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14533-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14534-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14535-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14536-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14537-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14538-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14539-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14540-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14541-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14542-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14543-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14544-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14545-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14546-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14547-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14548-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14549-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14550-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14551-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14552-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14553-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14555-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14556-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14557-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14558-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14559-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14560-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14561-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14562-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14564-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14565-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14566-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14567-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14568-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14569-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14570-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14571-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14572-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14573-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14574-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14575-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14576-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14577-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14578-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14579-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14580-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14581-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14582-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14583-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14584-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14585-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14586-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14587-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14588-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14589-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14590-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14591-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14592-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14593-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14594-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14595-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14597-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14598-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14599-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14600-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14601-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14602-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14603-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14604-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14605-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14606-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14607-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14609-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14610-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14611-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14613-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14614-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14616-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14617-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14618-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14619-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14620-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14621-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14622-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14623-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14624-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14625-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14626-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14627-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14629-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14630-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14633-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14634-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14635-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14636-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14637-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14638-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14639-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14640-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14641-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14642-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14643-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14645-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14646-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14647-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14648-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14649-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14650-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14651-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14652-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14653-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14654-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14656-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14657-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14658-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14660-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14662-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14663-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14664-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14665-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14666-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14667-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14668-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14670-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14671-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14672-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14673-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14674-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14675-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14676-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14677-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14678-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14679-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14680-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14682-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14683-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14684-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14685-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14687-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14688-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14690-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14691-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14692-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14693-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14694-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14697-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14698-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14699-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14701-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14702-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14703-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14704-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14705-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14707-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14708-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14709-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14710-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14712-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14713-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14714-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14715-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14716-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14719-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14720-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14721-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14722-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14723-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14724-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14725-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14726-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14727-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14728-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14729-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14730-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14731-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14732-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14733-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14734-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14736-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14737-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14738-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14739-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14740-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14741-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14742-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14743-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14744-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14745-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14746-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14747-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14748-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14749-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14750-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14752-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14753-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14754-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14755-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14757-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14758-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14759-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14760-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14761-Nova1E/2021": "2021-07-01",
+    "France/PAC-IHU-14762-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14763-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14764-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14765-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14766-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14767-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14769-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14770-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14771-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14772-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14773-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14774-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14776-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14777-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14781-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14783-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14784-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14785-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14786-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14787-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14788-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14790-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14791-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14792-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14794-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14795-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14796-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14797-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14799-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14800-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14801-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14802-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14803-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14804-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14805-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14806-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14807-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14808-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14809-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14810-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14811-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14812-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14813-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14814-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14815-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14816-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14817-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14818-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14820-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14821-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14822-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14823-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14824-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14825-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14826-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14827-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14829-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14830-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14831-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14832-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14833-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14834-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14835-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14836-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14837-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14838-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14839-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14840-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14842-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14843-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14844-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14845-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14847-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14848-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14849-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14850-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14851-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14852-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14853-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14854-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14856-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14857-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14859-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14860-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14861-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14862-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14863-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14864-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14865-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14866-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14867-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14868-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14869-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14870-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14871-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14872-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14873-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14874-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14875-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14876-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14877-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14878-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14879-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14880-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14881-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14882-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14883-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14884-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14885-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14886-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14887-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14888-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14889-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14890-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14891-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14892-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14896-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14897-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14898-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14899-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14900-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14901-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14902-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14903-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14904-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14905-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14906-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14908-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14909-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14910-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14911-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14912-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14913-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14914-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14915-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14916-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14917-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14918-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14919-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14920-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14921-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14922-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14923-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14924-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14925-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14926-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14927-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14928-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14929-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14930-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14931-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14932-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14933-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14934-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14935-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14936-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14937-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14939-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14940-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14941-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14942-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14943-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14944-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14945-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14946-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14947-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14948-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14949-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14950-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14951-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14952-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14953-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14955-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14956-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14957-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14958-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14959-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14960-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14961-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14962-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14963-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14964-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14965-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14966-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14967-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14968-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14969-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14970-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14970-Nova2M/2021": "2021-07-01",
+    "France/PAC-IHU-14970-Nova3M/2021": "2021-07-01",
+    "France/PAC-IHU-14971-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14972-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14973-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14974-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14975-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14977-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14978-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14980-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14981-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14982-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14983-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14984-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14985-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14986-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14987-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14988-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14989-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14990-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14991-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14992-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14993-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14994-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-14996-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-15000-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-15001-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-15002-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-15003-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-15004-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-15005-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-15006-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-15007-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-15008-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-15009-Nova1M/2021": "2021-07-01",
+    "France/PAC-IHU-15010-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15011-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15012-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15013-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15014-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15015-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15016-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15017-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15018-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15019-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15020-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15021-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15023-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15024-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15025-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15026-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15027-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15028-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15029-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15030-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15031-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15032-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15033-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15034-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15035-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15037-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15039-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15040-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15041-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15042-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15043-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15044-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15045-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15046-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15047-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15048-N1/2021": "2021-07-01",
+    "France/PAC-IHU-15050-N1/2021": "2021-07-01",
+    "France/PAC-IHU-6872-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-7464-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-7607-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-7612-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-7619-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-7625-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-7626-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-7638-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-7639-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-7646-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-7663-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-7667-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-7668-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-7670-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-7671-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-7673-Nova2E/2021": "2021-07-01",
+    "France/PAC-IHU-10453-Nova2A/2021": "2021-07-09",
+    "France/PAC-IHU-14243-Nova2A/2021": "2021-07-09",
+    "France/PAC-IHU-15080-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15081-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15082-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15083-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15086-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15087-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15088-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15089-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15090-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15091-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15092-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15093-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15094-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15095-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15096-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15097-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15098-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15099-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15101-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15102-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15104-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15105-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15106-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15107-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15108-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15109-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15110-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15111-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15112-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15113-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15114-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15115-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15116-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15117-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15118-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15119-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15121-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15123-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15124-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15125-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15126-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15127-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15128-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15129-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15130-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15131-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15132-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15133-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15134-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15135-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15136-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15137-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15138-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15139-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15140-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15141-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15142-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15143-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15144-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15145-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15146-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15147-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15148-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15149-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15150-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15151-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15152-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15153-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15154-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15155-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15156-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15157-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15158-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15159-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15160-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15161-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15162-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15163-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15164-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15166-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15167-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15168-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15169-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15170-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15171-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15172-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15173-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15174-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15175-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15176-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15177-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15178-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15180-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15181-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15182-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15183-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15184-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15185-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15186-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15187-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15188-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15189-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15190-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15191-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15192-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15193-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15194-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15195-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15197-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15198-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15199-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15200-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15201-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15202-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15203-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15204-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15205-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15206-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15207-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15208-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15209-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15210-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15211-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15212-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15213-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15215-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15216-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15217-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15218-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15219-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15220-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15221-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15222-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15223-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15224-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15225-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15226-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15227-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15228-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15229-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15230-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15231-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15232-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15234-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15235-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15236-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15237-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15238-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15239-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15240-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15241-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15242-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15243-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15244-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15246-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15248-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15249-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15250-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15251-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15252-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15253-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15254-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15255-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15256-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15257-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15258-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15259-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15260-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15261-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15262-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15263-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15264-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15266-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15267-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15268-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15269-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15270-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15272-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15273-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15274-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15275-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15276-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15277-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15278-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15281-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15282-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15283-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15286-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15287-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15288-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15289-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15291-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15292-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15293-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15294-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15295-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15296-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15297-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15299-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15300-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15301-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15302-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15303-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15304-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15305-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15306-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15307-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15308-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15309-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15311-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15312-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15314-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15315-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15316-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15318-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15319-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15320-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15321-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15322-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15323-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15324-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15325-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15326-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15327-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15328-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15329-Nova1E/2021": "2021-07-09",
+    "France/PAC-IHU-15372-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15374-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15376-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15377-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15378-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15379-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15380-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15381-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15382-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15383-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15384-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15386-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15387-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15388-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15389-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15390-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15391-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15392-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15393-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15396-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15399-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15402-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15403-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15405-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15408-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15410-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15412-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15415-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15417-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15418-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15419-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15420-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15421-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15422-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15423-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15424-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15425-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15433-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15435-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15436-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15438-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15439-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15440-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15443-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15444-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15445-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15446-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15448-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15450-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15451-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15452-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15453-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15454-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15456-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15457-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15458-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15460-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15463-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15464-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15466-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15467-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15468-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15470-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15471-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15472-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15473-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15474-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15475-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15476-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15478-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15479-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15480-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15481-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15482-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15483-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15484-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15485-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15487-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15488-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15489-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15490-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15491-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15493-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15494-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15496-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15497-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15498-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15499-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15500-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15501-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15502-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15503-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15504-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15505-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15507-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15508-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15510-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15512-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15513-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15514-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15516-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15517-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15519-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15520-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15521-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15522-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15523-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15526-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15528-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15529-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15530-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15532-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15533-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15534-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15536-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15537-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15538-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15541-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15543-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15544-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15546-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15547-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15548-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15549-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15550-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15551-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15552-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15553-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15554-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15555-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15557-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15558-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15559-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15560-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15561-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15562-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15563-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15564-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15565-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15566-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15567-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15568-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15569-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15570-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15573-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15574-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15575-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15576-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15577-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15578-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15580-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15581-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15582-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15584-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15587-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15588-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15589-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15590-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15591-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15592-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15593-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15595-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15596-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15597-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15598-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15599-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15601-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15602-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15604-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15605-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15607-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15608-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15609-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15610-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15611-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15612-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15613-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15614-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15615-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15617-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15618-Nova1A/2021": "2021-07-09",
+    "France/PAC-IHU-15620-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15621-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15622-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15624-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15625-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15626-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15627-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15628-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15629-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15631-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15632-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15633-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15634-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15635-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15636-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15637-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15638-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15639-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15640-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15641-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15642-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15643-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15644-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15645-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15646-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15647-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15648-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15649-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15650-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15651-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15652-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15653-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15654-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15655-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15656-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15657-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15658-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15659-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15660-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15661-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15662-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15663-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15664-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15665-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15666-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15667-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15668-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15669-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15670-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15672-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15673-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15674-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15675-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15676-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15677-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15678-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15680-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15682-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15683-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15684-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15685-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15686-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15687-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15688-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15689-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15690-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15691-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15692-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15694-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15695-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15697-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15698-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15699-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15700-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15701-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15702-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15703-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15704-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15705-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15706-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15707-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15708-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15709-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15710-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15711-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15712-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15714-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15715-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15716-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15717-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15718-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15719-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15720-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15722-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15723-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15724-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15725-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15728-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15729-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15730-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15731-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15732-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15733-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15734-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15736-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15737-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15739-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15741-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15744-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15745-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15749-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15752-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15754-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15755-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15757-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15758-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15760-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15762-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15763-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15764-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15765-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15766-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15767-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15768-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15769-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15770-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15772-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15773-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15774-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15775-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15777-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15779-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15780-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15781-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15784-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15788-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15789-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15790-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15791-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15793-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15795-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15796-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15800-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15802-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15803-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15805-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15806-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15809-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15810-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15811-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15812-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15817-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15822-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15823-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15827-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15830-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15831-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15832-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15834-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15836-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15842-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15847-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15848-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15850-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15856-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15859-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15860-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15861-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15862-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15863-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15864-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15869-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15870-Nova1M/2021": "2021-07-09",
+    "France/PAC-IHU-15871-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15872-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15873-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15874-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15875-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15876-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15877-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15878-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15879-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15880-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15881-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15882-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15883-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15884-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15885-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15886-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15887-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15888-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15890-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15892-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15893-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15894-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15895-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15896-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15897-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15898-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15899-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15900-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15901-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15902-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15904-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15905-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15906-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15908-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15909-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15910-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15911-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15912-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15914-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15916-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15917-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15918-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15919-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15920-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15921-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15922-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15925-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15926-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15927-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15928-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15929-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15930-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15931-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15937-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15938-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15939-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15940-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15944-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15945-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15946-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15948-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15949-N1/2021": "2021-07-12",
+    "France/PAC-IHU-15990-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-15991-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-15992-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-15993-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-15994-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-15995-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-15996-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-15997-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-15998-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-15999-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16000-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16001-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16002-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16003-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16004-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16005-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16006-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16008-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16009-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16010-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16011-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16012-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16013-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16014-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16015-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16016-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16017-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16018-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16019-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16020-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16021-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16022-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16023-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16024-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16025-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16026-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16027-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16028-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16029-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16030-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16031-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16033-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16034-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16035-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16036-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16037-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16038-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16040-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16041-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16042-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16043-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16044-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16045-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16046-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16047-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16048-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16049-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16050-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16051-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16053-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16054-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16055-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16055-NovaE2/2021": "2021-07-12",
+    "France/PAC-IHU-16056-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16056-NovaE2/2021": "2021-07-12",
+    "France/PAC-IHU-16057-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16058-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16059-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16060-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16061-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16065-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16066-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16067-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16068-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16069-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16070-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16071-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16072-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16073-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16074-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16075-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16076-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16077-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16078-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16079-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16080-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16081-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16082-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16083-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16084-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16085-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16086-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16087-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16088-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16089-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16090-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16091-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16092-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16093-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16094-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16095-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16096-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16097-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16098-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16099-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16100-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16101-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16102-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16103-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16104-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16106-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16107-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16108-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16109-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16110-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16113-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16114-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16115-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16116-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16117-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16118-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16119-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16120-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16121-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16122-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16123-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16125-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16126-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16127-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16128-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16129-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16131-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16132-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16133-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16134-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16135-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16136-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16137-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16138-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16139-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16142-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16143-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16144-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16145-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16146-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16147-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16148-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16149-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16150-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16151-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16152-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16153-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16154-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16155-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16156-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16157-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16158-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16159-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16160-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16161-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16162-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16164-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16166-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16167-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16168-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16169-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16170-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16171-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16172-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16173-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16174-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16176-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16177-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16178-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16179-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16180-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16181-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16182-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16183-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16184-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16185-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16187-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16188-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16189-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16190-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16191-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16193-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16196-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16197-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16199-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16200-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16202-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16204-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16205-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16207-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16208-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16209-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16210-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16211-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16212-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16213-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16214-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16215-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16217-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16218-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16219-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16220-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16221-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16222-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16223-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16224-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16225-Nova2A/2021": "2021-07-12",
+    "France/PAC-IHU-16225-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16226-Nova2A/2021": "2021-07-12",
+    "France/PAC-IHU-16226-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16227-Nova2A/2021": "2021-07-12",
+    "France/PAC-IHU-16227-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16228-Nova2A/2021": "2021-07-12",
+    "France/PAC-IHU-16228-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16229-Nova2A/2021": "2021-07-12",
+    "France/PAC-IHU-16229-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16230-Nova2A/2021": "2021-07-12",
+    "France/PAC-IHU-16230-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16231-Nova2A/2021": "2021-07-12",
+    "France/PAC-IHU-16231-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16232-Nova2A/2021": "2021-07-12",
+    "France/PAC-IHU-16232-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16233-Nova2A/2021": "2021-07-12",
+    "France/PAC-IHU-16233-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16235-Nova2A/2021": "2021-07-12",
+    "France/PAC-IHU-16235-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16236-Nova2A/2021": "2021-07-12",
+    "France/PAC-IHU-16236-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16237-Nova2A/2021": "2021-07-12",
+    "France/PAC-IHU-16237-NovaE1/2021": "2021-07-12",
+    "France/PAC-IHU-16239-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16240-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16242-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16243-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16244-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16245-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16246-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16248-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16249-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16250-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16251-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16252-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16253-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16254-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16256-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16257-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16258-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16259-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16260-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16261-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16262-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16263-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16264-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16265-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16266-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16267-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16268-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16269-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16270-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16271-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16272-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16273-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16274-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16275-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16276-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16277-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16279-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16280-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16281-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16282-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16283-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16284-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16285-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16286-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16287-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16288-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16289-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16290-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16293-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16294-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16295-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16297-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16298-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16299-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16300-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16301-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16302-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16303-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16304-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16305-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16306-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16307-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16308-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16310-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16311-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16312-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16313-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16314-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16315-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16316-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16317-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16319-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16320-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16321-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16322-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16323-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16324-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16325-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16326-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16327-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16328-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16329-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16330-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16331-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16332-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16334-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16335-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16336-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16337-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16339-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16340-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16341-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16343-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16344-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16345-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16346-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16347-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16348-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16349-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16350-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16351-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16352-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16353-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16354-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16355-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16356-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16357-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16358-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16359-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16360-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16361-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16362-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16363-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16364-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16365-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16366-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16367-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16368-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16369-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16370-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16371-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16372-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16373-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16374-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16375-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16376-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16377-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16378-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16379-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16380-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16381-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16382-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16383-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16384-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16385-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16386-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16387-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16388-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16389-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16390-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16391-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16392-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16393-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16394-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16395-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16396-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16397-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16398-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16399-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16400-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16401-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16402-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16403-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16404-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16405-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16406-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16407-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16408-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16409-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16410-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16411-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16412-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16413-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16414-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16415-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16416-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16417-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16418-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16419-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16420-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16421-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16422-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16423-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16424-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16425-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16426-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16427-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16428-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16429-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16430-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16431-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16432-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16433-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16434-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16435-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16436-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16437-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16438-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16439-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16440-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16441-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16442-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16443-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16444-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16445-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16446-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16448-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16449-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16450-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16451-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16452-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16453-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16454-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16455-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16456-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16457-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16459-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16460-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16461-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16462-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16463-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16464-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16466-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16467-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16468-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16469-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16470-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16471-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16472-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16473-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16475-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16476-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16477-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16478-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16479-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16480-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16481-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16482-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16483-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16484-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16485-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16486-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16487-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16488-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16489-Nova1M/2021": "2021-07-12",
+    "France/PAC-IHU-16568-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16569-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16570-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16571-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16572-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16573-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16575-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16576-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16577-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16578-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16579-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16580-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16581-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16582-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16583-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16584-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16585-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16586-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16587-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16588-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16589-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16590-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16592-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16593-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16594-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16595-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16596-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16597-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16598-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16599-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16600-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16601-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16602-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16605-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16606-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16607-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16608-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16609-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16610-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16611-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16612-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16613-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16614-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16615-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16616-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16618-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16620-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16621-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16622-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16624-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16626-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16627-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16628-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16630-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16632-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16633-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16634-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16635-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16636-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16638-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16639-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16641-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16642-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16643-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16644-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16645-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16646-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16647-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16648-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16649-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16650-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16653-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16654-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16655-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16656-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16657-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16658-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16660-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16664-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16665-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16666-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16668-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16669-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16671-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16672-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16673-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16675-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16677-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16679-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16680-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16681-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16682-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16683-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16684-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16685-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16686-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16687-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16688-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16689-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16690-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16691-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16692-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16693-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16694-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16695-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16696-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16697-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16698-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16699-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16700-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16701-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16702-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16703-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16704-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16705-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16706-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16707-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16708-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16709-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16710-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16711-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16712-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16713-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16714-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16715-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16716-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16717-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16718-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16719-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16720-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16721-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16722-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16724-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16725-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16726-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16727-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16728-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16729-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16730-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16731-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16733-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16734-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16735-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16736-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16737-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16738-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16739-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16741-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16742-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16743-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16744-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16745-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16746-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16747-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16748-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16749-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16750-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16751-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16752-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16753-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16754-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16755-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16756-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16757-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16758-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16759-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16760-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16761-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16762-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16763-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16764-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16765-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16766-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16767-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16768-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16769-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16770-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16771-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16772-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16773-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16774-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16775-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16777-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16778-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16779-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16780-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16781-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16783-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16784-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16785-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16786-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16787-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16788-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16789-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16790-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16791-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16792-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16794-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16795-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16796-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16797-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16798-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16799-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16800-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16802-Nova1A/2021": "2021-07-12",
+    "France/PAC-IHU-16803-Nova1A/2021": "2021-07-12",
 }

--- a/scripts/clusterDynamics.py
+++ b/scripts/clusterDynamics.py
@@ -81,9 +81,7 @@ clus_to_run = ["S222"]
 reask = True
 
 while reask:
-    clus_answer = input(
-        "\nWhat cluster to run? (Enter for S222) Type 'all' for all, type 'all mink' for all+mink: "
-    )
+    clus_answer = input("\nWhat cluster to run? (Enter for S222) Type 'all' for all, type 'all mink' for all+mink: ")
     if len(clus_answer) != 0:
         if clus_answer in clusters.keys():
             print(f"Using {clus_answer}\n")
@@ -113,8 +111,8 @@ for clus in clus_to_run:
         mink_meta = meta[meta["host"].apply(lambda x: x == "Mink")]
         wanted_seqs = list(mink_meta["strain"])
 
-        clusterlist_output = cluster_path + f"/clusters/cluster_mink.txt"
-        out_meta_file = cluster_path + f"/cluster_info/cluster_mink_meta.tsv"
+        clusterlist_output = cluster_path + "/clusters/cluster_mink.txt"
+        out_meta_file = cluster_path + "/cluster_info/cluster_mink_meta.tsv"
 
     else:
         snps = clusters[clus]["snps"]
@@ -123,13 +121,8 @@ for clus in clus_to_run:
         else:
             snps2 = []
 
-        clusterlist_output = (
-            cluster_path + f'/clusters/cluster_{clusters[clus]["build_name"]}.txt'
-        )
-        out_meta_file = (
-            cluster_path
-            + f'/cluster_info/cluster_{clusters[clus]["build_name"]}_meta.tsv'
-        )
+        clusterlist_output = cluster_path + f'/clusters/cluster_{clusters[clus]["build_name"]}.txt'
+        out_meta_file = cluster_path + f'/cluster_info/cluster_{clusters[clus]["build_name"]}_meta.tsv'
 
         # get the sequences that we want - which are 'part of the cluster:
         wanted_seqs = []
@@ -139,53 +132,33 @@ for clus in clus_to_run:
             snplist = row["all_snps"]
             if not pd.isna(snplist):
                 intsnp = [int(x) for x in snplist.split(",")]
-                if all(x in intsnp for x in snps) or (
-                    all(x in intsnp for x in snps2) and len(snps2) != 0
-                ):
+                if all(x in intsnp for x in snps) or (all(x in intsnp for x in snps2) and len(snps2) != 0):
                     # if meta.loc[meta['strain'] == strain].region.values[0] == "Europe":
                     wanted_seqs.append(row["strain"])
 
     # There's one spanish seq with date of 7 March - we think this is wrong.
     # If seq there and date bad - exclude!
     bad_seq = meta[meta["strain"].isin(["Spain/VC-IBV-98006466/2020"])]
-    if (
-        bad_seq.date.values[0] == "2020-03-07"
-        and "Spain/VC-IBV-98006466/2020" in wanted_seqs
-    ):
+    if bad_seq.date.values[0] == "2020-03-07" and "Spain/VC-IBV-98006466/2020" in wanted_seqs:
         wanted_seqs.remove("Spain/VC-IBV-98006466/2020")
 
     # There are two sequences from UK with suspected bad dates: exclude
     bad_seq = meta[meta["strain"].isin(["England/LIVE-1DD7AC/2020"])]
-    if (
-        bad_seq.date.values[0] == "2020-03-10"
-        and "England/LIVE-1DD7AC/2020" in wanted_seqs
-    ):
+    if bad_seq.date.values[0] == "2020-03-10" and "England/LIVE-1DD7AC/2020" in wanted_seqs:
         wanted_seqs.remove("England/LIVE-1DD7AC/2020")
     bad_seq = meta[meta["strain"].isin(["England/PORT-2D2111/2020"])]
-    if (
-        bad_seq.date.values[0] == "2020-03-21"
-        and "England/PORT-2D2111/2020" in wanted_seqs
-    ):
+    if bad_seq.date.values[0] == "2020-03-21" and "England/PORT-2D2111/2020" in wanted_seqs:
         wanted_seqs.remove("England/PORT-2D2111/2020")
 
     # suspected that these ones have reversed dd-mm (are actually 5 and 6 Nov)
     bad_seq = meta[meta["strain"].isin(["England/CAMB-1BA110/2020"])]
-    if (
-        bad_seq.date.values[0] == "2020-06-11"
-        and "England/CAMB-1BA110/2020" in wanted_seqs
-    ):
+    if bad_seq.date.values[0] == "2020-06-11" and "England/CAMB-1BA110/2020" in wanted_seqs:
         wanted_seqs.remove("England/CAMB-1BA110/2020")
     bad_seq = meta[meta["strain"].isin(["England/CAMB-1BA0F5/2020"])]
-    if (
-        bad_seq.date.values[0] == "2020-05-11"
-        and "England/CAMB-1BA0F5/2020" in wanted_seqs
-    ):
+    if bad_seq.date.values[0] == "2020-05-11" and "England/CAMB-1BA0F5/2020" in wanted_seqs:
         wanted_seqs.remove("England/CAMB-1BA0F5/2020")
     bad_seq = meta[meta["strain"].isin(["England/CAMB-1BA0B9/2020"])]
-    if (
-        bad_seq.date.values[0] == "2020-05-11"
-        and "England/CAMB-1BA0B9/2020" in wanted_seqs
-    ):
+    if bad_seq.date.values[0] == "2020-05-11" and "England/CAMB-1BA0B9/2020" in wanted_seqs:
         wanted_seqs.remove("England/CAMB-1BA0B9/2020")
 
     # get metadata for these sequences
@@ -262,9 +235,7 @@ for clus in clus_to_run:
         country_info.loc[coun].last_seq = temp_meta["date"].max()
         country_info.loc[coun].num_seqs = len(temp_meta)
 
-        country_dates[coun] = [
-            datetime.datetime.strptime(dat, "%Y-%m-%d") for dat in temp_meta["date"]
-        ]
+        country_dates[coun] = [datetime.datetime.strptime(dat, "%Y-%m-%d") for dat in temp_meta["date"]]
 
         herbst_dates = [x for x in country_dates[coun] if x >= cutoffDate]
         if coun in uk_countries:
@@ -274,16 +245,12 @@ for clus in clus_to_run:
         all_dates = [
             datetime.datetime.strptime(x, "%Y-%m-%d")
             for x in temp_meta["date"]
-            if len(x) is 10
-            and "-XX" not in x
-            and datetime.datetime.strptime(x, "%Y-%m-%d") >= cutoffDate
+            if len(x) is 10 and "-XX" not in x and datetime.datetime.strptime(x, "%Y-%m-%d") >= cutoffDate
         ]
         if len(all_dates) == 0:
             country_info.loc[coun].sept_oct_freq = 0
         else:
-            country_info.loc[coun].sept_oct_freq = round(
-                len(herbst_dates) / len(all_dates), 2
-            )
+            country_info.loc[coun].sept_oct_freq = round(len(herbst_dates) / len(all_dates), 2)
 
     print(country_info)
     print("\n")
@@ -328,9 +295,7 @@ for clus in clus_to_run:
         # week 20
         for ri, row in temp_meta.iterrows():
             dat = row.date
-            if (
-                len(dat) is 10 and "-XX" not in dat
-            ):  # only take those that have real dates
+            if len(dat) is 10 and "-XX" not in dat:  # only take those that have real dates
                 dt = datetime.datetime.strptime(dat, "%Y-%m-%d")
                 # exclude sequences with identical dates & underdiverged
                 if coun == "Ireland" and dat == "2020-09-22":
@@ -352,12 +317,8 @@ for clus in clus_to_run:
         total_week_counts[coun] = counts_by_week
 
     if print_files:
-        with open(
-            f"../cluster_new_scripts/{clus}_acknowledgement_table.tsv", "w"
-        ) as fh:
-            fh.write(
-                "#strain\tEPI_ISOLATE_ID\tOriginating lab\tsubmitting lab\tauthors\n"
-            )
+        with open(f"../cluster_new_scripts/{clus}_acknowledgement_table.tsv", "w") as fh:
+            fh.write("#strain\tEPI_ISOLATE_ID\tOriginating lab\tsubmitting lab\tauthors\n")
             for d in acknowledgement_table:
                 fh.write("\t".join(d) + "\n")
 
@@ -387,7 +348,7 @@ for clus in clus_to_run:
     countries_to_plot = [
         "France",
         "United Kingdom",
-        #'Latvia',
+        # 'Latvia',
         "Norway",
         "Spain",
         "Switzerland",
@@ -409,7 +370,10 @@ for clus in clus_to_run:
         #                                    gridspec_kw={'height_ratios':[1,1,3]})
         # Change to just show Travel to spain only. see above for old 3 panel version
         fig, (ax1, ax3) = plt.subplots(
-            nrows=2, sharex=True, figsize=(10, 6), gridspec_kw={"height_ratios": [1, 3]}
+            nrows=2,
+            sharex=True,
+            figsize=(10, 6),
+            gridspec_kw={"height_ratios": [1, 3]},
         )
         i = 0
         # for coun in [x for x in countries_to_plot]:
@@ -432,12 +396,8 @@ for clus in clus_to_run:
                 # ax1.text(strt, y_start+0.002, q_times["msg"], fontsize=fs*0.8)
                 ax1.text(strt, y_start + 0.003, q_times["msg"], fontsize=fs * 0.8)
                 if coun == "Denmark":
-                    strt = datetime.datetime.strptime(
-                        q_free_to_spain["Denmark2"]["start"], "%Y-%m-%d"
-                    )
-                    end = datetime.datetime.strptime(
-                        q_free_to_spain["Denmark2"]["end"], "%Y-%m-%d"
-                    )
+                    strt = datetime.datetime.strptime(q_free_to_spain["Denmark2"]["start"], "%Y-%m-%d")
+                    end = datetime.datetime.strptime(q_free_to_spain["Denmark2"]["end"], "%Y-%m-%d")
                     ax1.add_patch(
                         Rectangle(
                             (strt, y_start),
@@ -478,12 +438,14 @@ for clus in clus_to_run:
 
         # for a simpler plot of most interesting countries use this:
         for coun in [x for x in countries_to_plot]:
-            week_as_date, cluster_count, total_count = non_zero_counts(
-                cluster_data, total_data, coun
-            )
+            week_as_date, cluster_count, total_count = non_zero_counts(cluster_data, total_data, coun)
             # remove last data point if that point as less than frac sequences compared to the previous count
             week_as_date, cluster_count, total_count = trim_last_data_point(
-                week_as_date, cluster_count, total_count, frac=0.1, keep_count=10
+                week_as_date,
+                cluster_count,
+                total_count,
+                frac=0.1,
+                keep_count=10,
             )
 
             ax3.plot(
@@ -533,13 +495,12 @@ for clus in clus_to_run:
             plt.savefig(figure_path + f"overall_trends.{fmt}")
             trends_path = figure_path + f"overall_trends.{fmt}"
             copypath = trends_path.replace(
-                "trends", "trends-{}".format(datetime.date.today().strftime("%Y-%m-%d"))
+                "trends",
+                "trends-{}".format(datetime.date.today().strftime("%Y-%m-%d")),
             )
             copyfile(trends_path, copypath)
 
-        all_plots = input(
-            "\nDo you want to plot growth rate + all sequences graphs? (y/n): "
-        )
+        all_plots = input("\nDo you want to plot growth rate + all sequences graphs? (y/n): ")
 
         if all_plots == "y":
 
@@ -556,9 +517,7 @@ for clus in clus_to_run:
                 "Northern Ireland",
                 "United Kingdom",
             ]:
-                week_as_date, cluster_count, total_count = non_zero_counts(
-                    cluster_data, total_data, coun
-                )
+                week_as_date, cluster_count, total_count = non_zero_counts(cluster_data, total_data, coun)
 
                 if coun == "United Kingdom":
                     print("UK")
@@ -599,9 +558,7 @@ for clus in clus_to_run:
                 "United Kingdom",
                 "Denmark",
             ]:
-                week_as_date, cluster_count, total_count = non_zero_counts(
-                    cluster_data, total_data, coun
-                )
+                week_as_date, cluster_count, total_count = non_zero_counts(cluster_data, total_data, coun)
                 days = np.array([x.toordinal() for x in week_as_date])
                 mean_upper_lower = []
                 for x, n in zip(cluster_count, total_count):
@@ -671,19 +628,21 @@ for clus in clus_to_run:
 
             seqs_week = {}
 
-            for coun in ["Switzerland", "Spain", "United Kingdom", "Norway", "Denmark"]:
+            for coun in [
+                "Switzerland",
+                "Spain",
+                "United Kingdom",
+                "Norway",
+                "Denmark",
+            ]:
                 # read in case data
-                case_week_as_date, case_data = read_case_data_by_week(
-                    case_data_path + case_files[coun]
-                )
+                case_week_as_date, case_data = read_case_data_by_week(case_data_path + case_files[coun])
 
                 # Now get total number of sequence, per week - by using metadata.tsv from ncov
                 counts_by_week = defaultdict(int)
                 temp_meta = meta[meta["country"].isin([coun])]
                 for dat in temp_meta["date"]:
-                    if (
-                        len(dat) is 10 and "-XX" not in dat
-                    ):  # only take those that have real dates
+                    if len(dat) is 10 and "-XX" not in dat:  # only take those that have real dates
                         dt = datetime.datetime.strptime(dat, "%Y-%m-%d")
                         wk = dt.isocalendar()[1]  # returns ISO calendar week
                         counts_by_week[wk] += 1
@@ -693,12 +652,8 @@ for clus in clus_to_run:
                 seqs_data = seqs_data.sort_index()
 
                 # Only plot sequence data for weeks were data is available (avoid plotting random 0s bc no seqs)
-                weeks = pd.concat([cluster_data[coun], seqs_data[coun]], axis=1).fillna(
-                    0
-                )
-                week_as_date, cluster_count, total_count = non_zero_counts(
-                    cluster_data, total_data, coun
-                )
+                weeks = pd.concat([cluster_data[coun], seqs_data[coun]], axis=1).fillna(0)
+                week_as_date, cluster_count, total_count = non_zero_counts(cluster_data, total_data, coun)
                 # convert week numbers back to first day of that week - so that X axis is real time rather than weeks
                 days = np.array([x.toordinal() for x in case_week_as_date])
 
@@ -721,9 +676,7 @@ for clus in clus_to_run:
                 ax1.tick_params(axis="y", labelcolor=color)
                 ax1.set_yscale("log")
 
-                ax2 = (
-                    ax1.twinx()
-                )  # instantiate a second axes that shares the same x-axis
+                ax2 = ax1.twinx()  # instantiate a second axes that shares the same x-axis
                 color = "tab:red"
                 ax2.set_ylabel("Sequences", color=color)
                 # ax2.plot(week_as_date, weeks.loc[with_data].iloc[:,0]/(total[with_data]), 'o', color=color, label=coun, linestyle=sty)
@@ -754,14 +707,18 @@ for clus in clus_to_run:
                 if coun is "Norway":
                     plt.legend(
                         lines,
-                        ["cases per week", "total sequences", "sequences in cluster"],
+                        [
+                            "cases per week",
+                            "total sequences",
+                            "sequences in cluster",
+                        ],
                         loc=3,
                     )
                 else:
                     plt.legend(
                         lines,
                         [
-                            "cases per week",  #'cases per week w/o cluster',
+                            "cases per week",  # 'cases per week w/o cluster',
                             "total sequences",
                             "sequences in cluster",
                         ],
@@ -793,28 +750,28 @@ for clus in clus_to_run:
 # eng_y_end = 0.05
 # ax1.add_patch(Rectangle((eng_quarFree_start,eng_y_start), eng_quarFree_end-eng_quarFree_start, eng_y_end, ec='lightskyblue', fc='lightskyblue'))
 #
-##swiss q-free-travel to spain
+## swiss q-free-travel to spain
 # ch_quarFree_start = datetime.datetime.strptime("2020-06-15", "%Y-%m-%d")
 # ch_quarFree_end = datetime.datetime.strptime("2020-08-10", "%Y-%m-%d")
 # ch_y_start = 0.07
 # ch_y_end = 0.05
 # ax1.add_patch(Rectangle((ch_quarFree_start,ch_y_start), ch_quarFree_end-ch_quarFree_start, ch_y_end, ec='peru', fc='peru'))
 #
-##norway q-free-travel to spain
+## norway q-free-travel to spain
 # no_quarFree_start = datetime.datetime.strptime("2020-07-15", "%Y-%m-%d")
 # no_quarFree_end = datetime.datetime.strptime("2020-07-25", "%Y-%m-%d")
 # no_y_start = 0.12
 # no_y_end = 0.05
 # ax1.add_patch(Rectangle((no_quarFree_start,no_y_start), no_quarFree_end-no_quarFree_start, no_y_end, ec='lightpink', fc='lightpink'))
 #
-##latvia q-free-travel to spain
+## latvia q-free-travel to spain
 # la_quarFree_start = datetime.datetime.strptime("2020-07-01", "%Y-%m-%d")
 # la_quarFree_end = datetime.datetime.strptime("2020-07-17", "%Y-%m-%d")
 # la_y_start = 0.17
 # la_y_end = 0.05
 # ax1.add_patch(Rectangle((la_quarFree_start,la_y_start), la_quarFree_end-la_quarFree_start, la_y_end, ec='lightgreen', fc='lightgreen'))
 #
-##france Q-free travel to spain
+## france Q-free travel to spain
 # fr_quarFree_start = datetime.datetime.strptime("2020-06-15", "%Y-%m-%d")
 # fr_quarFree_end = datetime.datetime.strptime("2020-10-05", "%Y-%m-%d")
 # fr_y_start = 0.22

--- a/scripts/cluster_by_country.py
+++ b/scripts/cluster_by_country.py
@@ -33,15 +33,15 @@ for clus, ax in zip(clusters.keys(), axs):
     percents_t = percents[clus].div(percents[clus].sum(axis=1), axis=0)
     percents_t = percents_t.transpose()
     percents_t = percents_t.fillna(0)
-    week_as_date = [
-        datetime.datetime.strptime("2020-W{}-1".format(x), "%G-W%V-%u")
-        for x in percents[clus].index
-    ]
+    week_as_date = [datetime.datetime.strptime("2020-W{}-1".format(x), "%G-W%V-%u") for x in percents[clus].index]
 
     colors = [country_styles[co]["c"] for co in percents_t.index]
 
     ax.stackplot(
-        week_as_date, percents_t.values.tolist(), labels=percents_t.index, colors=colors
+        week_as_date,
+        percents_t.values.tolist(),
+        labels=percents_t.index,
+        colors=colors,
     )
     ax.text(
         datetime.datetime(2020, 5, 25),

--- a/scripts/clusters.py
+++ b/scripts/clusters.py
@@ -1,7 +1,6 @@
 clusters = {
-
     "Alpha": {
-        "snps": [23063, 23604, 24914], #23063T, 23604A, 24914C
+        "snps": [23063, 23604, 24914],  # 23063T, 23604A, 24914C
         "cluster_data": [],  # 501, 681, 1118
         "nextstrain_build": True,
         "graphing": True,
@@ -15,9 +14,7 @@ clusters = {
         "old_build_names": ["S.501Y.V1"],
         "who_name": ["Alpha"],
         "nextstrain_name": "20I (Alpha, V1)",
-        "pango_lineage": [
-            {"name": "B.1.1.7", "url": None}
-        ],
+        "pango_lineage": [{"name": "B.1.1.7", "url": None}],
         "alternative_names": ["VOC 202012/01"],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/20I.Alpha.V1",  # color, no europe filter
         "mutations": {
@@ -27,25 +24,25 @@ clusters = {
                 {"gene": "S", "left": "Y", "pos": 144, "right": "-"},
                 {"gene": "S", "left": "N", "pos": 501, "right": "Y"},
                 {"gene": "S", "left": "A", "pos": 570, "right": "D"},
-                {'gene': 'S', 'left': 'D', 'pos': 614, 'right': 'G'},
+                {"gene": "S", "left": "D", "pos": 614, "right": "G"},
                 {"gene": "S", "left": "P", "pos": 681, "right": "H"},
-                {'gene': 'S', 'left': 'T', 'pos': 716, 'right': 'I'},
-                {'gene': 'S', 'left': 'S', 'pos': 982, 'right': 'A'},
-                {'gene': 'S', 'left': 'D', 'pos': 1118, 'right': 'H'},
-                {'gene': 'ORF1a', 'left': 'T', 'pos': 1001, 'right': 'I'},
-                {'gene': 'ORF1a', 'left': 'A', 'pos': 1708, 'right': 'D'},
-                {'gene': 'ORF1a', 'left': 'I', 'pos': 2230, 'right': 'T'},
+                {"gene": "S", "left": "T", "pos": 716, "right": "I"},
+                {"gene": "S", "left": "S", "pos": 982, "right": "A"},
+                {"gene": "S", "left": "D", "pos": 1118, "right": "H"},
+                {"gene": "ORF1a", "left": "T", "pos": 1001, "right": "I"},
+                {"gene": "ORF1a", "left": "A", "pos": 1708, "right": "D"},
+                {"gene": "ORF1a", "left": "I", "pos": 2230, "right": "T"},
                 {"gene": "ORF1a", "left": "S", "pos": 3675, "right": "-"},
                 {"gene": "ORF1a", "left": "G", "pos": 3676, "right": "-"},
                 {"gene": "ORF1a", "left": "F", "pos": 3677, "right": "-"},
-                {'gene': 'N', 'left': 'D', 'pos': 3, 'right': 'L'},
+                {"gene": "N", "left": "D", "pos": 3, "right": "L"},
                 {"gene": "N", "left": "R", "pos": 203, "right": "K"},
                 {"gene": "N", "left": "G", "pos": 204, "right": "R"},
-                {'gene': 'N', 'left': 'S', 'pos': 235, 'right': 'F'},
-                {'gene': 'ORF1b', 'left': 'P', 'pos': 314, 'right': 'L'},
+                {"gene": "N", "left": "S", "pos": 235, "right": "F"},
+                {"gene": "ORF1b", "left": "P", "pos": 314, "right": "L"},
                 {"gene": "ORF8", "left": "Q", "pos": 27, "right": "*"},
-                {'gene': 'ORF8', 'left': 'R', 'pos': 52, 'right': 'I'},
-                {'gene': 'ORF8', 'left': 'Y', 'pos': 73, 'right': 'C'}
+                {"gene": "ORF8", "left": "R", "pos": 52, "right": "I"},
+                {"gene": "ORF8", "left": "Y", "pos": 73, "right": "C"},
             ],
             "synonymous": [
                 {"left": "C", "pos": 241, "right": "T"},
@@ -73,9 +70,7 @@ clusters = {
         "old_build_names": ["S.501Y.V2"],
         "who_name": ["Beta"],
         "nextstrain_name": "20H (Beta, V2)",
-        "pango_lineages": [
-            {"name": "B.1.351", "url": None}
-        ],
+        "pango_lineages": [{"name": "B.1.351", "url": None}],
         "alternative_names": ["501Y.V2"],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/20H.Beta.V2",  # color, no europe filter
         "mutations": {
@@ -88,17 +83,17 @@ clusters = {
                 {"gene": "S", "left": "K", "pos": 417, "right": "N"},
                 {"gene": "S", "left": "E", "pos": 484, "right": "K"},
                 {"gene": "S", "left": "N", "pos": 501, "right": "Y"},
-                {'gene': 'S', 'left': 'D', 'pos': 614, 'right': 'G'},
+                {"gene": "S", "left": "D", "pos": 614, "right": "G"},
                 {"gene": "S", "left": "A", "pos": 701, "right": "V"},
-                {'gene': 'ORF3a', 'left': 'Q', 'pos': 57, 'right': 'H'},
-                {'gene': 'ORF1a', 'left': 'T', 'pos': 265, 'right': 'I'},
-                {'gene': 'ORF1a', 'left': 'K', 'pos': 1655, 'right': 'N'},
-                {'gene': 'ORF1a', 'left': 'K', 'pos': 3353, 'right': 'R'},
+                {"gene": "ORF3a", "left": "Q", "pos": 57, "right": "H"},
+                {"gene": "ORF1a", "left": "T", "pos": 265, "right": "I"},
+                {"gene": "ORF1a", "left": "K", "pos": 1655, "right": "N"},
+                {"gene": "ORF1a", "left": "K", "pos": 3353, "right": "R"},
                 {"gene": "ORF1a", "left": "S", "pos": 3675, "right": "-"},
                 {"gene": "ORF1a", "left": "G", "pos": 3676, "right": "-"},
                 {"gene": "ORF1a", "left": "F", "pos": 3677, "right": "-"},
                 {"gene": "N", "left": "T", "pos": 205, "right": "I"},
-                {'gene': 'ORF1b', 'left': 'P', 'pos': 314, 'right': 'L'},
+                {"gene": "ORF1b", "left": "P", "pos": 314, "right": "L"},
                 {"gene": "E", "left": "P", "pos": 71, "right": "L"},
             ],
             "synonymous": [
@@ -124,36 +119,34 @@ clusters = {
         "old_build_names": ["S.501Y.V3"],
         "who_name": ["Gamma"],
         "nextstrain_name": "20J (Gamma, V3)",
-        "pango_lineages": [
-            {"name": "P.1", "url": None}
-        ],
+        "pango_lineages": [{"name": "P.1", "url": None}],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/20J.Gamma.V3",  # color, no europe filter
         "mutations": {
             "nonsynonymous": [
                 {"gene": "S", "left": "L", "pos": 18, "right": "F"},
-                {'gene': 'S', 'left': 'T', 'pos': 20, 'right': 'N'},
-                {'gene': 'S', 'left': 'P', 'pos': 26, 'right': 'S'},
-                {'gene': 'S', 'left': 'D', 'pos': 138, 'right': 'Y'},
-                {'gene': 'S', 'left': 'R', 'pos': 190, 'right': 'S'},
+                {"gene": "S", "left": "T", "pos": 20, "right": "N"},
+                {"gene": "S", "left": "P", "pos": 26, "right": "S"},
+                {"gene": "S", "left": "D", "pos": 138, "right": "Y"},
+                {"gene": "S", "left": "R", "pos": 190, "right": "S"},
                 {"gene": "S", "left": "K", "pos": 417, "right": "T"},
                 {"gene": "S", "left": "E", "pos": 484, "right": "K"},
                 {"gene": "S", "left": "N", "pos": 501, "right": "Y"},
-                {'gene': 'S', 'left': 'D', 'pos': 614, 'right': 'G'},
+                {"gene": "S", "left": "D", "pos": 614, "right": "G"},
                 {"gene": "S", "left": "H", "pos": 655, "right": "Y"},
-                {'gene': 'S', 'left': 'T', 'pos': 1027, 'right': 'I'},
-                {'gene': 'S', 'left': 'V', 'pos': 1176, 'right': 'F'},
-                {'gene': 'ORF3a', 'left': 'S', 'pos': 253, 'right': 'P'},
-                {'gene': 'ORF1a', 'left': 'S', 'pos': 1188, 'right': 'L'},
-                {'gene': 'ORF1a', 'left': 'K', 'pos': 1795, 'right': 'Q'},
+                {"gene": "S", "left": "T", "pos": 1027, "right": "I"},
+                {"gene": "S", "left": "V", "pos": 1176, "right": "F"},
+                {"gene": "ORF3a", "left": "S", "pos": 253, "right": "P"},
+                {"gene": "ORF1a", "left": "S", "pos": 1188, "right": "L"},
+                {"gene": "ORF1a", "left": "K", "pos": 1795, "right": "Q"},
                 {"gene": "ORF1a", "left": "S", "pos": 3675, "right": "-"},
                 {"gene": "ORF1a", "left": "G", "pos": 3676, "right": "-"},
                 {"gene": "ORF1a", "left": "F", "pos": 3677, "right": "-"},
                 {"gene": "N", "left": "P", "pos": 80, "right": "R"},
                 {"gene": "N", "left": "R", "pos": 203, "right": "K"},
                 {"gene": "N", "left": "G", "pos": 204, "right": "R"},
-                {'gene': 'ORF1b', 'left': 'P', 'pos': 314, 'right': 'L'},
-                {'gene': 'ORF1b', 'left': 'E', 'pos': 1264, 'right': 'D'},
-                {'gene': 'ORF8', 'left': 'E', 'pos': 92, 'right': 'K'}
+                {"gene": "ORF1b", "left": "P", "pos": 314, "right": "L"},
+                {"gene": "ORF1b", "left": "E", "pos": 1264, "right": "D"},
+                {"gene": "ORF8", "left": "E", "pos": 92, "right": "K"},
             ],
             "synonymous": [
                 {"left": "C", "pos": 241, "right": "T"},
@@ -169,13 +162,10 @@ clusters = {
             ],
         },
     },
-
-
-
     # Delta variant  -- part of 'Indian' in media - B.1.617.2
     "Delta": {
-        "snps": [22995, 23604, 22917], # S:478, 681, 452
-        "cluster_data": [],  
+        "snps": [22995, 23604, 22917],  # S:478, 681, 452
+        "cluster_data": [],
         "nextstrain_build": True,
         "type": "variant",
         "graphing": True,
@@ -184,13 +174,16 @@ clusters = {
         "col": "#66C266",
         "display_name": "21A (Delta)",
         "alt_display_name": ["21A/S:478K"],
-        #"other_nextstrain_names": ["21A (Delta)","21J (Delta)","21I (Delta)"],
+        # "other_nextstrain_names": ["21A (Delta)","21J (Delta)","21I (Delta)"],
         "build_name": "21A.Delta",
         "old_build_names": ["21A.S.478K"],
         "who_name": ["Delta"],
         "nextstrain_name": "21A (Delta)",
         "pango_lineages": [
-            {"name": "B.1.617.2", "url": "https://cov-lineages.org/lineages/lineage_B.1.617.2.html"}
+            {
+                "name": "B.1.617.2",
+                "url": "https://cov-lineages.org/lineages/lineage_B.1.617.2.html",
+            }
         ],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/21A.Delta",
         "mutations": {
@@ -216,21 +209,24 @@ clusters = {
                 {"gene": "ORF7a", "left": "T", "pos": 120, "right": "I"},
                 {"gene": "ORF8", "left": "D", "pos": 119, "right": "-"},
                 {"gene": "ORF8", "left": "F", "pos": 120, "right": "-"},
-                {"gene": "ORF9b", "left": "T", "pos": 60, "right": "A"}
+                {"gene": "ORF9b", "left": "T", "pos": 60, "right": "A"},
             ],
             "synonymous": [
                 {"left": "G", "pos": 210, "right": "T"},
                 {"left": "C", "pos": 241, "right": "T"},
                 {"left": "C", "pos": 3037, "right": "T"},
                 {"left": "A", "pos": 28271, "right": "-"},
-                {"left": "G", "pos": 29742, "right": "T"}
+                {"left": "G", "pos": 29742, "right": "T"},
             ],
         },
     },
-
     "21I.Delta": {
-        "snps": [5184, 11514, 22227], # 5184T, 11514T, 22227T : ORF1a:1640, ORF1a:3750, S:222
-        "cluster_data": [],  
+        "snps": [
+            5184,
+            11514,
+            22227,
+        ],  # 5184T, 11514T, 22227T : ORF1a:1640, ORF1a:3750, S:222
+        "cluster_data": [],
         "nextstrain_build": True,
         "type": "variant",
         "graphing": True,
@@ -244,7 +240,10 @@ clusters = {
         "who_name": ["Delta"],
         "nextstrain_name": "21I (Delta)",
         "pango_lineages": [
-            {"name": "B.1.617.1", "url": "https://cov-lineages.org/lineages/lineage_B.1.617.1.html"}
+            {
+                "name": "B.1.617.1",
+                "url": "https://cov-lineages.org/lineages/lineage_B.1.617.1.html",
+            }
         ],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/21I.Delta",
         "mutations": {
@@ -275,7 +274,7 @@ clusters = {
                 {"gene": "ORF7a", "left": "T", "pos": 120, "right": "I"},
                 {"gene": "ORF8", "left": "D", "pos": 119, "right": "-"},
                 {"gene": "ORF8", "left": "F", "pos": 120, "right": "-"},
-                {"gene": "ORF9b", "left": "T", "pos": 60, "right": "A"}
+                {"gene": "ORF9b", "left": "T", "pos": 60, "right": "A"},
             ],
             "synonymous": [
                 {"left": "G", "pos": 210, "right": "T"},
@@ -284,14 +283,13 @@ clusters = {
                 {"left": "A", "pos": 5584, "right": "G"},
                 {"left": "C", "pos": 13019, "right": "T"},
                 {"left": "A", "pos": 28271, "right": "-"},
-                {"left": "G", "pos": 29742, "right": "T"}
+                {"left": "G", "pos": 29742, "right": "T"},
             ],
         },
     },
-
     "21J.Delta": {
-        "snps": [4181,8986,11201], # 4181T,8986T,11201G - ORF1a: 1306, 2907, 3646
-        "cluster_data": [],  
+        "snps": [4181, 8986, 11201],  # 4181T,8986T,11201G - ORF1a: 1306, 2907, 3646
+        "cluster_data": [],
         "nextstrain_build": True,
         "type": "variant",
         "graphing": True,
@@ -305,7 +303,10 @@ clusters = {
         "who_name": ["Delta"],
         "nextstrain_name": "21J (Delta)",
         "pango_lineages": [
-            {"name": "B.1.617.1", "url": "https://cov-lineages.org/lineages/lineage_B.1.617.1.html"}
+            {
+                "name": "B.1.617.1",
+                "url": "https://cov-lineages.org/lineages/lineage_B.1.617.1.html",
+            }
         ],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/21J.Delta",
         "mutations": {
@@ -338,7 +339,7 @@ clusters = {
                 {"gene": "ORF7b", "left": "T", "pos": 40, "right": "I"},
                 {"gene": "ORF8", "left": "D", "pos": 119, "right": "-"},
                 {"gene": "ORF8", "left": "F", "pos": 120, "right": "-"},
-                {"gene": "ORF9b", "left": "T", "pos": 60, "right": "A"}
+                {"gene": "ORF9b", "left": "T", "pos": 60, "right": "A"},
             ],
             "synonymous": [
                 {"left": "G", "pos": 210, "right": "T"},
@@ -347,13 +348,12 @@ clusters = {
                 {"left": "C", "pos": 8986, "right": "T"},
                 {"left": "A", "pos": 11332, "right": "G"},
                 {"left": "A", "pos": 28271, "right": "-"},
-                {"left": "G", "pos": 29742, "right": "T"}
+                {"left": "G", "pos": 29742, "right": "T"},
             ],
         },
     },
-
-    "21K.Omicron": { #S.T572I - 23277T
-        "snps": [25000,25584,8393], #25000T,25584T,8393A
+    "21K.Omicron": {  # S.T572I - 23277T
+        "snps": [25000, 25584, 8393],  # 25000T,25584T,8393A
         "cluster_data": [],
         "nextstrain_build": True,
         "graphing": True,
@@ -368,7 +368,10 @@ clusters = {
         "alt_display_name": ["BA.1"],
         "nextstrain_name": "21K",
         "pango_lineages": [
-            {"name": "BA.1", "url": "https://cov-lineages.org/lineages/lineage_BA.1.html"},
+            {
+                "name": "BA.1",
+                "url": "https://cov-lineages.org/lineages/lineage_BA.1.html",
+            },
         ],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/21K.Omicron",
         "mutations": {
@@ -449,27 +452,26 @@ clusters = {
                 {"left": "A", "pos": 28271, "right": "T"},
             ],
         },
-     },
-
-    #21K.21L together
-    "21K.21L": { 
-        "snps": [22679, 23040, 23604], # 22679C, 23040G, 23604A
+    },
+    # 21K.21L together
+    "21K.21L": {
+        "snps": [22679, 23040, 23604],  # 22679C, 23040G, 23604A
         "cluster_data": [],
         "nextstrain_build": True,
         "graphing": False,
         "important": False,
         "other_nextstrain_names": ["21K (Omicron)", "21L"],
-        "country_info": [], 'col': "#b3d9ff", 
+        "country_info": [],
+        "col": "#b3d9ff",
         "display_name": "21K.21L",
         "type": "do_not_display",
         "build_name": "21K.21L",
-        "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/21K.21L"
+        "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/21K.21L",
     },
-
     # Sister clade to 21K - TBD if Omicron
     "21L": {
-        "snps": [21618,22775,23525], # S21618T, 22775A, 23525T
-        "cluster_data": [],  
+        "snps": [21618, 22775, 23525],  # S21618T, 22775A, 23525T
+        "cluster_data": [],
         "nextstrain_build": True,
         "type": "do_not_display",
         "graphing": False,
@@ -478,21 +480,23 @@ clusters = {
         "col": "#cfafcf",
         "display_name": "21L",
         "alt_display_name": ["21L"],
-        #"other_nextstrain_names": ["21A (Delta)","21J (Delta)","21I (Delta)"],
+        # "other_nextstrain_names": ["21A (Delta)","21J (Delta)","21I (Delta)"],
         "build_name": "21L",
         "old_build_names": ["21L"],
         "nextstrain_name": "21L",
         "pango_lineages": [
-            {"name": "BA.2", "url": "https://cov-lineages.org/lineage.html?lineage=BA.2"}
+            {
+                "name": "BA.2",
+                "url": "https://cov-lineages.org/lineage.html?lineage=BA.2",
+            }
         ],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/21L",
-        "mutations": {}
+        "mutations": {},
     },
-
-    # variant  -- part of 'Indian' in media - B.1.617.1 
+    # variant  -- part of 'Indian' in media - B.1.617.1
     "Kappa": {
-        "snps": [17523, 23604, 22917], #ORF1b:1352, S:681, 452 
-        "cluster_data": [],  
+        "snps": [17523, 23604, 22917],  # ORF1b:1352, S:681, 452
+        "cluster_data": [],
         "nextstrain_build": True,
         "type": "variant",
         "graphing": True,
@@ -506,7 +510,10 @@ clusters = {
         "who_name": ["Kappa"],
         "nextstrain_name": "21B (Kappa)",
         "pango_lineages": [
-            {"name": "B.1.617.1", "url": "https://cov-lineages.org/lineages/lineage_B.1.617.1.html"}
+            {
+                "name": "B.1.617.1",
+                "url": "https://cov-lineages.org/lineages/lineage_B.1.617.1.html",
+            }
         ],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/21B.Kappa",
         "mutations": {
@@ -528,7 +535,7 @@ clusters = {
                 {"gene": "ORF3a", "left": "S", "pos": 26, "right": "L"},
                 {"gene": "ORF1a", "left": "T", "pos": 1567, "right": "I"},
                 {"gene": "ORF1a", "left": "T", "pos": 3646, "right": "A"},
-                {"gene": "ORF7a", "left": "V", "pos": 82, "right": "A"}
+                {"gene": "ORF7a", "left": "V", "pos": 82, "right": "A"},
             ],
             "synonymous": [
                 {"left": "G", "pos": 210, "right": "T"},
@@ -537,15 +544,14 @@ clusters = {
                 {"left": "C", "pos": 3457, "right": "T"},
                 {"left": "C", "pos": 26681, "right": "T"},
                 {"left": "A", "pos": 28271, "right": "-"},
-                {"left": "G", "pos": 29742, "right": "T"}
+                {"left": "G", "pos": 29742, "right": "T"},
             ],
         },
     },
-
     # "delta plus" - build only - Delta + 417
     "Delta417": {
-        "snps": [22995, 23604, 22917, 22813], # S:478, 681, 452, 417
-        "cluster_data": [],  
+        "snps": [22995, 23604, 22917, 22813],  # S:478, 681, 452, 417
+        "cluster_data": [],
         "nextstrain_build": True,
         "type": "do_not_display",
         "graphing": False,
@@ -556,7 +562,6 @@ clusters = {
         "build_name": "21A.Delta.S.K417",
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/21A.Delta.S.K417",
     },
-
     # 'not-called-nigerian variant' B.1.525
     # 21D Eta
     "Eta": {
@@ -574,33 +579,31 @@ clusters = {
         "old_build_names": ["20A.S.484K"],
         "who_name": ["Eta"],
         "nextstrain_name": "21D (Eta)",
-        "pango_lineages": [
-            {"name": "B.1.525", "url": None}
-        ],
+        "pango_lineages": [{"name": "B.1.525", "url": None}],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/21D.Eta",  # color, no europe filter
         "mutations": {
             "nonsynonymous": [
-                {'gene': 'S', 'left': 'Q', 'pos': 52, 'right': 'R'},
+                {"gene": "S", "left": "Q", "pos": 52, "right": "R"},
                 {"gene": "S", "left": "A", "pos": 67, "right": "V"},
                 {"gene": "S", "left": "H", "pos": 69, "right": "-"},
                 {"gene": "S", "left": "V", "pos": 70, "right": "-"},
                 {"gene": "S", "left": "Y", "pos": 144, "right": "-"},
                 {"gene": "S", "left": "E", "pos": 484, "right": "K"},
-                {'gene': 'S', 'left': 'D', 'pos': 614, 'right': 'G'},
+                {"gene": "S", "left": "D", "pos": 614, "right": "G"},
                 {"gene": "S", "left": "Q", "pos": 677, "right": "H"},
                 {"gene": "S", "left": "F", "pos": 888, "right": "L"},
-                {'gene': 'ORF1b', 'left': 'P', 'pos': 314, 'right': 'F'},
+                {"gene": "ORF1b", "left": "P", "pos": 314, "right": "F"},
                 {"gene": "N", "left": "S", "pos": 2, "right": "-"},
                 {"gene": "N", "left": "D", "pos": 3, "right": "Y"},
                 {"gene": "N", "left": "A", "pos": 12, "right": "G"},
-                {'gene': 'N', 'left': 'T', 'pos': 205, 'right': 'I'},
-                {'gene': 'M', 'left': 'I', 'pos': 82, 'right': 'T'},
-                {'gene': 'ORF1a', 'left': 'T', 'pos': 2007, 'right': 'I'},
+                {"gene": "N", "left": "T", "pos": 205, "right": "I"},
+                {"gene": "M", "left": "I", "pos": 82, "right": "T"},
+                {"gene": "ORF1a", "left": "T", "pos": 2007, "right": "I"},
                 {"gene": "ORF1a", "left": "S", "pos": 3675, "right": "-"},
                 {"gene": "ORF1a", "left": "G", "pos": 3676, "right": "-"},
                 {"gene": "ORF1a", "left": "F", "pos": 3677, "right": "-"},
-                {'gene': 'E', 'left': 'L', 'pos': 21, 'right': 'F'},
-                {'gene': 'ORF6', 'left': 'F', 'pos': 2, 'right': '-'}
+                {"gene": "E", "left": "L", "pos": 21, "right": "F"},
+                {"gene": "ORF6", "left": "F", "pos": 2, "right": "-"},
             ],
             "synonymous": [
                 {"left": "C", "pos": 241, "right": "T"},
@@ -618,7 +621,6 @@ clusters = {
             ],
         },
     },
-
     # "new york variant"
     # 21F Iota
     "Iota": {
@@ -636,9 +638,7 @@ clusters = {
         "old_build_names": ["20C.S.484K"],
         "who_name": ["Iota"],
         "nextstrain_name": "21F (Iota)",
-        "pango_lineages": [
-            {"name": "B.1.526", "url": None}
-        ],
+        "pango_lineages": [{"name": "B.1.526", "url": None}],
         "alternative_names": ["B.1.526 (partial)"],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/21F.Iota?c=gt-S_484",  # color, no europe filter
         "mutations": {
@@ -647,14 +647,14 @@ clusters = {
                 {"gene": "S", "left": "T", "pos": 95, "right": "I"},
                 {"gene": "S", "left": "D", "pos": 253, "right": "G"},
                 {"gene": "S", "left": "E", "pos": 484, "right": "K"},
-                {'gene': 'S', 'left': 'D', 'pos': 614, 'right': 'G'},
+                {"gene": "S", "left": "D", "pos": 614, "right": "G"},
                 {"gene": "S", "left": "A", "pos": 701, "right": "V"},
-                {'gene': 'ORF1b', 'left': 'P', 'pos': 314, 'right': 'L'},
+                {"gene": "ORF1b", "left": "P", "pos": 314, "right": "L"},
                 {"gene": "ORF1b", "left": "Q", "pos": 1011, "right": "H"},
                 {"gene": "ORF3a", "left": "P", "pos": 42, "right": "L"},
-                {'gene': 'ORF3a', 'left': 'Q', 'pos': 57, 'right': 'H'},
-                {'gene': 'ORF1a', 'left': 'T', 'pos': 265, 'right': 'I'},
-                {'gene': 'ORF1a', 'left': 'L', 'pos': 3201, 'right': 'P'},
+                {"gene": "ORF3a", "left": "Q", "pos": 57, "right": "H"},
+                {"gene": "ORF1a", "left": "T", "pos": 265, "right": "I"},
+                {"gene": "ORF1a", "left": "L", "pos": 3201, "right": "P"},
                 {"gene": "ORF1a", "left": "S", "pos": 3675, "right": "-"},
                 {"gene": "ORF1a", "left": "G", "pos": 3676, "right": "-"},
                 {"gene": "ORF1a", "left": "F", "pos": 3677, "right": "-"},
@@ -670,11 +670,14 @@ clusters = {
             ],
         },
     },
-
     # C.37 - build only
     "21GLambda": {
-        "snps": [7424, 23031, 24138], #ORF1a 2387 (7424G)  #S 490 (23031C) 859 (24138A)
-        "cluster_data": [],  
+        "snps": [
+            7424,
+            23031,
+            24138,
+        ],  # ORF1a 2387 (7424G)  #S 490 (23031C) 859 (24138A)
+        "cluster_data": [],
         "nextstrain_build": True,
         "graphing": True,
         "type": "variant",
@@ -686,19 +689,17 @@ clusters = {
         "old_build_names": [],
         "who_name": ["Lambda"],
         "nextstrain_name": "21G (Lambda)",
-        "pango_lineages": [
-            {"name": "C.37", "url": None}
-        ],
+        "pango_lineages": [{"name": "C.37", "url": None}],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/21G.Lambda",
         "mutations": {
             "nonsynonymous": [
-                {'gene': 'S', 'left': 'G', 'pos': 75, 'right': 'V'},
+                {"gene": "S", "left": "G", "pos": 75, "right": "V"},
                 {"gene": "S", "left": "T", "pos": 76, "right": "I"},
                 {"gene": "S", "left": "R", "pos": 246, "right": "-"},
                 {"gene": "S", "left": "S", "pos": 247, "right": "-"},
                 {"gene": "S", "left": "Y", "pos": 248, "right": "-"},
                 {"gene": "S", "left": "L", "pos": 249, "right": "-"},
-                {'gene': 'S', 'left': 'T', 'pos': 250, 'right': '-'},
+                {"gene": "S", "left": "T", "pos": 250, "right": "-"},
                 {"gene": "S", "left": "P", "pos": 251, "right": "-"},
                 {"gene": "S", "left": "G", "pos": 252, "right": "-"},
                 {"gene": "S", "left": "D", "pos": 253, "right": "N"},
@@ -706,20 +707,20 @@ clusters = {
                 {"gene": "S", "left": "F", "pos": 490, "right": "S"},
                 {"gene": "S", "left": "D", "pos": 614, "right": "G"},
                 {"gene": "S", "left": "T", "pos": 859, "right": "N"},
-                {'gene': 'ORF1a', 'left': 'T', 'pos': 1246, 'right': 'I'},
-                {'gene': 'ORF1a', 'left': 'P', 'pos': 2287, 'right': 'S'},
-                {'gene': 'ORF1a', 'left': 'F', 'pos': 2387, 'right': 'V'},
-                {'gene': 'ORF1a', 'left': 'L', 'pos': 3201, 'right': 'P'},
-                {'gene': 'ORF1a', 'left': 'T', 'pos': 3255, 'right': 'I'},
-                {'gene': 'ORF1a', 'left': 'G', 'pos': 3278, 'right': 'S'},
-                {'gene': 'ORF1a', 'left': 'S', 'pos': 3675, 'right': '-'},
-                {'gene': 'ORF1a', 'left': 'G', 'pos': 3676, 'right': '-'},
-                {'gene': 'ORF1a', 'left': 'F', 'pos': 3677, 'right': '-'},
-                {'gene': 'ORF1b', 'left': 'P', 'pos': 314, 'right': 'L'},
+                {"gene": "ORF1a", "left": "T", "pos": 1246, "right": "I"},
+                {"gene": "ORF1a", "left": "P", "pos": 2287, "right": "S"},
+                {"gene": "ORF1a", "left": "F", "pos": 2387, "right": "V"},
+                {"gene": "ORF1a", "left": "L", "pos": 3201, "right": "P"},
+                {"gene": "ORF1a", "left": "T", "pos": 3255, "right": "I"},
+                {"gene": "ORF1a", "left": "G", "pos": 3278, "right": "S"},
+                {"gene": "ORF1a", "left": "S", "pos": 3675, "right": "-"},
+                {"gene": "ORF1a", "left": "G", "pos": 3676, "right": "-"},
+                {"gene": "ORF1a", "left": "F", "pos": 3677, "right": "-"},
+                {"gene": "ORF1b", "left": "P", "pos": 314, "right": "L"},
                 {"gene": "N", "left": "P", "pos": 13, "right": "L"},
                 {"gene": "N", "left": "R", "pos": 203, "right": "K"},
                 {"gene": "N", "left": "G", "pos": 204, "right": "R"},
-                {'gene': 'N', 'left': 'G', 'pos': 214, 'right': 'C'},
+                {"gene": "N", "left": "G", "pos": 214, "right": "C"},
             ],
             "synonymous": [
                 {"left": "C", "pos": 241, "right": "T"},
@@ -732,11 +733,10 @@ clusters = {
             ],
         },
     },
-
     # B.1.621 - Mu
     "21H": {
-        "snps": [22599, 4878, 17491], #S 346 (22599A)  ORF1a: 1538 (4878T) nuc: 17491T
-        "cluster_data": [],  
+        "snps": [22599, 4878, 17491],  # S 346 (22599A)  ORF1a: 1538 (4878T) nuc: 17491T
+        "cluster_data": [],
         "nextstrain_build": True,
         "graphing": True,
         "type": "variant",
@@ -748,35 +748,33 @@ clusters = {
         "old_build_names": ["21H"],
         "who_name": ["Mu"],
         "nextstrain_name": "21H (Mu)",
-        "pango_lineages": [
-            {"name": "B.1.621", "url": None}
-        ],
+        "pango_lineages": [{"name": "B.1.621", "url": None}],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/21H.Mu",
         "mutations": {
             "nonsynonymous": [
-                {'gene': 'S', 'left': 'T', 'pos': 95, 'right': 'I'},
+                {"gene": "S", "left": "T", "pos": 95, "right": "I"},
                 {"gene": "S", "left": "Y", "pos": 144, "right": "S"},
                 {"gene": "S", "left": "Y", "pos": 145, "right": "N"},
                 {"gene": "S", "left": "R", "pos": 346, "right": "K"},
                 {"gene": "S", "left": "E", "pos": 484, "right": "K"},
                 {"gene": "S", "left": "N", "pos": 501, "right": "Y"},
-                {'gene': 'S', 'left': 'D', 'pos': 614, 'right': 'G'},
+                {"gene": "S", "left": "D", "pos": 614, "right": "G"},
                 {"gene": "S", "left": "P", "pos": 681, "right": "H"},
                 {"gene": "S", "left": "D", "pos": 950, "right": "N"},
-                {'gene': 'ORF1a', 'left': 'T', 'pos': 1055, 'right': 'A'},
-                {'gene': 'ORF1a', 'left': 'T', 'pos': 1538, 'right': 'I'},
-                {'gene': 'ORF1a', 'left': 'T', 'pos': 3255, 'right': 'I'},
-                {'gene': 'ORF1a', 'left': 'Q', 'pos': 3729, 'right': 'R'},
-                {'gene': 'ORF1b', 'left': 'P', 'pos': 314, 'right': 'L'},
-                {'gene': 'ORF1b', 'left': 'P', 'pos': 1342, 'right': 'S'},
+                {"gene": "ORF1a", "left": "T", "pos": 1055, "right": "A"},
+                {"gene": "ORF1a", "left": "T", "pos": 1538, "right": "I"},
+                {"gene": "ORF1a", "left": "T", "pos": 3255, "right": "I"},
+                {"gene": "ORF1a", "left": "Q", "pos": 3729, "right": "R"},
+                {"gene": "ORF1b", "left": "P", "pos": 314, "right": "L"},
+                {"gene": "ORF1b", "left": "P", "pos": 1342, "right": "S"},
                 {"gene": "N", "left": "T", "pos": 205, "right": "I"},
-                {'gene': 'ORF3a', 'left': 'Q', 'pos': 57, 'right': 'H'},
-                {'gene': 'ORF3a', 'left': 'V', 'pos': 256, 'right': 'I'},
-                {'gene': 'ORF3a', 'left': 'N', 'pos': 257, 'right': 'Q'},
-                {'gene': 'ORF3a', 'left': 'P', 'pos': 258, 'right': '*'},
-                {'gene': 'ORF8', 'left': 'T', 'pos': 11, 'right': 'K'},
-                {'gene': 'ORF8', 'left': 'P', 'pos': 38, 'right': 'S'},
-                {'gene': 'ORF8', 'left': 'S', 'pos': 67, 'right': 'F'},
+                {"gene": "ORF3a", "left": "Q", "pos": 57, "right": "H"},
+                {"gene": "ORF3a", "left": "V", "pos": 256, "right": "I"},
+                {"gene": "ORF3a", "left": "N", "pos": 257, "right": "Q"},
+                {"gene": "ORF3a", "left": "P", "pos": 258, "right": "*"},
+                {"gene": "ORF8", "left": "T", "pos": 11, "right": "K"},
+                {"gene": "ORF8", "left": "P", "pos": 38, "right": "S"},
+                {"gene": "ORF8", "left": "S", "pos": 67, "right": "F"},
             ],
             "synonymous": [
                 {"left": "C", "pos": 241, "right": "T"},
@@ -790,11 +788,14 @@ clusters = {
             ],
         },
     },
-
     # B.1.1.519 - builds turned of 11 Oct, graphing continues
     "20BS732": {
-        "snps": [10029, 23756, 21306], #ORF1a  3255 (10029T)   S: 732 (23756G) nuc 21306T
-        "cluster_data": [],  
+        "snps": [
+            10029,
+            23756,
+            21306,
+        ],  # ORF1a  3255 (10029T)   S: 732 (23756G) nuc 21306T
+        "cluster_data": [],
         "nextstrain_build": False,
         "graphing": True,
         "type": "variant",
@@ -806,21 +807,19 @@ clusters = {
         "old_build_names": [],
         "who_name": [],
         "nextstrain_name": "",
-        "pango_lineages": [
-            {"name": "B.1.1.519", "url": None}
-        ],
+        "pango_lineages": [{"name": "B.1.1.519", "url": None}],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/20B.S.732A",
         "mutations": {
             "nonsynonymous": [
                 {"gene": "S", "left": "T", "pos": 478, "right": "K"},
-                {'gene': 'S', 'left': 'D', 'pos': 614, 'right': 'G'},
+                {"gene": "S", "left": "D", "pos": 614, "right": "G"},
                 {"gene": "S", "left": "P", "pos": 681, "right": "H"},
                 {"gene": "S", "left": "T", "pos": 732, "right": "A"},
-                {'gene': 'ORF1a', 'left': 'P', 'pos': 959, 'right': 'S'},
-                {'gene': 'ORF1a', 'left': 'T', 'pos': 3255, 'right': 'I'},
-                {'gene': 'ORF1a', 'left': 'I', 'pos': 3618, 'right': 'V'},
-                {'gene': 'ORF1a', 'left': 'T', 'pos': 4175, 'right': 'I'},
-                {'gene': 'ORF1b', 'left': 'P', 'pos': 314, 'right': 'L'},
+                {"gene": "ORF1a", "left": "P", "pos": 959, "right": "S"},
+                {"gene": "ORF1a", "left": "T", "pos": 3255, "right": "I"},
+                {"gene": "ORF1a", "left": "I", "pos": 3618, "right": "V"},
+                {"gene": "ORF1a", "left": "T", "pos": 4175, "right": "I"},
+                {"gene": "ORF1b", "left": "P", "pos": 314, "right": "L"},
                 {"gene": "N", "left": "R", "pos": 203, "right": "K"},
                 {"gene": "N", "left": "G", "pos": 204, "right": "R"},
             ],
@@ -836,11 +835,14 @@ clusters = {
             ],
         },
     },
-
-    #B.1.620 20A/S:126A - builds turned off 11 Oct, graphing continues
+    # B.1.620 20A/S:126A - builds turned off 11 Oct, graphing continues
     "20AS126": {
-        "snps": [21939, 1473, 6236], #S: 126 (21939C)  #ORF1a: 403 (1473T), 1991 (6236A)
-        "cluster_data": [],  
+        "snps": [
+            21939,
+            1473,
+            6236,
+        ],  # S: 126 (21939C)  #ORF1a: 403 (1473T), 1991 (6236A)
+        "cluster_data": [],
         "nextstrain_build": False,
         "graphing": True,
         "type": "variant",
@@ -851,19 +853,17 @@ clusters = {
         "build_name": "20A.S.126A",
         "old_build_names": [],
         "who_name": [],
-        "pango_lineages": [
-            {"name": "B.1.620", "url": None}
-        ],
+        "pango_lineages": [{"name": "B.1.620", "url": None}],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/20A.S.126A",
         "mutations": {
             "nonsynonymous": [
-                {'gene': 'S', 'left': 'P', 'pos': 26, 'right': 'S'},
+                {"gene": "S", "left": "P", "pos": 26, "right": "S"},
                 {"gene": "S", "left": "H", "pos": 69, "right": "-"},
                 {"gene": "S", "left": "V", "pos": 70, "right": "-"},
                 {"gene": "S", "left": "V", "pos": 126, "right": "A"},
                 {"gene": "S", "left": "Y", "pos": 144, "right": "-"},
                 {"gene": "S", "left": "L", "pos": 241, "right": "-"},
-                {'gene': 'S', 'left': 'L', 'pos': 242, 'right': '-'},
+                {"gene": "S", "left": "L", "pos": 242, "right": "-"},
                 {"gene": "S", "left": "A", "pos": 243, "right": "-"},
                 {"gene": "S", "left": "H", "pos": 245, "right": "Y"},
                 {"gene": "S", "left": "S", "pos": 477, "right": "N"},
@@ -872,15 +872,15 @@ clusters = {
                 {"gene": "S", "left": "P", "pos": 681, "right": "H"},
                 {"gene": "S", "left": "T", "pos": 1027, "right": "I"},
                 {"gene": "S", "left": "D", "pos": 1118, "right": "H"},
-                {'gene': 'ORF1a', 'left': 'T', 'pos': 403, 'right': 'I'},
-                {'gene': 'ORF1a', 'left': 'V', 'pos': 1991, 'right': 'I'},
-                {'gene': 'ORF1a', 'left': 'S', 'pos': 3675, 'right': '-'},
-                {'gene': 'ORF1a', 'left': 'G', 'pos': 3676, 'right': '-'},
-                {'gene': 'ORF1a', 'left': 'F', 'pos': 3677, 'right': '-'},
-                {'gene': 'ORF1b', 'left': 'P', 'pos': 314, 'right': 'L'},
-                {'gene': 'ORF1b', 'left': 'A', 'pos': 1215, 'right': 'S'},
+                {"gene": "ORF1a", "left": "T", "pos": 403, "right": "I"},
+                {"gene": "ORF1a", "left": "V", "pos": 1991, "right": "I"},
+                {"gene": "ORF1a", "left": "S", "pos": 3675, "right": "-"},
+                {"gene": "ORF1a", "left": "G", "pos": 3676, "right": "-"},
+                {"gene": "ORF1a", "left": "F", "pos": 3677, "right": "-"},
+                {"gene": "ORF1b", "left": "P", "pos": 314, "right": "L"},
+                {"gene": "ORF1b", "left": "A", "pos": 1215, "right": "S"},
                 {"gene": "N", "left": "A", "pos": 220, "right": "V"},
-                {'gene': 'ORF9b', 'left': 'I', 'pos': 5, 'right': 'T'},
+                {"gene": "ORF9b", "left": "I", "pos": 5, "right": "T"},
             ],
             "synonymous": [
                 {"left": "C", "pos": 241, "right": "T"},
@@ -895,8 +895,6 @@ clusters = {
             ],
         },
     },
-
-
     "EU1": {
         "snps": [22227, 28932, 29645],
         "cluster_data": [],
@@ -928,11 +926,10 @@ clusters = {
             ],
         },
     },
-
     # 'CA variant'
     "Epsilon": {
         "snps": [21600, 22018, 22917],
-        "cluster_data": [],  #'CA' variant
+        "cluster_data": [],  # 'CA' variant
         "nextstrain_build": False,
         "graphing": True,
         "type": "variant",
@@ -947,7 +944,7 @@ clusters = {
         "nextstrain_name": "21C (Epsilon)",
         "pango_lineages": [
             {"name": "B.1.427", "url": None},
-            {"name": "B.1.429", "url": None}
+            {"name": "B.1.429", "url": None},
         ],
         "alternative_names": ["CAL.20C"],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/21C.Epsilon",  # color, no europe filter
@@ -956,7 +953,7 @@ clusters = {
                 {"gene": "S", "left": "S", "pos": 13, "right": "I"},
                 {"gene": "S", "left": "W", "pos": 152, "right": "C"},
                 {"gene": "S", "left": "L", "pos": 452, "right": "R"},
-                {'gene': 'S', 'left': 'D', 'pos': 614, 'right': 'G'},
+                {"gene": "S", "left": "D", "pos": 614, "right": "G"},
                 {"gene": "ORF1a", "left": "I", "pos": 4205, "right": "V"},
                 {"gene": "ORF1b", "left": "D", "pos": 1183, "right": "Y"},
             ],
@@ -969,7 +966,6 @@ clusters = {
             ],
         },
     },
-
     "S439": {
         "snps": [7767, 22879],
         "cluster_data": [],
@@ -981,9 +977,7 @@ clusters = {
         "col": "#6666FF",
         "display_name": "20A/S:439K",
         "build_name": "S.N439K",
-        "pango_lineages": [
-            {"name": "B.1.258", "url": None}
-        ],
+        "pango_lineages": [{"name": "B.1.258", "url": None}],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/S.N439K?c=gt-S_439&f_region=Europe",
         "mutations": {
             "nonsynonymous": [
@@ -996,7 +990,7 @@ clusters = {
         },
     },
     "S677HRobin1": {
-        "snps": [23593, 29402, 8083], #T, T, A
+        "snps": [23593, 29402, 8083],  # T, T, A
         "cluster_data": [],
         "nextstrain_build": True,
         "graphing": True,
@@ -1009,20 +1003,20 @@ clusters = {
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/S.Q677H.Robin1?f_country=USA",
         "mutations": {
             "nonsynonymous": [
-                {'gene': 'S', 'left': 'D', 'pos': 614, 'right': 'G'},
+                {"gene": "S", "left": "D", "pos": 614, "right": "G"},
                 {"gene": "S", "left": "Q", "pos": 677, "right": "H"},
                 {"gene": "N", "left": "P", "pos": 67, "right": "S"},
                 {"gene": "N", "left": "P", "pos": 199, "right": "L"},
                 {"gene": "N", "left": "D", "pos": 377, "right": "Y"},
                 {"gene": "ORF1a", "left": "T", "pos": 265, "right": "I"},
-                {'gene': 'ORF1a', 'left': 'M', 'pos': 2606, 'right': 'I'},
+                {"gene": "ORF1a", "left": "M", "pos": 2606, "right": "I"},
                 {"gene": "ORF1a", "left": "L", "pos": 3352, "right": "F"},
-                {'gene': 'ORF1b', 'left': 'P', 'pos': 314, 'right': 'L'},
+                {"gene": "ORF1b", "left": "P", "pos": 314, "right": "L"},
                 {"gene": "ORF1b", "left": "N", "pos": 1653, "right": "D"},
                 {"gene": "ORF1b", "left": "R", "pos": 2613, "right": "C"},
-                {'gene': 'ORF3a', 'left': 'Q', 'pos': 57, 'right': 'H'},
-                {'gene': 'ORF3a', 'left': 'G', 'pos': 172, 'right': 'V'},
-                {'gene': 'ORF8', 'left': 'S', 'pos': 24, 'right': 'L'}
+                {"gene": "ORF3a", "left": "Q", "pos": 57, "right": "H"},
+                {"gene": "ORF3a", "left": "G", "pos": 172, "right": "V"},
+                {"gene": "ORF8", "left": "S", "pos": 24, "right": "L"},
             ],
             "synonymous": [
                 {"left": "C", "pos": 241, "right": "T"},
@@ -1047,19 +1041,19 @@ clusters = {
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/S.Q677P.Pelican?f_country=USA",
         "mutations": {
             "nonsynonymous": [
-                {'gene': 'S', 'left': 'D', 'pos': 614, 'right': 'G'},
+                {"gene": "S", "left": "D", "pos": 614, "right": "G"},
                 {"gene": "S", "left": "Q", "pos": 677, "right": "P"},
                 {"gene": "N", "left": "P", "pos": 67, "right": "S"},
                 {"gene": "N", "left": "P", "pos": 199, "right": "L"},
                 {"gene": "ORF1a", "left": "T", "pos": 265, "right": "I"},
                 {"gene": "ORF1a", "left": "L", "pos": 3352, "right": "F"},
-                {'gene': 'ORF1a', 'left': 'Q', 'pos': 3729, 'right': 'R'},
-                {'gene': 'ORF1b', 'left': 'P', 'pos': 314, 'right': 'L'},
+                {"gene": "ORF1a", "left": "Q", "pos": 3729, "right": "R"},
+                {"gene": "ORF1b", "left": "P", "pos": 314, "right": "L"},
                 {"gene": "ORF1b", "left": "N", "pos": 1653, "right": "D"},
                 {"gene": "ORF1b", "left": "R", "pos": 2613, "right": "C"},
-                {'gene': 'ORF3a', 'left': 'Q', 'pos': 57, 'right': 'H'},
-                {'gene': 'ORF3a', 'left': 'G', 'pos': 172, 'right': 'V'},
-                {'gene': 'ORF8', 'left': 'S', 'pos': 24, 'right': 'L'}
+                {"gene": "ORF3a", "left": "Q", "pos": 57, "right": "H"},
+                {"gene": "ORF3a", "left": "G", "pos": 172, "right": "V"},
+                {"gene": "ORF8", "left": "S", "pos": 24, "right": "L"},
             ],
             "synonymous": [
                 {"left": "C", "pos": 241, "right": "T"},
@@ -1070,7 +1064,6 @@ clusters = {
             ],
         },
     },
-
     "EU2": {
         "snps": [22992, 4543],
         "cluster_data": [],
@@ -1081,11 +1074,9 @@ clusters = {
         "country_info": [],
         "col": "#A3D8F3",
         "display_name": "20A.EU2",
-        #"alt_display_name": "S:477N",
+        # "alt_display_name": "S:477N",
         "build_name": "20A.EU2",
-        "pango_lineages": [
-            {"name": "B.1.160", "url": None}
-        ],
+        "pango_lineages": [{"name": "B.1.160", "url": None}],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/20A.EU2?f_region=Europe",
         "mutations": {
             "nonsynonymous": [
@@ -1105,7 +1096,6 @@ clusters = {
             ],
         },
     },
-
     "S98": {
         "snps": [21855, 25505],
         "cluster_data": [],
@@ -1117,9 +1107,7 @@ clusters = {
         "col": "#C8C8DA",
         "display_name": "20A/S:98F",
         "build_name": "S.S98F",
-        "pango_lineages": [
-            {"name": "B.1.221", "url": None}
-        ],
+        "pango_lineages": [{"name": "B.1.221", "url": None}],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/S.S98F?c=gt-S_98&f_region=Europe",  # color, europe Filter
         "mutations": {
             "nonsynonymous": [
@@ -1143,9 +1131,7 @@ clusters = {
         "col": "#D1E8FF",
         "display_name": "20C/S:80Y",
         "build_name": "S.D80Y",
-        "pango_lineages": [
-            {"name": "B.1.367", "url": None}
-        ],
+        "pango_lineages": [{"name": "B.1.367", "url": None}],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/S.D80Y?f_region=Europe",
         "mutations": {
             "nonsynonymous": [
@@ -1183,13 +1169,9 @@ clusters = {
         "col": "#b3e6ff",
         "display_name": "20B/S:626S",
         "build_name": "S.A626S",
-        "pango_lineages": [
-            {"name": "B.1.1.277", "url": None}
-        ],
+        "pango_lineages": [{"name": "B.1.1.277", "url": None}],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/S.A626S?f_region=Europe",
-        "mutations": {
-            "nonsynonymous": [{"gene": "S", "left": "A", "pos": 626, "right": "S"}]
-        },
+        "mutations": {"nonsynonymous": [{"gene": "S", "left": "A", "pos": 626, "right": "S"}]},
     },
     "S1122": {
         "snps": [24926, 9120],
@@ -1202,9 +1184,7 @@ clusters = {
         "col": "#A3A3C2",
         "display_name": "20B/S:1122L",
         "build_name": "S.V1122L",
-        "pango_lineages": [
-            {"name": "B.1.1.302", "url": None}
-        ],
+        "pango_lineages": [{"name": "B.1.1.302", "url": None}],
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/S.V1122L?c=gt-S_1122&f_region=Europe",  # color, europe Filter
         "mutations": {
             "nonsynonymous": [
@@ -1500,72 +1480,91 @@ clusters = {
         "build_name": "S.Q677H.Mockingbird",
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/S.Q677H.Mockingbird?c=gt-S_677&f_country=USA",
     },
-
-#    "Delta.N.412R": { # 613 cluster expanding in canada? #stopped 11 Oct 21
-#        "snps": [2401,23401,26763,29507], #ORF1a: 712Q (2401A), S: 613H (23401T), M: 81S (26763T), N: 412R (29507C)
-#        "cluster_data": [],
-#        "nextstrain_build": True,
-#        "graphing": False,
-#        "important": False,
-#        "country_info": [], 'col': "#b3d9ff", "display_name": "Delta+N:412R",
-#        "type": "do_not_display",
-#        "build_name": "Delta.N.412R",
-#        "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/Delta.N.412R?c=gt-S_613"
-#    },
-
-    "Delta.299I": { # "AY.33" - has Spike T29A, T250I, T299I and Q613H
-        "snps": [4181,21647,22311,22458,23401], #ORF1a: 1306S (4181T), S: 29A (21647G), 250I (22311T), 299I (22458T), 613H (23401T)
+    #    "Delta.N.412R": { # 613 cluster expanding in canada? #stopped 11 Oct 21
+    #        "snps": [2401,23401,26763,29507], #ORF1a: 712Q (2401A), S: 613H (23401T), M: 81S (26763T), N: 412R (29507C)
+    #        "cluster_data": [],
+    #        "nextstrain_build": True,
+    #        "graphing": False,
+    #        "important": False,
+    #        "country_info": [], 'col': "#b3d9ff", "display_name": "Delta+N:412R",
+    #        "type": "do_not_display",
+    #        "build_name": "Delta.N.412R",
+    #        "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/Delta.N.412R?c=gt-S_613"
+    #    },
+    "Delta.299I": {  # "AY.33" - has Spike T29A, T250I, T299I and Q613H
+        "snps": [
+            4181,
+            21647,
+            22311,
+            22458,
+            23401,
+        ],  # ORF1a: 1306S (4181T), S: 29A (21647G), 250I (22311T), 299I (22458T), 613H (23401T)
         "cluster_data": [],
         "nextstrain_build": True,
         "graphing": False,
         "important": False,
-        "country_info": [], 'col': "#b3d9ff", "display_name": "Delta+299I",
+        "country_info": [],
+        "col": "#b3d9ff",
+        "display_name": "Delta+299I",
         "type": "do_not_display",
         "build_name": "Delta.299I",
-        "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/Delta.299I?c=gt-S_299"
+        "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/Delta.299I?c=gt-S_299",
     },
-
-    "Delta.250I": { # cornelius' larger cluster - key one has Spike T29A, T250I, T299I and then Q613H
-        "snps": [4181,21647,22311], #ORF1a: 1306S (4181T), S: 29A (21647G), 250I (22311T) 
+    "Delta.250I": {  # cornelius' larger cluster - key one has Spike T29A, T250I, T299I and then Q613H
+        "snps": [
+            4181,
+            21647,
+            22311,
+        ],  # ORF1a: 1306S (4181T), S: 29A (21647G), 250I (22311T)
         "cluster_data": [],
         "nextstrain_build": True,
         "graphing": False,
         "important": False,
-        "country_info": [], 'col': "#b3d9ff", "display_name": "Delta+250I",
+        "country_info": [],
+        "col": "#b3d9ff",
+        "display_name": "Delta+250I",
         "type": "do_not_display",
         "build_name": "Delta.250I",
-        "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/Delta.250I?c=gt-S_250"
+        "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/Delta.250I?c=gt-S_250",
     },
-
-    #AY.4.2 - up to 10% in UK - cornelius
-    "Delta.145H": { # OF1a:2529v + S:222V + S:145H (in some)
-        "snps": [22227, 17040, 7851], # 22227T (S:222V), 17040C (syn), 7851T (ORF1a:2529V)
+    # AY.4.2 - up to 10% in UK - cornelius
+    "Delta.145H": {  # OF1a:2529v + S:222V + S:145H (in some)
+        "snps": [
+            22227,
+            17040,
+            7851,
+        ],  # 22227T (S:222V), 17040C (syn), 7851T (ORF1a:2529V)
         "cluster_data": [],
         "nextstrain_build": True,
         "graphing": False,
         "important": False,
-        "country_info": [], 'col': "#b3d9ff", "display_name": "Delta+145H",
+        "country_info": [],
+        "col": "#b3d9ff",
+        "display_name": "Delta+145H",
         "type": "do_not_display",
         "build_name": "Delta.145H",
-        "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/Delta.145H?c=gt-S_145,222"
+        "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/Delta.145H?c=gt-S_145,222",
     },
-
-    #AY.34 - possible rise Italy? - cornelius
-    "Delta.ORF1a3059F": { # 
-        "snps": [23593, 9441, 22498], # S:677H (23593C), ORF1a:3059F (9441T) nuc: C22498T , ####26109A, 26681T, 27014T
+    # AY.34 - possible rise Italy? - cornelius
+    "Delta.ORF1a3059F": {  #
+        "snps": [
+            23593,
+            9441,
+            22498,
+        ],  # S:677H (23593C), ORF1a:3059F (9441T) nuc: C22498T , ####26109A, 26681T, 27014T
         "cluster_data": [],
         "nextstrain_build": True,
         "graphing": False,
         "important": False,
-        "country_info": [], 'col': "#b3d9ff", "display_name": "Delta+ORF1a3059F",
+        "country_info": [],
+        "col": "#b3d9ff",
+        "display_name": "Delta+ORF1a3059F",
         "type": "do_not_display",
         "build_name": "Delta.ORF1a3059F",
-        "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/Delta.ORF1a3059F?c=gt-ORF1a_3059"
+        "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/Delta.ORF1a3059F?c=gt-ORF1a_3059",
     },
-
-    #additional mutation builds with no pages (yet?)
-
-    "S613": { #613H - 23401T
+    # additional mutation builds with no pages (yet?)
+    "S613": {  # 613H - 23401T
         "snps": [23401],
         "cluster_data": [],
         "nextstrain_build": True,
@@ -1578,7 +1577,7 @@ clusters = {
         "build_name": "S.Q613",
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/S.Q613?c=gt-S_613",  # color
     },
-    "S_222": { #S.A222V - 22227T
+    "S_222": {  # S.A222V - 22227T
         "snps": [22227],
         "cluster_data": [],
         "nextstrain_build": True,
@@ -1591,7 +1590,7 @@ clusters = {
         "build_name": "S.A222",
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/S.A222?c=gt-S_222",  # color
     },
-    "S145": { #S.Y145H - 21995C
+    "S145": {  # S.Y145H - 21995C
         "snps": [21995],
         "cluster_data": [],
         "nextstrain_build": True,
@@ -1604,7 +1603,7 @@ clusters = {
         "build_name": "S.Y145",
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/S.Y145?c=gt-S_145",  # color
     },
-    "S572": { #S.T572I - 23277T
+    "S572": {  # S.T572I - 23277T
         "snps": [23277],
         "cluster_data": [],
         "nextstrain_build": True,
@@ -1617,69 +1616,60 @@ clusters = {
         "build_name": "S.T572",
         "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/S.T572?c=gt-S_572",  # color
     },
-
-
-
- #  "Orf1b813": { #S.T572I - 23277T
- #      "snps": [15904, 18904], #813H, 1813H
- #      "cluster_data": [],
- #      "nextstrain_build": True,
- #      "graphing": False,
- #      "type": "do_not_display",
- #      "important": False,
- #      "country_info": [],
- #      "col": "#ff8080",
- #      "display_name": "Orf1b:Q813H",
- #      "build_name": "Orf1b.Q813H",
- #      "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/Orf1b.Q813H?c=gt-ORF1b_813,1813",  # color
- #  },
-    
-
+    #  "Orf1b813": { #S.T572I - 23277T
+    #      "snps": [15904, 18904], #813H, 1813H
+    #      "cluster_data": [],
+    #      "nextstrain_build": True,
+    #      "graphing": False,
+    #      "type": "do_not_display",
+    #      "important": False,
+    #      "country_info": [],
+    #      "col": "#ff8080",
+    #      "display_name": "Orf1b:Q813H",
+    #      "build_name": "Orf1b.Q813H",
+    #      "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/Orf1b.Q813H?c=gt-ORF1b_813,1813",  # color
+    #  },
     # build for Delta and Kappa -- retired 11/11/21
-#    "21AS154S478":{
-#        "snps": [29402, 22917, 14408], # N377, S452. ORF1b 314
-#        "cluster_data": [],  
-#        "nextstrain_build": True,
-#        "type": "do_not_display",
-#        "graphing": False,
-#        "important": False,
-#        "country_info": [],
-#        "col": "#009900",
-#        "display_name": "21A/21B",
-#        "build_name": "21A.21B",
-#        "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/21A.21B",
-#    },
-
-    #B.1.1.318 - prominent in Greece
+    #    "21AS154S478":{
+    #        "snps": [29402, 22917, 14408], # N377, S452. ORF1b 314
+    #        "cluster_data": [],
+    #        "nextstrain_build": True,
+    #        "type": "do_not_display",
+    #        "graphing": False,
+    #        "important": False,
+    #        "country_info": [],
+    #        "col": "#009900",
+    #        "display_name": "21A/21B",
+    #        "build_name": "21A.21B",
+    #        "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/21A.21B",
+    #    },
+    # B.1.1.318 - prominent in Greece
     # Turned off 11 Oct 2021 as few recent sequences
-#    "S796": {'snps': [23604,23948,9072], #A/C/T
-#    "cluster_data": [], 
-#    "build_name": "20B.S.796H", 
-#    "display_name": "20B/S:796H",
-#    "nextstrain_build": True, 
-#    "graphing": False, 
-#    "important": False,
-#    "type": "do_not_display",
-#    "country_info": [],
-#    "col": "#b3d9ff",
-#    "nextstrain_url": ""},
-
-    #B.1.619 - recent expansion in S Korea
+    #    "S796": {'snps': [23604,23948,9072], #A/C/T
+    #    "cluster_data": [],
+    #    "build_name": "20B.S.796H",
+    #    "display_name": "20B/S:796H",
+    #    "nextstrain_build": True,
+    #    "graphing": False,
+    #    "important": False,
+    #    "type": "do_not_display",
+    #    "country_info": [],
+    #    "col": "#b3d9ff",
+    #    "nextstrain_url": ""},
+    # B.1.619 - recent expansion in S Korea
     # Turned off 11 Oct 2021 as few recent sequences
-#    "S210": {'snps': [8311,9319], #T/T
-#    "cluster_data": [], 
-#    "build_name": "20A.S.210T", 
-#    "display_name": "20A/S:210T",
-#    "nextstrain_build": False, 
-#    "graphing": False, 
-#    "important": False,
-#    "type": "do_not_display",
-#    "country_info": [],
-#    "col": "#b3d9ff",
-#    "nextstrain_url": ""},
-
-
-    #"21H.417": { #21H + 417
+    #    "S210": {'snps': [8311,9319], #T/T
+    #    "cluster_data": [],
+    #    "build_name": "20A.S.210T",
+    #    "display_name": "20A/S:210T",
+    #    "nextstrain_build": False,
+    #    "graphing": False,
+    #    "important": False,
+    #    "type": "do_not_display",
+    #    "country_info": [],
+    #    "col": "#b3d9ff",
+    #    "nextstrain_url": ""},
+    # "21H.417": { #21H + 417
     #    "snps": [22599, 4878, 17491, 22813], #S 346 (22599A)  ORF1a: 1538 (4878T) nuc: 17491T, S:417
     #    "nextstrain_build": True,
     #    "graphing": False,
@@ -1689,25 +1679,22 @@ clusters = {
     #    "type": "do_not_display",
     #    "build_name": "21H.417N",
     #    "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/21H.417N?c=gt-S_417"
-    #}
-
-    #uk delta?
-    #"Ukdelt": {"snps": [22995,23604,22917,7851], # S:478, 681, 452, ??
-    #"cluster_data": [], "build_name": "ukdelt", "display_name": "ukdelt",
-    #"nextstrain_build": True, "graphing": False, "nextstrain_url": ""}
-
+    # }
+    # uk delta?
+    # "Ukdelt": {"snps": [22995,23604,22917,7851], # S:478, 681, 452, ??
+    # "cluster_data": [], "build_name": "ukdelt", "display_name": "ukdelt",
+    # "nextstrain_build": True, "graphing": False, "nextstrain_url": ""}
     # B.1.1.519  23756, 22995, 12789
-    #"S732": {'snps': [23755, 22994, 12788], 'cluster_data': [], #S732, S478, ORF1a 4175
-    #"nextstrain_build": True,
-    #"graphing": False,
-    #"usa_graph": False,
-    #"important": False,
-    #"country_info": [], 'col': "#b3d9ff", "display_name": "S:732A",
-    #"type": "do_not_display",
-    #"build_name": "S.Q675",
-    #"nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/S.732A?c=gt-S_732"
-    #}
-
+    # "S732": {'snps': [23755, 22994, 12788], 'cluster_data': [], #S732, S478, ORF1a 4175
+    # "nextstrain_build": True,
+    # "graphing": False,
+    # "usa_graph": False,
+    # "important": False,
+    # "country_info": [], 'col': "#b3d9ff", "display_name": "S:732A",
+    # "type": "do_not_display",
+    # "build_name": "S.Q675",
+    # "nextstrain_url": "https://nextstrain.org/groups/neherlab/ncov/S.732A?c=gt-S_732"
+    # }
     # trying out 675
     # "S675": {'snps': [23586], 'cluster_data': [],
     # "nextstrain_build": True,
@@ -1775,7 +1762,7 @@ clusters = {
     # }
     # NY stuff
     # "ORF811": {  'snps': [9866, 25516, 27924], 'cluster_data': [],
-    #'build_name': "ORF8.T11I"
+    # 'build_name': "ORF8.T11I"
     # }
     #            "S222": {'snps': [22226, 28931, 29644], 'cluster_data': [],
     #            "country_info":[], 'col': "#8a8a8a", "display_name": "20A.EU1",

--- a/scripts/colors_and_countries.py
+++ b/scripts/colors_and_countries.py
@@ -58,9 +58,7 @@ colors = [
 
 # separate out Scotland, England, NI, Wales...
 uk_countries = ["Scotland", "England", "Wales", "Northern Ireland"]
-countries_and_uk_list = [
-    x for x in country_list if x != "United Kingdom"
-] + uk_countries
+countries_and_uk_list = [x for x in country_list if x != "United Kingdom"] + uk_countries
 all_countries = country_list + uk_countries
 
 # For the main cluster, ran out of colors... try this hack.
@@ -68,8 +66,7 @@ all_countries = country_list + uk_countries
 linestyles = ["-", "-.", "--", ":"]
 
 country_styles = {
-    country: {"c": colors[i], "ls": linestyles[i // len(colors)]}
-    for i, country in enumerate(country_list)
+    country: {"c": colors[i], "ls": linestyles[i // len(colors)]} for i, country in enumerate(country_list)
 }
 
 country_styles.update(
@@ -77,7 +74,10 @@ country_styles.update(
         "Scotland": {"c": country_styles["United Kingdom"]["c"], "ls": "--"},
         "England": {"c": country_styles["United Kingdom"]["c"], "ls": "-"},
         "Wales": {"c": country_styles["United Kingdom"]["c"], "ls": "-."},
-        "Northern Ireland": {"c": country_styles["United Kingdom"]["c"], "ls": ":"},
+        "Northern Ireland": {
+            "c": country_styles["United Kingdom"]["c"],
+            "ls": ":",
+        },
     }
 )
 
@@ -149,7 +149,7 @@ country_list_2 = [
     "Turkey",  # 4
     "South Africa",  # 5
     "Curacao",  # 6
-    "Russia", # 7
+    "Russia",  # 7
     "Poland",  # 8
     "Romania",  # 9
     "Canada",  # 10
@@ -178,48 +178,45 @@ country_list_3 = [
     "Estonia",  # 10
     "Greece",  # 11
     "Chile",  # 12
-    "Qatar",    # 13
-    "Sri Lanka",   # 14
-    "Kenya",    # 15
-    "Philippines",     # 16
-    "Argentina", # 17
-    "Cambodia",       # 18  
-    "Ecuador",    #19
-    "Fiji",    #20
+    "Qatar",  # 13
+    "Sri Lanka",  # 14
+    "Kenya",  # 15
+    "Philippines",  # 16
+    "Argentina",  # 17
+    "Cambodia",  # 18
+    "Ecuador",  # 19
+    "Fiji",  # 20
 ]
 
 country_list_4 = [
-    "Sint Maarten",         #1
-    "Angola",               #2
-    "Trinidad and Tobago",  #3
-    "Peru",                 #4
-    "Maldives",               #5
-    "Lebanon",              #6
-    "New Zealand",          #7
-    "Vietnam",             #8
-    "Costa Rica",           #9
-    "Bahrain",              #10
-    "Pakistan",             #11
-    "Kosovo",               #12
-    "Bonaire",              #13
-    "Papua New Guinea",     #14
-    "Jordan",               #15
-    "Uganda",               #16
+    "Sint Maarten",  # 1
+    "Angola",  # 2
+    "Trinidad and Tobago",  # 3
+    "Peru",  # 4
+    "Maldives",  # 5
+    "Lebanon",  # 6
+    "New Zealand",  # 7
+    "Vietnam",  # 8
+    "Costa Rica",  # 9
+    "Bahrain",  # 10
+    "Pakistan",  # 11
+    "Kosovo",  # 12
+    "Bonaire",  # 13
+    "Papua New Guinea",  # 14
+    "Jordan",  # 15
+    "Uganda",  # 16
 ]
 
 country_styles_1 = {
-    country: {"c": colors_2[i], "ls": "-"}  # linestyles[i//len(colors)]}
-    for i, country in enumerate(country_list_1)
+    country: {"c": colors_2[i], "ls": "-"} for i, country in enumerate(country_list_1)  # linestyles[i//len(colors)]}
 }
 
 country_styles_2 = {
-    country: {"c": colors_2[i], "ls": "--"}  # linestyles[i//len(colors)]}
-    for i, country in enumerate(country_list_2)
+    country: {"c": colors_2[i], "ls": "--"} for i, country in enumerate(country_list_2)  # linestyles[i//len(colors)]}
 }
 
 country_styles_3 = {
-    country: {"c": colors_2[i], "ls": "-."}  # linestyles[i//len(colors)]}
-    for i, country in enumerate(country_list_3)
+    country: {"c": colors_2[i], "ls": "-."} for i, country in enumerate(country_list_3)  # linestyles[i//len(colors)]}
 }
 
 country_styles_4 = {
@@ -227,4 +224,9 @@ country_styles_4 = {
     for i, country in enumerate(country_list_4)
 }
 
-country_styles_all = {**country_styles_1, **country_styles_2, **country_styles_3, **country_styles_4}
+country_styles_all = {
+    **country_styles_1,
+    **country_styles_2,
+    **country_styles_3,
+    **country_styles_4,
+}

--- a/scripts/compare_S222_S477.py
+++ b/scripts/compare_S222_S477.py
@@ -7,7 +7,6 @@ import seaborn as sns
 from shutil import copyfile
 from collections import defaultdict
 from matplotlib.patches import Rectangle
-import matplotlib.patches as mpatches
 import copy
 from colors_and_countries import *
 from travel_data import *
@@ -56,10 +55,7 @@ for clus in clusters.keys():
     # There's one spanish seq with date of 7 March - we think this is wrong.
     # If seq there and date bad - exclude!
     bad_seq = meta[meta["strain"].isin(["Spain/VC-IBV-98006466/2020"])]
-    if (
-        bad_seq.date.values[0] == "2020-03-07"
-        and "Spain/VC-IBV-98006466/2020" in wanted_seqs
-    ):
+    if bad_seq.date.values[0] == "2020-03-07" and "Spain/VC-IBV-98006466/2020" in wanted_seqs:
         wanted_seqs.remove("Spain/VC-IBV-98006466/2020")
 
     print(len(wanted_seqs))  # how many are there?
@@ -87,9 +83,7 @@ for clus in clusters.keys():
         country_info.loc[coun].last_seq = temp_meta["date"].max()
         country_info.loc[coun].num_seqs = len(temp_meta)
 
-        country_dates[coun] = [
-            datetime.datetime.strptime(dat, "%Y-%m-%d") for dat in temp_meta["date"]
-        ]
+        country_dates[coun] = [datetime.datetime.strptime(dat, "%Y-%m-%d") for dat in temp_meta["date"]]
 
         herbst_dates = [x for x in country_dates[coun] if x >= cutoffDate]
         if coun in uk_countries:
@@ -99,13 +93,9 @@ for clus in clusters.keys():
         all_dates = [
             datetime.datetime.strptime(x, "%Y-%m-%d")
             for x in temp_meta["date"]
-            if len(x) is 10
-            and "-XX" not in x
-            and datetime.datetime.strptime(x, "%Y-%m-%d") >= cutoffDate
+            if len(x) is 10 and "-XX" not in x and datetime.datetime.strptime(x, "%Y-%m-%d") >= cutoffDate
         ]
-        country_info.loc[coun].sept_aug_freq = round(
-            len(herbst_dates) / len(all_dates), 2
-        )
+        country_info.loc[coun].sept_aug_freq = round(len(herbst_dates) / len(all_dates), 2)
 
     print(f"\nCluster {clus}")
     print(country_info)
@@ -118,9 +108,7 @@ for clus in clusters.keys():
         counts_by_week = defaultdict(int)
         for dat in country_dates[coun]:
             # counts_by_week[dat.timetuple().tm_yday//7]+=1 # old method
-            counts_by_week[
-                (dat.isocalendar()[1] // 2 * 2)
-            ] += 1  # returns ISO calendar week
+            counts_by_week[(dat.isocalendar()[1] // 2 * 2)] += 1  # returns ISO calendar week
         clus_week_counts[coun] = counts_by_week
 
     # Get counts per week for sequences regardless of whether in the cluster or not - from week 20 only.
@@ -134,9 +122,7 @@ for clus in clusters.keys():
         # week 20
         for ri, row in temp_meta.iterrows():
             dat = row.date
-            if (
-                len(dat) is 10 and "-XX" not in dat
-            ):  # only take those that have real dates
+            if len(dat) is 10 and "-XX" not in dat:  # only take those that have real dates
                 dt = datetime.datetime.strptime(dat, "%Y-%m-%d")
                 # exclude sequences with identical dates & underdiverged
                 if coun == "Ireland" and dat == "2020-09-22":
@@ -226,9 +212,7 @@ for coun, ax in zip(countries_to_plot, axs[1:]):
     # for cluster_data in [cluster_data_S477, cluster_data_S222]:
     for clus in clusters.keys():
         cluster_data = clusters[clus]["cluster_data"]
-        week_as_date, cluster_count, total_count = non_zero_counts(
-            cluster_data, total_data, coun
-        )
+        week_as_date, cluster_count, total_count = non_zero_counts(cluster_data, total_data, coun)
 
         week_as_dates[coun] = week_as_date
         # clusters[clus]['week_as_date'] = week_as_date
@@ -270,9 +254,12 @@ for coun, ax in zip(countries_to_plot, axs[1:]):
             ptchs.append(patch)
         if i == len(clusters) - 1:
             ax.fill_between(
-                week_as_date, cluster_count / total_count, 1, facecolor=grey_color
+                week_as_date,
+                cluster_count / total_count,
+                1,
+                facecolor=grey_color,
             )
-            patch = mpatches.Patch(color=grey_color, label=f"other")
+            patch = mpatches.Patch(color=grey_color, label="other")
             ptchs.append(patch)
         # if i == 0:
         first_clus_count = cluster_count  # unindented
@@ -290,9 +277,7 @@ plt.tight_layout()
 
 plt.savefig(figure_path + f"EUClusters_compare.{fmt}")
 trends_path = figure_path + f"EUClusters_compare.{fmt}"
-copypath = trends_path.replace(
-    "compare", "compare-{}".format(datetime.date.today().strftime("%Y-%m-%d"))
-)
+copypath = trends_path.replace("compare", "compare-{}".format(datetime.date.today().strftime("%Y-%m-%d")))
 copyfile(trends_path, copypath)
 
 

--- a/scripts/compare_country_lineages.py
+++ b/scripts/compare_country_lineages.py
@@ -7,7 +7,6 @@ import seaborn as sns
 from shutil import copyfile
 from collections import defaultdict
 from matplotlib.patches import Rectangle
-import matplotlib.patches as mpatches
 import copy
 import json
 from colors_and_countries import *
@@ -83,9 +82,7 @@ for clus in clusters:
         gaplist = row["gap_list"]
         if snps and not pd.isna(snplist):
             intsnp = [int(x) for x in snplist.split(",")]
-            if all(x in intsnp for x in snps) or (
-                all(x in intsnp for x in snps2) and len(snps2) != 0
-            ):
+            if all(x in intsnp for x in snps) or (all(x in intsnp for x in snps2) and len(snps2) != 0):
                 # if meta.loc[meta['strain'] == strain].region.values[0] == "Europe":
                 wanted_seqs.append(row["strain"])
         # look for all locations in gap list
@@ -131,9 +128,7 @@ for clus in clusters:
         country_info.loc[coun].last_seq = temp_meta["date"].max()
         country_info.loc[coun].num_seqs = len(temp_meta)
 
-        country_dates[coun] = [
-            datetime.datetime.strptime(dat, "%Y-%m-%d") for dat in temp_meta["date"]
-        ]
+        country_dates[coun] = [datetime.datetime.strptime(dat, "%Y-%m-%d") for dat in temp_meta["date"]]
 
         herbst_dates = [x for x in country_dates[coun] if x >= cutoffDate]
         if coun in uk_countries:
@@ -143,9 +138,7 @@ for clus in clusters:
         all_dates = [
             datetime.datetime.strptime(x, "%Y-%m-%d")
             for x in temp_meta["date"]
-            if len(x) is 10
-            and "-XX" not in x
-            and datetime.datetime.strptime(x, "%Y-%m-%d") >= cutoffDate
+            if len(x) is 10 and "-XX" not in x and datetime.datetime.strptime(x, "%Y-%m-%d") >= cutoffDate
         ]
         # country_info.loc[coun].sept_aug_freq = round(len(herbst_dates)/len(all_dates),2)
 
@@ -161,9 +154,7 @@ for clus in clusters:
         for dat in country_dates[coun]:
             #   counts_by_week[dat.isocalendar()[1]]+=1  #FOR ONE WEEK
             # for TWO WEEKS 2 weeks
-            wk = (
-                dat.isocalendar()[1] // 2 * 2
-            )  # returns ISO calendar week -every 2 weeks
+            wk = dat.isocalendar()[1] // 2 * 2  # returns ISO calendar week -every 2 weeks
             yr = dat.isocalendar()[0]
             yr_wk = (yr, wk)
             counts_by_week[yr_wk] += 1
@@ -180,9 +171,7 @@ for clus in clusters:
         # week 20
         for ri, row in temp_meta.iterrows():
             dat = row.date
-            if (
-                len(dat) is 10 and "-XX" not in dat
-            ):  # only take those that have real dates
+            if len(dat) is 10 and "-XX" not in dat:  # only take those that have real dates
                 dt = datetime.datetime.strptime(dat, "%Y-%m-%d")
                 # exclude sequences with identical dates & underdiverged
                 if coun == "Ireland" and dat == "2020-09-22":
@@ -260,7 +249,10 @@ country_week = {clus: {} for clus in clusters}
 fs = 14
 rws = int(np.ceil((len(countries_to_plot) + 1) / 2))
 fig, axs = plt.subplots(
-    nrows=rws, ncols=2, sharex=True, figsize=(9, 11)  # len(countries_to_plot)+1,
+    nrows=rws,
+    ncols=2,
+    sharex=True,
+    figsize=(9, 11),  # len(countries_to_plot)+1,
 )
 
 min_week = datetime.datetime(2020, 12, 31)
@@ -303,9 +295,7 @@ for coun, ax in zip(countries_to_plot, fig.axes[1:]):  # axs[1:]):
 
         week_as_dates[coun] = week_as_date
 
-        json_output["countries"][coun][clusters[clus]["display_name"]] = list(
-            cluster_count
-        )
+        json_output["countries"][coun][clusters[clus]["display_name"]] = list(cluster_count)
 
         country_week[clus][coun] = cluster_count / total_count
 
@@ -328,16 +318,17 @@ for coun, ax in zip(countries_to_plot, fig.axes[1:]):  # axs[1:]):
         ptchs.append(patch)
         if i == len(clus_keys) - 1:  # len(clusters)-1 :
             ax.fill_between(
-                week_as_date, cluster_count / total_count, 1, facecolor=grey_color
+                week_as_date,
+                cluster_count / total_count,
+                1,
+                facecolor=grey_color,
             )
-            patch = mpatches.Patch(color=grey_color, label=f"other")
+            patch = mpatches.Patch(color=grey_color, label="other")
             ptchs.append(patch)
         # if i == 0:
         first_clus_count = cluster_count  # unindented
         i += 1
-    json_output["countries"][coun]["week"] = [
-        datetime.datetime.strftime(x, "%Y-%m-%d") for x in week_as_date
-    ]
+    json_output["countries"][coun]["week"] = [datetime.datetime.strftime(x, "%Y-%m-%d") for x in week_as_date]
     json_output["countries"][coun]["total_sequences"] = [int(x) for x in total_count]
 
     ax.text(datetime.datetime(2020, 6, 1), 0.7, coun, fontsize=fs)
@@ -346,12 +337,8 @@ for coun, ax in zip(countries_to_plot, fig.axes[1:]):  # axs[1:]):
     # ax.legend(ncol=1, fontsize=fs*0.8, loc=2)
 
 json_output["plotting_dates"] = {}
-json_output["plotting_dates"]["min_date"] = datetime.datetime.strftime(
-    min_week, "%Y-%m-%d"
-)
-json_output["plotting_dates"]["max_date"] = datetime.datetime.strftime(
-    max_week, "%Y-%m-%d"
-)
+json_output["plotting_dates"]["min_date"] = datetime.datetime.strftime(min_week, "%Y-%m-%d")
+json_output["plotting_dates"]["max_date"] = datetime.datetime.strftime(max_week, "%Y-%m-%d")
 
 fig.axes[0].legend(handles=ptchs, loc=3, fontsize=fs * 0.7, ncol=3)
 fig.axes[0].axis("off")
@@ -359,16 +346,14 @@ fig.autofmt_xdate(rotation=30)
 plt.show()
 plt.tight_layout()
 
-with open(cluster_tables_path + f"EUClusters_data.json", "w") as fh:
+with open(cluster_tables_path + "EUClusters_data.json", "w") as fh:
     json.dump(json_output, fh)
 
-plt.savefig(overall_trends_figs_path + f"EUClusters_compare.png")
+plt.savefig(overall_trends_figs_path + "EUClusters_compare.png")
 
 plt.savefig(figure_path + f"EUClusters_compare.{fmt}")
 trends_path = figure_path + f"EUClusters_compare.{fmt}"
-copypath = trends_path.replace(
-    "compare", "compare-{}".format(datetime.date.today().strftime("%Y-%m-%d"))
-)
+copypath = trends_path.replace("compare", "compare-{}".format(datetime.date.today().strftime("%Y-%m-%d")))
 copyfile(trends_path, copypath)
 
 

--- a/scripts/compare_lineages.py
+++ b/scripts/compare_lineages.py
@@ -53,10 +53,7 @@ known_clusters = {}
 clus_files = [
     x
     for x in listdir(named_clusters_dir)
-    if "2020-" not in x
-    and "clusone" not in x
-    and "clustwo" not in x
-    and "_clus" not in x
+    if "2020-" not in x and "clusone" not in x and "clustwo" not in x and "_clus" not in x
 ]
 for file in clus_files:
     cluster_name = file.strip("cluster_.txt")
@@ -75,9 +72,12 @@ for file in clus_files:
 T = Phylo.read(treefile, "newick")
 node_data = read_node_data([branchfile])
 
-node_data, node_attrs, node_data_names, metadata_names = parse_node_data_and_metadata(
-    T, [branchfile], metadatafile
-)
+(
+    node_data,
+    node_attrs,
+    node_data_names,
+    metadata_names,
+) = parse_node_data_and_metadata(T, [branchfile], metadatafile)
 rate = node_data["clock"]["rate"]
 
 # Add country and division, date, etc to each node
@@ -153,9 +153,7 @@ for country, date in countries_dates.items():
     ##### Reorganize collected data #####
 
     # Compare against known clusters:
-    lineage_clusters = (
-        {}
-    )  # compares all collected lineages to known clusters and stores overlap percentage
+    lineage_clusters = {}  # compares all collected lineages to known clusters and stores overlap percentage
     for lineage in lineages_strains:
         lineage_clusters[lineage] = {}
         strains = lineages_strains[lineage]
@@ -165,14 +163,10 @@ for country, date in countries_dates.items():
             for strain in strains:
                 if strain in strains_cluster:
                     overlapping_strains += 1
-            lineage_clusters[lineage][cluster] = round(
-                overlapping_strains / len(strains), 2
-            )
+            lineage_clusters[lineage][cluster] = round(overlapping_strains / len(strains), 2)
 
     # Save lineage strains in text file for easier access
-    with open(
-        output_folder + "lineage_strains_" + country + "_" + date + ".txt", "w"
-    ) as f:
+    with open(output_folder + "lineage_strains_" + country + "_" + date + ".txt", "w") as f:
         for lineage in lineages_strains:
             f.write(lineage + "\n")
             for strain in lineages_strains[lineage]:
@@ -210,10 +204,7 @@ for country, date in countries_dates.items():
     total_data = total_data.fillna(0)
 
     # Get dates for calendar weeks
-    week_as_date = [
-        datetime.datetime.strptime("2020-W{}-1".format(x), "%G-W%V-%u")
-        for x in lineages_data.index
-    ]
+    week_as_date = [datetime.datetime.strptime("2020-W{}-1".format(x), "%G-W%V-%u") for x in lineages_data.index]
     lineages_data.index = week_as_date
     total_data.index = week_as_date
 
@@ -228,13 +219,14 @@ for country, date in countries_dates.items():
 
     fs = 14
     fig, (ax1, ax2) = plt.subplots(
-        nrows=2, sharex=True, figsize=(12, 6), gridspec_kw={"height_ratios": [1, 3]}
+        nrows=2,
+        sharex=True,
+        figsize=(12, 6),
+        gridspec_kw={"height_ratios": [1, 3]},
     )
 
     # First plot: absolute numbers compare total versus lineages
-    ax1.stackplot(
-        total_data.columns, total_data.values.tolist(), color="darkblue"
-    )  # "lightgray")
+    ax1.stackplot(total_data.columns, total_data.values.tolist(), color="darkblue")  # "lightgray")
     # ax1.stackplot(lineages_data.columns, lineages_data.values.sum(axis = 0).tolist(), color="gray")
     # ax1.legend(["Overall total", "Lineages total"], fontsize=fs * 0.8, loc=2)
     ax1.tick_params(labelsize=fs * 0.8)
@@ -264,10 +256,7 @@ for country, date in countries_dates.items():
         for i in range(len(lineages_data_frequencies.index))
     ]  # create gradient of grey shades
     for i, lineage in enumerate(lineages_data_frequencies.index):
-        if (
-            lineage in lineage_to_cluster
-            and lineage_to_cluster[lineage] in special_colors
-        ):
+        if lineage in lineage_to_cluster and lineage_to_cluster[lineage] in special_colors:
             colors[i] = special_colors[lineage_to_cluster[lineage]]
 
     ax2.fill_between(
@@ -284,11 +273,12 @@ for country, date in countries_dates.items():
         colors=colors,
     )
 
-    handles, labels = ax2.get_legend_handles_labels()  # get the labels and handles
+    (
+        handles,
+        labels,
+    ) = ax2.get_legend_handles_labels()  # get the labels and handles
     new_labels = ["other lineages"]  # one gray label for all gray lineages
-    gray_handles = [
-        handles[i] for i in range(len(labels)) if labels[i] not in lineage_to_cluster
-    ]
+    gray_handles = [handles[i] for i in range(len(labels)) if labels[i] not in lineage_to_cluster]
     new_handles = [gray_handles[int(len(gray_handles) / 2)]]  # medium shade of gray
 
     for i, label in enumerate(labels):
@@ -297,7 +287,11 @@ for country, date in countries_dates.items():
             new_handles.append(handles[i])
 
     ax2.legend(
-        reversed(new_handles), reversed(new_labels), ncol=1, loc=2, fontsize=fs * 0.8
+        reversed(new_handles),
+        reversed(new_labels),
+        ncol=1,
+        loc=2,
+        fontsize=fs * 0.8,
     )
     fig.autofmt_xdate(rotation=30)
     ax2.tick_params(labelsize=fs * 0.8)
@@ -305,7 +299,8 @@ for country, date in countries_dates.items():
     ax2.set_title("Lineage frequencies")
     ax2.set_ylim(0, 1)
     ax2.set_xlim(
-        lineages_data_frequencies.columns[0], lineages_data_frequencies.columns[-1]
+        lineages_data_frequencies.columns[0],
+        lineages_data_frequencies.columns[-1],
     )
 
     # fig.suptitle(country + " (Tree Cutoff Date: " + cutoffDate.strftime("%A, %d %b %Y") + ")")
@@ -318,6 +313,7 @@ for country, date in countries_dates.items():
     plt.savefig(figure_path + f"compare_lineages_{country}.{fmt}")
     lineages_path = figure_path + f"compare_lineages_{country}.{fmt}"
     copypath = lineages_path.replace(
-        country, "{}-{}".format(country, datetime.date.today().strftime("%Y-%m-%d"))
+        country,
+        "{}-{}".format(country, datetime.date.today().strftime("%Y-%m-%d")),
     )
     copyfile(lineages_path, copypath)

--- a/scripts/convert_to_web_app_json.py
+++ b/scripts/convert_to_web_app_json.py
@@ -57,7 +57,7 @@ def wrap_cluster_data(country_data_aos):
                 "cluster_counts": cluster_counts,
             }
         )
-    country_data_aos_wrapped.sort(key=lambda d: d['week'])
+    country_data_aos_wrapped.sort(key=lambda d: d["week"])
     return country_data_aos_wrapped, list(cluster_names)
 
 
@@ -70,12 +70,8 @@ def convert_per_country_data(json_input):
     distributions = []
     for (country, country_data) in countries.items():
         country_data_aos = soa_to_aos(country_data)
-        country_data_aos_wrapped, cluster_names_new = wrap_cluster_data(
-            country_data_aos
-        )
-        distributions.append(
-            {"country": country, "distribution": country_data_aos_wrapped}
-        )
+        country_data_aos_wrapped, cluster_names_new = wrap_cluster_data(country_data_aos)
+        distributions.append({"country": country, "distribution": country_data_aos_wrapped})
         cluster_names = sorted(list(set(cluster_names_new + cluster_names)))
 
     return cluster_names, distributions, min_date, max_date
@@ -117,9 +113,7 @@ def interpolate_per_cluster_data(cluster_data):
 
     # Add rows for missing weeks. Fill values of the new rows wih NaN.
     old_index = df.index
-    new_index = pd.date_range(old_index[0], old_index[-1], freq="7D").strftime(
-        "%Y-%m-%d"
-    )
+    new_index = pd.date_range(old_index[0], old_index[-1], freq="7D").strftime("%Y-%m-%d")
     df_reindexed = df.reindex(new_index, fill_value=np.NaN)
 
     df_interp = df_reindexed.interpolate(method="linear")
@@ -128,9 +122,7 @@ def interpolate_per_cluster_data(cluster_data):
     # We want a closed diff: only rows that are not in the original data, plus boundaries for every span of missing data
     index_interp = diff_left_closed(new_index.tolist(), old_index.tolist(), closed=True)
 
-    index_interp_open = diff_left_closed(
-        new_index.tolist(), old_index.tolist(), closed=False
-    )
+    index_interp_open = diff_left_closed(new_index.tolist(), old_index.tolist(), closed=False)
 
     df_result = df_interp
     df_result["interp"] = False
@@ -203,9 +195,7 @@ def convert_per_cluster_data(clusters):
         build_name = cluster["build_name"]
 
         distribution = []
-        with open(
-            os.path.join(cluster_tables_path, f"{build_name}_data.json"), "r"
-        ) as f:
+        with open(os.path.join(cluster_tables_path, f"{build_name}_data.json"), "r") as f:
             json_input = json.load(f)
 
             for (country, cluster_data) in json_input.items():
@@ -213,14 +203,10 @@ def convert_per_cluster_data(clusters):
                     list(set([country] + per_cluster_data_output["country_names"]))
                 )
                 cluster_data_interp = interpolate_per_cluster_data(cluster_data)
-                update_per_cluster_distribution(
-                    cluster_data_interp, country, distribution
-                )
+                update_per_cluster_distribution(cluster_data_interp, country, distribution)
 
-        distribution.sort(key=lambda d: d['week'])
-        per_cluster_data_output["distributions"].append(
-            {"cluster": display_name, "distribution": distribution}
-        )
+        distribution.sort(key=lambda d: d["week"])
+        per_cluster_data_output["distributions"].append({"cluster": display_name, "distribution": distribution})
 
     return per_cluster_data_output, per_cluster_data_output_interp
 
@@ -299,9 +285,7 @@ def convert_mutation_comparison(mutation_comparison):
 
     # Matrix [ variants x mutation_positions ],
     # containing mutation string if there is a mutation at a given position in a given variant, and NaN otherwise
-    mutation_presence = pd.DataFrame(
-        None, index=all_mutations_pos, columns=all_variants
-    )
+    mutation_presence = pd.DataFrame(None, index=all_mutations_pos, columns=all_variants)
     for variant, variant_data in mutation_comparison.items():
         for mut in variant_data["nonsynonymous"]:
             mut_obj = mutation_string_to_object(mut)
@@ -329,18 +313,13 @@ def convert_mutation_comparison(mutation_comparison):
 
     def shared_to_json(shared):
         # Convert shared mutations into a format convenient for web app
-        return [
-            {"pos": pos, "presence": pres.replace({np.nan: None}).tolist()}
-            for pos, pres in shared.iterrows()
-        ]
+        return [{"pos": pos, "presence": pres.replace({np.nan: None}).tolist()} for pos, pres in shared.iterrows()]
 
     # Convert individual mutations into a format convenient for web app
     individual = individual.sort_index(ascending=True)
     individual = {k: v.dropna().tolist() for k, v in individual.T.iterrows()}
     individual = pd.DataFrame.from_dict(individual, orient="index").T
-    individual = [
-        {"index": k, "mutations": v.tolist()} for k, v in individual.iterrows()
-    ]
+    individual = [{"index": k, "mutations": v.tolist()} for k, v in individual.iterrows()]
 
     return {
         "variants": all_variants,
@@ -351,8 +330,8 @@ def convert_mutation_comparison(mutation_comparison):
 
 
 def convert_region_data(region_name, region_input):
-    region_input_file = region_input['data']
-    per_country_intro_content = region_input['per_country_intro_content']
+    region_input_file = region_input["data"]
+    per_country_intro_content = region_input["per_country_intro_content"]
 
     if region_input_file is None:
         return {
@@ -366,9 +345,7 @@ def convert_region_data(region_name, region_input):
     with open(os.path.join(cluster_tables_path, region_input_file), "r") as f:
         json_input = json.load(f)
 
-    cluster_names, distributions, min_date, max_date = convert_per_country_data(
-        json_input
-    )
+    cluster_names, distributions, min_date, max_date = convert_per_country_data(json_input)
 
     return {
         "region": region_name,
@@ -384,16 +361,16 @@ def convert_region_data(region_name, region_input):
 REGIONS_INPUTS = {
     "World": {
         "data": "EUClusters_data.json",
-        "per_country_intro_content": "World.md"
+        "per_country_intro_content": "World.md",
     },
     "United States": {
         "data": "USAClusters_data.json",
-        "per_country_intro_content": "UnitedStates.md"
+        "per_country_intro_content": "UnitedStates.md",
     },
     "Switzerland": {
         "data": "SwissClusters_data.json",
-        "per_country_intro_content": "Switzerland.md"
-    }
+        "per_country_intro_content": "Switzerland.md",
+    },
 }
 
 
@@ -427,20 +404,22 @@ def check_acknowledgements(ack_output_path: str):
             if not os.path.isdir(ack_dir):
                 warnings.append(f" * does not have acknowledgements directory ('{ack_dir}')")
 
-            if build_name not in acknowledgements_keys['acknowledgements']:
-                warnings.append(f" * not in 'acknowledgements_keys.json'")
+            if build_name not in acknowledgements_keys["acknowledgements"]:
+                warnings.append(" * not in 'acknowledgements_keys.json'")
             else:
-                num_chunks = acknowledgements_keys['acknowledgements'][build_name]["numChunks"]
+                num_chunks = acknowledgements_keys["acknowledgements"][build_name]["numChunks"]
                 chunks = set(glob.glob(os.path.join(ack_dir, "*.json")))
                 for i in range(num_chunks):
                     filename = "{0:03}.json".format(i)
                     chunk = os.path.join(ack_dir, filename)
-                    if not chunk in chunks:
-                        warnings.append(f" * 'acknowledgements_keys.json' has 'numChunks' "
-                                        f"set to {num_chunks}, but chunk '{filename}' was not found")
+                    if chunk not in chunks:
+                        warnings.append(
+                            f" * 'acknowledgements_keys.json' has 'numChunks' "
+                            f"set to {num_chunks}, but chunk '{filename}' was not found"
+                        )
 
             if len(warnings) > 0:
-                warnings_str = '\n    '.join(warnings)
+                warnings_str = "\n    ".join(warnings)
                 print(f"\nWarning: cluster {build_name}:\n    {warnings_str}")
 
 
@@ -452,9 +431,9 @@ if __name__ == "__main__":
     max_date = format_date(datetime(1000, 1, 1))
     for region_name, region_input in REGIONS_INPUTS.items():
         region_data = convert_region_data(region_name, region_input)
-        if region_data['min_date'] is not None and region_data['max_date'] is not None:
-            min_date = compare_dates(min_date, region_data['min_date'], min)
-            max_date = compare_dates(max_date, region_data['max_date'], max)
+        if region_data["min_date"] is not None and region_data["max_date"] is not None:
+            min_date = compare_dates(min_date, region_data["min_date"], min)
+            max_date = compare_dates(max_date, region_data["max_date"], max)
         regions_data["regions"].append(region_data)
 
     with open(os.path.join(output_path, "perCountryData.json"), "w") as fh:
@@ -467,9 +446,10 @@ if __name__ == "__main__":
     with open(os.path.join(output_path, "params.json"), "w") as fh:
         json.dump(params, fh, indent=2, sort_keys=True)
 
-    per_cluster_data_output, per_cluster_data_output_interp = convert_per_cluster_data(
-        clusters
-    )
+    (
+        per_cluster_data_output,
+        per_cluster_data_output_interp,
+    ) = convert_per_cluster_data(clusters)
     with open(os.path.join(output_path, "perClusterData.json"), "w") as fh:
         json.dump(per_cluster_data_output, fh, indent=2, sort_keys=True)
 

--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -3,6 +3,7 @@ import numpy as np
 import datetime
 from collections import defaultdict
 
+
 def logistic(x, a, t50):
     return np.exp((x - t50) * a) / (1 + np.exp((x - t50) * a))
 
@@ -19,9 +20,7 @@ def fit_logistic(days, cluster, total):
     return sol
 
 
-def trim_last_data_point(
-    week_as_date, cluster_count, total_count, frac=0.2, keep_count=10
-):
+def trim_last_data_point(week_as_date, cluster_count, total_count, frac=0.2, keep_count=10):
     if total_count[-1] < frac * total_count[-2] and total_count[-1] < keep_count:
         return week_as_date[:-1], cluster_count[:-1], total_count[:-1]
 
@@ -35,30 +34,23 @@ def non_zero_counts(cluster_data, total_data, country, smoothing=None):
         smoothing = np.array([1])
         smooth = False
 
-    cluster_and_total = pd.concat(
-        [cluster_data[country], total_data[country]], axis=1
-    ).fillna(0)
+    cluster_and_total = pd.concat([cluster_data[country], total_data[country]], axis=1).fillna(0)
     # remove initial time points without data
     data_range = np.cumsum(cluster_and_total.iloc[:, 1]) > 0
     with_data = cluster_and_total.iloc[:, 1] > 0
     with_data_inrange = with_data[data_range]
     # this lets us plot X axis as dates rather than weeks (I struggle with weeks...)
     week_as_date = [
-        datetime.datetime.strptime("{}-W{}-1".format(*x), "%G-W%V-%u")
-        for x in cluster_and_total[data_range].index
+        datetime.datetime.strptime("{}-W{}-1".format(*x), "%G-W%V-%u") for x in cluster_and_total[data_range].index
     ]
     # plt.plot(weeks.index[with_data_inrange], weeks.loc[with_data_inrange].iloc[:,0]/(total[with_data_inrange]), 'o', color=palette[i], label=coun, linestyle=sty)
     if len(week_as_date) < len(smoothing) and smooth:
         chop = -(len(week_as_date) - len(smoothing) - 1) // 2
         smoothing = smoothing[chop:-chop]
     mode = "same"  # RICHARD
-    cluster_count = np.convolve(
-        cluster_and_total[data_range].iloc[:, 0], smoothing, mode=mode
-    )  #'same')
+    cluster_count = np.convolve(cluster_and_total[data_range].iloc[:, 0], smoothing, mode=mode)  # 'same')
     # cluster_count = cluster_count[0:len(week_as_date)]
-    total_count = np.convolve(
-        cluster_and_total[data_range].iloc[:, 1], smoothing, mode=mode
-    )  #'same')
+    total_count = np.convolve(cluster_and_total[data_range].iloc[:, 1], smoothing, mode=mode)  # 'same')
     # if mode == 'valid':
     #     total_count = total_count[0:len(week_as_date)]
 

--- a/scripts/mutation_comparison.py
+++ b/scripts/mutation_comparison.py
@@ -54,7 +54,7 @@ mutation_comparison = {
             "S:T478K",
             "S:D614G",
             "S:P681R",
-            "S:D950N"
+            "S:D950N",
         ]
     },
     "21B (Kappa)\n(B.1.617.1)": {
@@ -64,7 +64,7 @@ mutation_comparison = {
             "S:E484Q",
             "S:D614G",
             "S:P681R",
-            "S:Q1071H"
+            "S:Q1071H",
         ]
     },
     "21K (Omicron)\n(BA.1)": {
@@ -104,7 +104,7 @@ mutation_comparison = {
             "S:N856K",
             "S:Q954H",
             "S:N969K",
-            "S:L981F"
+            "S:L981F",
         ]
     },
     "21L\n(BA.2)": {
@@ -142,7 +142,7 @@ mutation_comparison = {
             "S:N764K",
             "S:D796Y",
             "S:Q954H",
-            "S:N969K"
+            "S:N969K",
         ]
     },
     "21D (Eta)\n(B.1.525)": {
@@ -158,9 +158,7 @@ mutation_comparison = {
             "S:F888L",
         ]
     },
-    "21F (Iota)\n(B.1.526)": {
-        "nonsynonymous": ["S:L5F", "S:T95I", "S:D253G", "S:E484K", "S:D614G", "S:A701V"]
-    },
+    "21F (Iota)\n(B.1.526)": {"nonsynonymous": ["S:L5F", "S:T95I", "S:D253G", "S:E484K", "S:D614G", "S:A701V"]},
     "21G (Lambda)\n(C.37)": {
         "nonsynonymous": [
             "S:G75V",
@@ -192,24 +190,23 @@ mutation_comparison = {
             "S:D950N",
         ]
     },
-#    "20A/S:126A\n(B.1.620)": {
-#        "nonsynonymous": [
-#            "S:P26S",
-#            "S:H69-",
-#            "S:V70-",
-#            "S:V126A",
-#            "S:Y144-",
-#            "S:L241-",
-#            "S:L242-",
-#            "S:A243-",
-#            "S:H245Y",
-#            "S:S477N",
-#            "S:E484K",
-#            "S:D614G",
-#            "S:P681H",
-#            "S:T1027I",
-#            "S:D1118H",
-#        ]
-#    },
-
+    #    "20A/S:126A\n(B.1.620)": {
+    #        "nonsynonymous": [
+    #            "S:P26S",
+    #            "S:H69-",
+    #            "S:V70-",
+    #            "S:V126A",
+    #            "S:Y144-",
+    #            "S:L241-",
+    #            "S:L242-",
+    #            "S:A243-",
+    #            "S:H245Y",
+    #            "S:S477N",
+    #            "S:E484K",
+    #            "S:D614G",
+    #            "S:P681H",
+    #            "S:T1027I",
+    #            "S:D1118H",
+    #        ]
+    #    },
 }

--- a/scripts/name_table.py
+++ b/scripts/name_table.py
@@ -5,36 +5,29 @@ name_table = [
     {
         "clade": "20I (Alpha, V1)",
         "who": "Alpha",
-        "lineages": [
-            {"name": "B.1.1.7", "url": None}
-        ],
-        "others": [
-            {"name": "VOC 202012/01", "url": None}
-        ],
+        "lineages": [{"name": "B.1.1.7", "url": None}],
+        "others": [{"name": "VOC 202012/01", "url": None}],
     },
     {
         "clade": "20H (Beta, V2)",
         "who": "Beta",
-        "lineages": [
-            {"name": "B.1.351", "url": None}
-        ],
-        "others": [
-            {"name": "501Y.V2", "url": None}
-        ],
+        "lineages": [{"name": "B.1.351", "url": None}],
+        "others": [{"name": "501Y.V2", "url": None}],
     },
     {
         "clade": "20J (Gamma, V3)",
         "who": "Gamma",
-        "lineages": [
-            {"name": "P.1", "url": None}
-        ],
+        "lineages": [{"name": "P.1", "url": None}],
         "others": [],
     },
     {
         "clade": "21A (Delta)",
         "who": "Delta",
         "lineages": [
-            {"name": "B.1.617.2", "url": "https://cov-lineages.org/lineages/lineage_B.1.617.2.html"}
+            {
+                "name": "B.1.617.2",
+                "url": "https://cov-lineages.org/lineages/lineage_B.1.617.2.html",
+            }
         ],
         "others": [],
     },
@@ -54,60 +47,56 @@ name_table = [
         "clade": "21B (Kappa)",
         "who": "Kappa",
         "lineages": [
-            {"name": "B.1.617.1", "url": "https://cov-lineages.org/lineages/lineage_B.1.617.1.html"}
+            {
+                "name": "B.1.617.1",
+                "url": "https://cov-lineages.org/lineages/lineage_B.1.617.1.html",
+            }
         ],
-        "others": []
+        "others": [],
     },
     {
         "clade": "21C (Epsilon)",
         "who": "Epsilon",
         "lineages": [
             {"name": "B.1.427", "url": None},
-            {"name": "B.1.429", "url": None}
+            {"name": "B.1.429", "url": None},
         ],
-        "others": [
-            {"name": "CAL.20C", "url": None}
-        ],
+        "others": [{"name": "CAL.20C", "url": None}],
     },
     {
         "clade": "21D (Eta)",
         "who": "Eta",
-        "lineages": [
-            {"name": "B.1.525", "url": None}
-        ],
+        "lineages": [{"name": "B.1.525", "url": None}],
         "others": [],
     },
     {
         "clade": "21F (Iota)",
         "who": "Iota",
-        "lineages": [
-            {"name": "B.1.526", "url": None}
-        ],
+        "lineages": [{"name": "B.1.526", "url": None}],
         "others": [
             {"name": "(Part of Pango lineage)", "url": None},
-        ]
+        ],
     },
     {
         "clade": "21G (Lambda)",
         "who": "Lambda",
-        "lineages": [
-            {"name": "C.37", "url": None}
-        ],
+        "lineages": [{"name": "C.37", "url": None}],
         "others": [],
     },
     {
         "clade": "21H (Mu)",
         "who": "Mu",
-        "lineages": [
-            {"name": "B.1.621", "url": None}
-        ],
+        "lineages": [{"name": "B.1.621", "url": None}],
         "others": [],
     },
     {
         "clade": "21K (Omicron)",
         "who": "Omicron",
         "lineages": [
-            {"name": "BA.1", "url": "https://cov-lineages.org/lineages/lineage_BA.1.html"}
+            {
+                "name": "BA.1",
+                "url": "https://cov-lineages.org/lineages/lineage_BA.1.html",
+            }
         ],
         "others": [],
     },
@@ -117,79 +106,61 @@ name_table = [
         "lineages": [
             {"name": "B.1.177", "url": None},
         ],
-        "others": [
-            {"name": "EU1", "url": None}
-        ],
+        "others": [{"name": "EU1", "url": None}],
     },
     {
         "clade": "20B/S:732A",
         "who": "",
-        "lineages": [
-            {"name": "B.1.1.519", "url": None}
-        ],
+        "lineages": [{"name": "B.1.1.519", "url": None}],
         "others": [],
     },
     {
         "clade": "20A/S:126A",
         "who": "",
-        "lineages": [
-            {"name": "B.1.620", "url": None}
-        ],
+        "lineages": [{"name": "B.1.620", "url": None}],
         "others": [],
     },
     {
         "clade": "20A.EU2",
         "who": None,
-        "lineages": [
-            {"name": "B.1.160", "url": None}
-        ],
+        "lineages": [{"name": "B.1.160", "url": None}],
         "others": [],
     },
     {
         "clade": "20A/S:439K",
         "who": None,
-        "lineages": [
-            {"name": "B.1.258", "url": None}
-        ],
+        "lineages": [{"name": "B.1.258", "url": None}],
         "others": [],
     },
     {
         "clade": "20A/S:98F",
         "who": None,
-        "lineages": [
-            {"name": "B.1.221", "url": None}
-        ],
+        "lineages": [{"name": "B.1.221", "url": None}],
         "others": [],
     },
     {
         "clade": "20C/S:80Y",
         "who": None,
-        "lineages": [
-            {"name": "B.1.367", "url": None}
-        ],
+        "lineages": [{"name": "B.1.367", "url": None}],
         "others": [],
     },
     {
         "clade": "20B/S:626S",
         "who": None,
-        "lineages": [
-            {"name": "B.1.1.277", "url": None}
-        ],
+        "lineages": [{"name": "B.1.1.277", "url": None}],
         "others": [],
     },
     {
         "clade": "20B/S:1122L",
         "who": None,
-        "lineages": [
-            {"name": "B.1.1.302", "url": None}
-        ],
+        "lineages": [{"name": "B.1.1.302", "url": None}],
         "others": [],
-    }
+    },
 ]
 
 
 def does_url_respond(url: str):
-    req = urllib.request.Request(url, headers={'content-type': 'text/html'})
+    req = urllib.request.Request(url, headers={"content-type": "text/html"})
 
     try:
         urllib.request.urlopen(req)

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,10 @@
+pandas
+numpy
+matplotlib
+seaborn
+nextstrain-augur
+biopython
+phylo-treetime
+flake8
+black
+mypy

--- a/scripts/swiss_regions.py
+++ b/scripts/swiss_regions.py
@@ -1,5 +1,5 @@
 swiss_regions = {
-    'Geneva': "Region 1",
+    "Geneva": "Region 1",
     "Neuchâtel": "Region 1",
     "Vaud": "Region 1",
     "Valais": "Region 1",
@@ -25,7 +25,7 @@ swiss_regions = {
     "Zürich": "Region 5",
     "Graubünden": "Region 6",
     "Ticino": "Region 6",
-    "Switzerland": ""
+    "Switzerland": "",
 }
 
 


### PR DESCRIPTION
Resolves #245.

The goal of this PR is to provide the necessary basis to facilitate contribution from different people to the python code in the future while at the same time keeping disruption to the existing workflow and changes to a minimum.

Features of this PR:
- Adds a `requirements.txt` to the `scripts` folder to keep track of dependencies
- Provides a `Makefile` to easily install the necessary dependencies and setup linting and formatting
- Uses flake8 and black for linting and formatting inside the `scripts`
- Adds most of the current linting problems to the `.flake8` ignore list with a description of the problem. This prevents yellow and red flags from popping up all over the code in the IDE but allows for progressive removal of the flags and enhancement of the code style if desired.
- Reformats the Python files using this setup
- Includes the VS Code settings to enable linting and formatting

I've tried to do justice to most of the points raised by @ivan-aksamentov in his [comment](https://github.com/hodcroftlab/covariants/issues/245#issuecomment-998104731) on #245 and tried to keep this as light and unobtrusive as possible but I'm aware that this is an opinionated solution that may require changes.

Debatable point may include:
- Should the VS Code settings be included in `/scripts/.vscode/settings.json` since this is an IDE-specific feature?
- Use of virtual environments for the setup
- Use of second `Makefile` for setup: The reason behind this is to make linting and formatting completely optional and only part of the `scripts` folder. However other solutions might be providing a bash script for setup or integrating the `make` endpoint into the project's main `Makefile`.
- Some imports from the code are not in the `scripts` folder, their paths could be added to `python.analysis.extraPaths` in the VS Code `settings.json`.
- The `requirements.txt` file currently only contains the package names but not their versions, perhaps the output of `pip freeze` could be added here to add exact versioning. 

Due to missing data it is also not possible for me to test all of the functions. Since only the formatting has been changed their functionality should not be affected but it would probably be good to test and confirm this anyway.

Happy to hear your feedback and to either move forward with this draft or reconsider the approach or certain aspects.