### PR TITLE
use router query string to preselect region and variants

### DIFF
--- a/web/src/components/CountryDistribution/CountryDistributionPage.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPage.tsx
@@ -1,4 +1,6 @@
 import { mapValues } from 'lodash'
+import { stringify } from 'querystring'
+import { useRouter } from 'next/router'
 import React, { useCallback, useMemo } from 'react'
 import { Col, Row } from 'reactstrap'
 
@@ -23,6 +25,7 @@ import {
 
 import { CountryDistributionPlotCard } from './CountryDistributionPlotCard'
 import { useCountryAndClusterQuery } from './useCountryQuery'
+import { getCurrentQs } from './utils'
 import { CountryFlag } from '../Common/CountryFlag'
 import { USStateCode } from '../Common/USStateCode'
 import { PageHeading } from '../Common/PageHeading'
@@ -31,8 +34,9 @@ const enabledFilters = ['clusters', 'countriesWithIcons']
 const { regionNames, regionsHaveData } = getRegions()
 
 export function CountryDistributionPage() {
+  const router = useRouter()
   const {
-    state: { region, setRegion, setPlaces, places, countryDistributions, currentClusters, setClusters },
+    state: { region, setPlaces, places, countryDistributions, currentClusters, setClusters },
   } = useCountryAndClusterQuery()
 
   const regionsTitle = useMemo(() => (region === Region.WORLD ? 'Countries' : 'Regions'), [region])
@@ -107,6 +111,27 @@ export function CountryDistributionPage() {
     const contentFilename = getPerCountryIntroContentFilename(region)
     return getRegionPerCountryContent(contentFilename)
   }, [region])
+
+  const setRegion = useCallback(
+    (nextRegion: Region) => {
+      if (region === nextRegion) {
+        return
+      }
+      const fullPath = `${router.basePath}${router.pathname}`
+      const nextRegionQs = { ...getCurrentQs(router) }
+
+      if (nextRegion === Region.WORLD) {
+        delete nextRegionQs.countries
+      } else if (nextRegion === Region.UNITED_STATES) {
+        nextRegionQs.countries = 'usa'
+      } else if (nextRegion === Region.SWITZERLAND) {
+        nextRegionQs.countries = 'switzerland'
+      }
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      router.replace(`${fullPath}?${stringify(nextRegionQs)}`)
+    },
+    [region, router],
+  )
 
   return (
     <Layout wide>

--- a/web/src/components/CountryDistribution/CountryDistributionPage.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPage.tsx
@@ -121,11 +121,11 @@ export function CountryDistributionPage() {
       const nextRegionQs = { ...getCurrentQs(router) }
 
       if (nextRegion === Region.WORLD) {
-        delete nextRegionQs.countries
+        delete nextRegionQs.region
       } else if (nextRegion === Region.UNITED_STATES) {
-        nextRegionQs.countries = 'usa'
+        nextRegionQs.region = 'usa'
       } else if (nextRegion === Region.SWITZERLAND) {
-        nextRegionQs.countries = 'switzerland'
+        nextRegionQs.region = 'switzerland'
       }
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       router.replace(`${fullPath}?${stringify(nextRegionQs)}`)

--- a/web/src/components/CountryDistribution/CountryDistributionPage.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPage.tsx
@@ -24,8 +24,8 @@ import {
 } from 'src/io/getPerCountryData'
 
 import { CountryDistributionPlotCard } from './CountryDistributionPlotCard'
-import { useCountryAndClusterQuery } from './useCountryQuery'
-import { getCurrentQs } from './utils'
+import { useRouterQuery } from './useCountryQuery'
+import { getCurrentQs, RegionQueryString } from './utils'
 import { CountryFlag } from '../Common/CountryFlag'
 import { USStateCode } from '../Common/USStateCode'
 import { PageHeading } from '../Common/PageHeading'
@@ -37,12 +37,12 @@ export function CountryDistributionPage() {
   const router = useRouter()
   const {
     state: { region, setPlaces, places, countryDistributions, currentClusters, setClusters },
-  } = useCountryAndClusterQuery()
+  } = useRouterQuery()
 
-  const regionsTitle = useMemo(() => (region === Region.WORLD ? 'Countries' : 'Regions'), [region])
+  const regionsTitle = useMemo(() => (region === Region.World ? 'Countries' : 'Regions'), [region])
   const iconComponent = useMemo(() => {
-    if (region === Region.WORLD) return CountryFlag
-    if (region === Region.UNITED_STATES) return USStateCode
+    if (region === Region.World) return CountryFlag
+    if (region === Region.UnitedStates) return USStateCode
     return undefined
   }, [region])
 
@@ -120,12 +120,12 @@ export function CountryDistributionPage() {
       const fullPath = `${router.basePath}${router.pathname}`
       const nextRegionQs = { ...getCurrentQs(router) }
 
-      if (nextRegion === Region.WORLD) {
+      if (nextRegion === Region.World) {
         delete nextRegionQs.region
-      } else if (nextRegion === Region.UNITED_STATES) {
-        nextRegionQs.region = 'usa'
-      } else if (nextRegion === Region.SWITZERLAND) {
-        nextRegionQs.region = 'switzerland'
+      } else if (nextRegion === Region.UnitedStates) {
+        nextRegionQs.region = RegionQueryString.UnitedStates
+      } else if (nextRegion === Region.Switzerland) {
+        nextRegionQs.region = RegionQueryString.Switzerland
       }
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       router.replace(`${fullPath}?${stringify(nextRegionQs)}`)

--- a/web/src/components/CountryDistribution/CountryDistributionPage.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPage.tsx
@@ -101,7 +101,15 @@ export function CountryDistributionPage() {
 
   useEffect(() => {
     setPlaces(initialPlaces)
-  }, [initialPlaces])
+  }, [initialPlaces, setPlaces])
+
+  useEffect(() => {
+    setCurrentRegion(initialRegion)
+  }, [initialRegion, setCurrentRegion])
+
+  useEffect(() => {
+    setClusters(initialClustersState)
+  }, [initialClustersState, setClusters])
 
   const regionsTitle = useMemo(() => (currentRegion === Region.WORLD ? 'Countries' : 'Regions'), [currentRegion])
   const iconComponent = useMemo(() => {
@@ -137,15 +145,13 @@ export function CountryDistributionPage() {
     setClusters((oldClusters) => toggleCluster(oldClusters, clusterName))
   }, [])
 
-  const handleClusterSelectAll = useCallback(
-    () => setClusters((oldClusters) => mapValues(oldClusters, (cluster) => ({ ...cluster, enabled: true }))),
-    [],
-  )
+  const handleClusterSelectAll = useCallback(() => {
+    setClusters((oldClusters) => mapValues(oldClusters, (cluster) => ({ ...cluster, enabled: true })))
+  }, [])
 
-  const handleClusterDeselectAll = useCallback(
-    () => setClusters((oldClusters) => mapValues(oldClusters, (cluster) => ({ ...cluster, enabled: false }))),
-    [],
-  )
+  const handleClusterDeselectAll = useCallback(() => {
+    setClusters((oldClusters) => mapValues(oldClusters, (cluster) => ({ ...cluster, enabled: false })))
+  }, [])
 
   const handleCountryCheckedChange = useCallback(
     (countryName: string) => {

--- a/web/src/components/CountryDistribution/RegionSwitcher.tsx
+++ b/web/src/components/CountryDistribution/RegionSwitcher.tsx
@@ -4,6 +4,8 @@ import { Button, Col, Row } from 'reactstrap'
 import { safeZip } from 'src/helpers/safeZip'
 import styled from 'styled-components'
 
+import { Region } from 'src/io/getPerCountryData'
+
 export const RegionSwitcherContainer = styled.div`
   margin: 5px 5px;
   padding: 0.65rem 1rem;
@@ -33,14 +35,14 @@ export const RegionButton = styled(Button)`
 `
 
 export interface RegionSwitcherProps {
-  regions: string[]
+  regions: Region[]
   regionsHaveData: boolean[]
   currentRegion: string
-  setCurrentRegion(region: string): void
+  setCurrentRegion(region: Region): void
 }
 
 export function RegionSwitcher({ regions, regionsHaveData, currentRegion, setCurrentRegion }: RegionSwitcherProps) {
-  const onRegionButtonClick = useCallback((region: string) => () => setCurrentRegion(region), [setCurrentRegion])
+  const onRegionButtonClick = useCallback((region: Region) => () => setCurrentRegion(region), [setCurrentRegion])
   const getRegionButtonColor = (region: string) => (currentRegion === region ? 'success' : undefined)
 
   return (

--- a/web/src/components/CountryDistribution/useCountryQuery.tsx
+++ b/web/src/components/CountryDistribution/useCountryQuery.tsx
@@ -3,9 +3,8 @@ import { useRouter } from 'next/router'
 import { Region, ClusterState, getPerCountryData, CountryDistribution } from 'src/io/getPerCountryData'
 import { Places } from 'src/io/getPlaces'
 
-import { getRegionBySelectedCountries, getCurriedClustersBySelectedClusters } from './utils'
+import { getRegionBySelectedRegionQs, getCurriedClustersStateBySelectedClusters, ParsedUrlQuery } from './utils'
 
-export type ParsedUrlQuery = string | string[] | undefined
 
 export const convertUrlQueryToSelection = (queryString: ParsedUrlQuery): string[] => {
   if (!queryString) {
@@ -20,7 +19,7 @@ export const convertUrlQueryToSelection = (queryString: ParsedUrlQuery): string[
   return []
 }
 
-export const useCountryAndClusterQuery = (): {
+export const useRouterQuery = (): {
   rawQueries: {
     selectedRegion: ParsedUrlQuery
     selectedClusters: ParsedUrlQuery
@@ -38,7 +37,7 @@ export const useCountryAndClusterQuery = (): {
 
   const { region: selectedRegion, variants: selectedClusters } = router.query
 
-  const [currentRegion, setCurrentRegion] = useState(getRegionBySelectedCountries(selectedRegion))
+  const [currentRegion, setCurrentRegion] = useState<Region>(getRegionBySelectedRegionQs(selectedRegion))
 
   const {
     allPossibleClusters,
@@ -47,7 +46,7 @@ export const useCountryAndClusterQuery = (): {
     countryDistributions,
   } = useMemo(() => {
     const { clusters: allPossibleClusters, places, countryDistributions } = getPerCountryData(currentRegion)
-    const getClustersBySelectedClusters = getCurriedClustersBySelectedClusters(allPossibleClusters)
+    const getClustersBySelectedClusters = getCurriedClustersStateBySelectedClusters(allPossibleClusters)
     return {
       places,
       allPossibleClusters,
@@ -72,7 +71,7 @@ export const useCountryAndClusterQuery = (): {
   }, [selectedClusters, setClusters, getClustersBySelectedClusters])
 
   useEffect(() => {
-    setCurrentRegion(getRegionBySelectedCountries(selectedRegion))
+    setCurrentRegion(getRegionBySelectedRegionQs(selectedRegion))
   }, [selectedRegion, setCurrentRegion])
 
   return {

--- a/web/src/components/CountryDistribution/useCountryQuery.tsx
+++ b/web/src/components/CountryDistribution/useCountryQuery.tsx
@@ -4,7 +4,7 @@ import { stringify } from 'querystring'
 import { Region, ClusterState, getPerCountryData, CountryDistribution } from 'src/io/getPerCountryData'
 import { Places } from 'src/io/getPlaces'
 
-import { getRegionBySelectedCountries, getCurriedClustersBySelectedClusters } from './utils'
+import { getRegionBySelectedCountries, getCurriedClustersBySelectedClusters, getCurrentQs } from './utils'
 
 export type ParsedUrlQuery = string | string[] | undefined
 
@@ -65,17 +65,15 @@ export const useCountryAndClusterQuery = (): {
     if (currentRegion === nextRegion) {
       return
     }
-
     const fullPath = `${router.basePath}${router.pathname}`
-
-    let nextRegionQs = {}
+    const nextRegionQs = { ...getCurrentQs(router) }
 
     if (nextRegion === Region.WORLD) {
-      nextRegionQs = {}
+      delete nextRegionQs.countries
     } else if (nextRegion === Region.UNITED_STATES) {
-      nextRegionQs = { countries: 'usa' }
+      nextRegionQs.countries = 'usa'
     } else if (nextRegion === Region.SWITZERLAND) {
-      nextRegionQs = { countries: 'switzerland' }
+      nextRegionQs.countries = 'switzerland'
     }
     return void router.replace(`${fullPath}?${stringify(nextRegionQs)}`)
   }

--- a/web/src/components/CountryDistribution/useCountryQuery.tsx
+++ b/web/src/components/CountryDistribution/useCountryQuery.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react'
 import { useRouter } from 'next/router'
+import { stringify } from 'querystring'
 import { Region, ClusterState, getPerCountryData, CountryDistribution } from 'src/io/getPerCountryData'
 import { Places } from 'src/io/getPlaces'
 
@@ -27,7 +28,7 @@ export const useCountryAndClusterQuery = (): {
   }
   state: {
     region: Region
-    setRegion: React.Dispatch<React.SetStateAction<Region>>
+    setRegion: (region: Region) => void
     places: Places
     setPlaces: React.Dispatch<React.SetStateAction<Places>>
     countryDistributions: CountryDistribution[]
@@ -60,6 +61,25 @@ export const useCountryAndClusterQuery = (): {
   const [places, setPlaces] = useState<Places>(initialPlaces)
   const [currentClusters, setClusters] = useState<ClusterState>(getClustersBySelectedClusters(selectedClusters))
 
+  const setCurrentRegionAsQs = (nextRegion: Region): void => {
+    if (currentRegion === nextRegion) {
+      return
+    }
+
+    const fullPath = `${router.basePath}${router.pathname}`
+
+    let nextRegionQs = {}
+
+    if (nextRegion === Region.WORLD) {
+      nextRegionQs = {}
+    } else if (nextRegion === Region.UNITED_STATES) {
+      nextRegionQs = { countries: 'usa' }
+    } else if (nextRegion === Region.SWITZERLAND) {
+      nextRegionQs = { countries: 'switzerland' }
+    }
+    return void router.replace(`${fullPath}?${stringify(nextRegionQs)}`)
+  }
+
   useEffect(() => {
     setPlaces(initialPlaces)
   }, [initialPlaces, setPlaces])
@@ -83,7 +103,7 @@ export const useCountryAndClusterQuery = (): {
     },
     state: {
       region: currentRegion,
-      setRegion: setCurrentRegion,
+      setRegion: setCurrentRegionAsQs,
       places,
       setPlaces,
       countryDistributions,

--- a/web/src/components/CountryDistribution/useCountryQuery.tsx
+++ b/web/src/components/CountryDistribution/useCountryQuery.tsx
@@ -19,6 +19,10 @@ export const convertUrlQueryToSelection = (queryString: ParsedUrlQuery): string[
   return []
 }
 
+/**
+ * A react hook that take in router query params as source of truth
+ * and compute the React component states for UI display
+ */
 export const useRouterQuery = (): {
   rawQueries: {
     selectedRegion: ParsedUrlQuery

--- a/web/src/components/CountryDistribution/useCountryQuery.tsx
+++ b/web/src/components/CountryDistribution/useCountryQuery.tsx
@@ -5,7 +5,6 @@ import { Places } from 'src/io/getPlaces'
 
 import { getRegionBySelectedRegionQs, getCurriedClustersStateBySelectedClusters, ParsedUrlQuery } from './utils'
 
-
 export const convertUrlQueryToSelection = (queryString: ParsedUrlQuery): string[] => {
   if (!queryString) {
     return []

--- a/web/src/components/CountryDistribution/useCountryQuery.tsx
+++ b/web/src/components/CountryDistribution/useCountryQuery.tsx
@@ -22,7 +22,7 @@ export const convertUrlQueryToSelection = (queryString: ParsedUrlQuery): string[
 
 export const useCountryAndClusterQuery = (): {
   rawQueries: {
-    selectedCountries: ParsedUrlQuery
+    selectedRegion: ParsedUrlQuery
     selectedClusters: ParsedUrlQuery
   }
   state: {
@@ -36,9 +36,9 @@ export const useCountryAndClusterQuery = (): {
 } => {
   const router = useRouter()
 
-  const { countries: selectedCountries, variants: selectedClusters } = router.query
+  const { region: selectedRegion, variants: selectedClusters } = router.query
 
-  const [currentRegion, setCurrentRegion] = useState(getRegionBySelectedCountries(selectedCountries))
+  const [currentRegion, setCurrentRegion] = useState(getRegionBySelectedCountries(selectedRegion))
 
   const {
     allPossibleClusters,
@@ -72,12 +72,12 @@ export const useCountryAndClusterQuery = (): {
   }, [selectedClusters, setClusters, getClustersBySelectedClusters])
 
   useEffect(() => {
-    setCurrentRegion(getRegionBySelectedCountries(selectedCountries))
-  }, [selectedCountries, setCurrentRegion])
+    setCurrentRegion(getRegionBySelectedCountries(selectedRegion))
+  }, [selectedRegion, setCurrentRegion])
 
   return {
     rawQueries: {
-      selectedCountries,
+      selectedRegion,
       selectedClusters,
     },
     state: {

--- a/web/src/components/CountryDistribution/useCountryQuery.tsx
+++ b/web/src/components/CountryDistribution/useCountryQuery.tsx
@@ -1,10 +1,9 @@
 import React, { useState, useEffect, useMemo } from 'react'
 import { useRouter } from 'next/router'
-import { stringify } from 'querystring'
 import { Region, ClusterState, getPerCountryData, CountryDistribution } from 'src/io/getPerCountryData'
 import { Places } from 'src/io/getPlaces'
 
-import { getRegionBySelectedCountries, getCurriedClustersBySelectedClusters, getCurrentQs } from './utils'
+import { getRegionBySelectedCountries, getCurriedClustersBySelectedClusters } from './utils'
 
 export type ParsedUrlQuery = string | string[] | undefined
 
@@ -28,7 +27,6 @@ export const useCountryAndClusterQuery = (): {
   }
   state: {
     region: Region
-    setRegion: (region: Region) => void
     places: Places
     setPlaces: React.Dispatch<React.SetStateAction<Places>>
     countryDistributions: CountryDistribution[]
@@ -61,23 +59,6 @@ export const useCountryAndClusterQuery = (): {
   const [places, setPlaces] = useState<Places>(initialPlaces)
   const [currentClusters, setClusters] = useState<ClusterState>(getClustersBySelectedClusters(selectedClusters))
 
-  const setCurrentRegionAsQs = (nextRegion: Region): void => {
-    if (currentRegion === nextRegion) {
-      return
-    }
-    const fullPath = `${router.basePath}${router.pathname}`
-    const nextRegionQs = { ...getCurrentQs(router) }
-
-    if (nextRegion === Region.WORLD) {
-      delete nextRegionQs.countries
-    } else if (nextRegion === Region.UNITED_STATES) {
-      nextRegionQs.countries = 'usa'
-    } else if (nextRegion === Region.SWITZERLAND) {
-      nextRegionQs.countries = 'switzerland'
-    }
-    return void router.replace(`${fullPath}?${stringify(nextRegionQs)}`)
-  }
-
   useEffect(() => {
     setPlaces(initialPlaces)
   }, [initialPlaces, setPlaces])
@@ -101,7 +82,6 @@ export const useCountryAndClusterQuery = (): {
     },
     state: {
       region: currentRegion,
-      setRegion: setCurrentRegionAsQs,
       places,
       setPlaces,
       countryDistributions,

--- a/web/src/components/CountryDistribution/useCountryQuery.tsx
+++ b/web/src/components/CountryDistribution/useCountryQuery.tsx
@@ -1,0 +1,94 @@
+import React, { useState, useEffect, useMemo } from 'react'
+import { useRouter } from 'next/router'
+import { Region, ClusterState, getPerCountryData, CountryDistribution } from 'src/io/getPerCountryData'
+import { Places } from 'src/io/getPlaces'
+
+import { getRegionBySelectedCountries, getCurriedClustersBySelectedClusters } from './utils'
+
+export type ParsedUrlQuery = string | string[] | undefined
+
+export const convertUrlQueryToSelection = (queryString: ParsedUrlQuery): string[] => {
+  if (!queryString) {
+    return []
+  }
+  if (typeof queryString === 'string') {
+    return [queryString]
+  }
+  if (Array.isArray(queryString)) {
+    return queryString
+  }
+  return []
+}
+
+export const useCountryAndClusterQuery = (): {
+  rawQueries: {
+    selectedCountries: ParsedUrlQuery
+    selectedClusters: ParsedUrlQuery
+  }
+  state: {
+    region: Region
+    setRegion: React.Dispatch<React.SetStateAction<Region>>
+    places: Places
+    setPlaces: React.Dispatch<React.SetStateAction<Places>>
+    countryDistributions: CountryDistribution[]
+    currentClusters: ClusterState
+    setClusters: React.Dispatch<React.SetStateAction<ClusterState>>
+  }
+} => {
+  const router = useRouter()
+
+  const { countries: selectedCountries, variants: selectedClusters } = router.query
+
+  const [currentRegion, setCurrentRegion] = useState(getRegionBySelectedCountries(selectedCountries))
+
+  const {
+    allPossibleClusters,
+    getClustersBySelectedClusters,
+    places: initialPlaces,
+    countryDistributions,
+  } = useMemo(() => {
+    const { clusters: allPossibleClusters, places, countryDistributions } = getPerCountryData(currentRegion)
+    const getClustersBySelectedClusters = getCurriedClustersBySelectedClusters(allPossibleClusters)
+    return {
+      places,
+      allPossibleClusters,
+      countryDistributions,
+      getClustersBySelectedClusters,
+    }
+  }, [currentRegion])
+
+  const [places, setPlaces] = useState<Places>(initialPlaces)
+  const [currentClusters, setClusters] = useState<ClusterState>(getClustersBySelectedClusters(selectedClusters))
+
+  useEffect(() => {
+    setPlaces(initialPlaces)
+  }, [initialPlaces, setPlaces])
+
+  useEffect(() => {
+    setClusters(getClustersBySelectedClusters(selectedClusters))
+  }, [selectedClusters, getClustersBySelectedClusters, allPossibleClusters])
+
+  useEffect(() => {
+    setClusters(getClustersBySelectedClusters(selectedClusters))
+  }, [selectedClusters, setClusters, getClustersBySelectedClusters])
+
+  useEffect(() => {
+    setCurrentRegion(getRegionBySelectedCountries(selectedCountries))
+  }, [selectedCountries, setCurrentRegion])
+
+  return {
+    rawQueries: {
+      selectedCountries,
+      selectedClusters,
+    },
+    state: {
+      region: currentRegion,
+      setRegion: setCurrentRegion,
+      places,
+      setPlaces,
+      countryDistributions,
+      currentClusters,
+      setClusters,
+    },
+  }
+}

--- a/web/src/components/CountryDistribution/utils.ts
+++ b/web/src/components/CountryDistribution/utils.ts
@@ -55,9 +55,9 @@ export const getCurriedClustersBySelectedClusters = (fallbackClusters: ClusterSt
 }
 
 export const getCurrentQs = (router: NextRouter) => {
-  const result: Partial<Record<'countries' | 'variants', string[] | string>> = {}
-  if (router.query && router.query.countries) {
-    result.countries = router.query.countries
+  const result: Partial<Record<'region' | 'variants', string[] | string>> = {}
+  if (router.query && router.query.region) {
+    result.region = router.query.region
   }
   if (router.query && router.query.variants) {
     result.variants = router.query.variants

--- a/web/src/components/CountryDistribution/utils.ts
+++ b/web/src/components/CountryDistribution/utils.ts
@@ -1,3 +1,5 @@
+import { NextRouter } from 'next/router'
+
 import { Region, ClusterState } from 'src/io/getPerCountryData'
 
 export const getRegionBySelectedCountries = (countries: string | string[] | undefined): Region => {
@@ -50,4 +52,15 @@ export const getCurriedClustersBySelectedClusters = (fallbackClusters: ClusterSt
       return { ...acc, [key]: { enabled: selectedClusters.has(key) } }
     }, {})
   }
+}
+
+export const getCurrentQs = (router: NextRouter) => {
+  const result: Partial<Record<'countries' | 'variants', string[] | string>> = {}
+  if (router.query && router.query.countries) {
+    result.countries = router.query.countries
+  }
+  if (router.query && router.query.variants) {
+    result.variants = router.query.variants
+  }
+  return result
 }

--- a/web/src/components/CountryDistribution/utils.ts
+++ b/web/src/components/CountryDistribution/utils.ts
@@ -55,12 +55,7 @@ export const getCurriedClustersStateBySelectedClusters = (fallbackClusters: Clus
       }
       return noClusterSelectedState
     }
-    let selectedClusters = new Set<string>()
-    if (typeof clusters === 'string') {
-      selectedClusters.add(clusters)
-    } else if (Array.isArray(clusters)) {
-      selectedClusters = new Set(clusters)
-    }
+    const selectedClusters = new Set<string>(Array.isArray(clusters) ? clusters : [clusters])
     return clusterKeys.reduce((acc, key) => {
       return { ...acc, [key]: { enabled: selectedClusters.has(key) } }
     }, {})

--- a/web/src/components/CountryDistribution/utils.ts
+++ b/web/src/components/CountryDistribution/utils.ts
@@ -1,0 +1,53 @@
+import { Region, ClusterState } from 'src/io/getPerCountryData'
+
+export const getRegionBySelectedCountries = (countries: string | string[] | undefined): Region => {
+  if (Array.isArray(countries)) {
+    if (
+      countries.length === 1 &&
+      [Region.UNITED_STATES.toLowerCase(), 'usa', 'us'].includes(countries[0].toLowerCase())
+    ) {
+      return Region.UNITED_STATES
+    }
+    if (countries.length === 1 && countries[0].toLowerCase() === Region.SWITZERLAND.toLowerCase()) {
+      return Region.SWITZERLAND
+    }
+    return Region.WORLD
+  }
+  if (countries) {
+    switch (countries.toLowerCase()) {
+      case Region.UNITED_STATES.toLowerCase():
+      case 'usa':
+      case 'us':
+        return Region.UNITED_STATES
+      case Region.SWITZERLAND.toLowerCase():
+        return Region.SWITZERLAND
+      default:
+        return Region.WORLD
+    }
+  }
+  return Region.WORLD
+}
+
+export const getCurriedClustersBySelectedClusters = (fallbackClusters: ClusterState) => {
+  const clusterKeys = Object.keys(fallbackClusters)
+  const noClusterSelectedState = clusterKeys.reduce((acc, key) => {
+    return { ...acc, [key]: { enabled: false } }
+  }, {})
+  return (clusters: string | string[] | undefined, deselectAll = false): ClusterState => {
+    if (!clusters) {
+      if (!deselectAll) {
+        return fallbackClusters
+      }
+      return noClusterSelectedState
+    }
+    let selectedClusters = new Set<string>()
+    if (typeof clusters === 'string') {
+      selectedClusters.add(clusters)
+    } else if (Array.isArray(clusters)) {
+      selectedClusters = new Set(clusters)
+    }
+    return clusterKeys.reduce((acc, key) => {
+      return { ...acc, [key]: { enabled: selectedClusters.has(key) } }
+    }, {})
+  }
+}

--- a/web/src/components/CountryDistribution/utils.ts
+++ b/web/src/components/CountryDistribution/utils.ts
@@ -2,35 +2,48 @@ import { NextRouter } from 'next/router'
 
 import { Region, ClusterState } from 'src/io/getPerCountryData'
 
-export const getRegionBySelectedCountries = (countries: string | string[] | undefined): Region => {
-  if (Array.isArray(countries)) {
-    if (
-      countries.length === 1 &&
-      [Region.UNITED_STATES.toLowerCase(), 'usa', 'us'].includes(countries[0].toLowerCase())
-    ) {
-      return Region.UNITED_STATES
-    }
-    if (countries.length === 1 && countries[0].toLowerCase() === Region.SWITZERLAND.toLowerCase()) {
-      return Region.SWITZERLAND
-    }
-    return Region.WORLD
-  }
-  if (countries) {
-    switch (countries.toLowerCase()) {
-      case Region.UNITED_STATES.toLowerCase():
-      case 'usa':
-      case 'us':
-        return Region.UNITED_STATES
-      case Region.SWITZERLAND.toLowerCase():
-        return Region.SWITZERLAND
-      default:
-        return Region.WORLD
-    }
-  }
-  return Region.WORLD
+export type ParsedUrlQuery = string | string[] | undefined
+
+/**
+ * An enum of possible `region`, as expressed as query strings
+ */
+export enum RegionQueryString {
+  World = 'world',
+  UnitedStates = 'usa',
+  Switzerland = 'switzerland',
 }
 
-export const getCurriedClustersBySelectedClusters = (fallbackClusters: ClusterState) => {
+/**
+ * map the extracted router query string to the currently selected region
+ */
+export const getRegionBySelectedRegionQs = (regionQs: ParsedUrlQuery): Region => {
+  if (Array.isArray(regionQs)) {
+    if (regionQs.length === 1 && regionQs[0].toLowerCase() === RegionQueryString.UnitedStates) {
+      return Region.UnitedStates
+    }
+    if (regionQs.length === 1 && regionQs[0].toLowerCase() === RegionQueryString.Switzerland) {
+      return Region.Switzerland
+    }
+    return Region.World
+  }
+  if (regionQs) {
+    switch (regionQs.toLowerCase()) {
+      case RegionQueryString.UnitedStates.toLowerCase():
+        return Region.UnitedStates
+      case RegionQueryString.Switzerland.toLowerCase():
+        return Region.Switzerland
+      default:
+        return Region.World
+    }
+  }
+  return Region.World
+}
+
+/**
+ * A curried function that take in a fallback cluster state, return a callback function that
+ * take in the selected clusters, and return the `ClusterState`
+ */
+export const getCurriedClustersStateBySelectedClusters = (fallbackClusters: ClusterState) => {
   const clusterKeys = Object.keys(fallbackClusters)
   const noClusterSelectedState = clusterKeys.reduce((acc, key) => {
     return { ...acc, [key]: { enabled: false } }
@@ -54,7 +67,10 @@ export const getCurriedClustersBySelectedClusters = (fallbackClusters: ClusterSt
   }
 }
 
-export const getCurrentQs = (router: NextRouter) => {
+/**
+ * parse the current query string from Next Router and give the selected region/variants
+ */
+export const getCurrentQs = (router: NextRouter): Partial<Record<'region' | 'variants', string[] | string>> => {
   const result: Partial<Record<'region' | 'variants', string[] | string>> = {}
   if (router.query && router.query.region) {
     result.region = router.query.region

--- a/web/src/io/getPerCountryData.ts
+++ b/web/src/io/getPerCountryData.ts
@@ -14,7 +14,6 @@ export enum Region {
   Switzerland = 'Switzerland',
 }
 
-
 export interface PerCountryDatum {
   cluster_names: string[]
   distributions: CountryDistribution[]

--- a/web/src/io/getPerCountryData.ts
+++ b/web/src/io/getPerCountryData.ts
@@ -5,11 +5,15 @@ import { pickBy } from 'lodash'
 import { getEnabledCountriesNames, getPlaces, Places } from 'src/io/getPlaces'
 import perCountryDataJson from 'src/../data/perCountryData.json'
 
+/**
+ * An enum of possible `region`, used primarily for internal React state. Also same key of the raw data
+ */
 export enum Region {
-  WORLD = 'World',
-  UNITED_STATES = 'United States',
-  SWITZERLAND = 'Switzerland',
+  World = 'World',
+  UnitedStates = 'United States',
+  Switzerland = 'Switzerland',
 }
+
 
 export interface PerCountryDatum {
   cluster_names: string[]

--- a/web/src/io/getPerCountryData.ts
+++ b/web/src/io/getPerCountryData.ts
@@ -5,12 +5,18 @@ import { pickBy } from 'lodash'
 import { getEnabledCountriesNames, getPlaces, Places } from 'src/io/getPlaces'
 import perCountryDataJson from 'src/../data/perCountryData.json'
 
+export enum Region {
+  WORLD = 'World',
+  UNITED_STATES = 'United States',
+  SWITZERLAND = 'Switzerland',
+}
+
 export interface PerCountryDatum {
   cluster_names: string[]
   distributions: CountryDistribution[]
   max_date: string
   min_date: string
-  region: string
+  region: Region
   per_country_intro_content: string
 }
 


### PR DESCRIPTION
this is related to https://github.com/hodcroftlab/covariants/issues/30

## What
In this PR, I add logic to do the following
0. refactor so the `region` React state is now using an enum instead of string
1. look for the `region` query param to compute initial React state for the region
2. when the user switch region, it automatically update the query param
3. look for the `variants` query param to compute initial React state for the `ClusterState` (please note that user selecting/deselecting a variant will not update the query param)

## Motivation
This PR is very much a beginning PR to tackle https://github.com/hodcroftlab/covariants/issues/30
Due the complexity of the React states (regions, clusters) and the complexity of the world data (continents vs countries/places) I decided this PR is a good stopping point for me to show a demo of what I have.

But generally, the idea is to use the query params as the `source of truth` and any update on the UI checkboxes should be update the router's query params

Future `TODOs` will be
1. add the ability to allow user to select states when region is US
2. add the ability to allow user to select regions when region is Switzerland
3. add the ability to update the variants query params when a different variant is selected/deselected
4. add the ability to update the query params when a different country/continents is selected/deselected

## Demo

https://covariants-git-fork-scko823-query-string-country-hodcroftlab.vercel.app/per-country?variants=21J%20(Delta)&variants=21K%20(Omicron)&region=switzerland

https://covariants-git-fork-scko823-query-string-country-hodcroftlab.vercel.app/per-country?variants=21J%20(Delta)&variants=21K%20(Omicron)&region=usa