### PR TITLE
Add "lesser than cutoff" value to plot tooltip

### DIFF
--- a/web/src/components/ClusterDistribution/ClusterDistributionPlotTooltip.tsx
+++ b/web/src/components/ClusterDistribution/ClusterDistributionPlotTooltip.tsx
@@ -115,7 +115,11 @@ export function ClusterDistributionPlotTooltip(props: ClusterDistributionPlotToo
                 </td>
                 <td>{interpolated && '*'}</td>
                 <td className="px-2 text-right">
-                  {value !== undefined && value > EPSILON ? formatProportion(value) : '-'}
+                  {value !== undefined && value > EPSILON
+                    ? formatProportion(value)
+                    : value !== undefined && value !== 0
+                    ? `<${EPSILON}`
+                    : '-'}
                 </td>
               </tr>
             )


### PR DESCRIPTION
Currently, when I'm looking at the `/per-variant` page and a graph has a value (i.e.: a line of the graph just barely visible but not nothing), but below the cutoff value defined in `ClusterDistributionPlotTooltip.tsx` (const `EPSILON`), the tooltip will display "`-`" as value.

To me, this doesn't make much sense, as I would think "`-`" means "no data" or "nothing". But I can clearly see a tiny little bit of graph. Not nothing.

Therefore, I suggest changing the tooltip code to display "`<0.01`" (dynamically based on `EPSILON`) if a value is present, but below the cutoff value.

Note that ESLint will raise an "unicorn/no-nested-ternary: Do not nest ternary expressions." warning.. But I don't have any experience with TypeScript to be honest and a lot of pages on the world wide web say just to disable the `no-nested-ternary` rule :roll_eyes: 