### PR TITLE
Adjust wording on clade figure slightly

### DIFF
--- a/web/src/components/Variants/CladeSchema.tsx
+++ b/web/src/components/Variants/CladeSchema.tsx
@@ -27,7 +27,11 @@ export function CladeSchema() {
         <CladeSchemaSvg />
       </CladeSchemaPicture>
       <CladeSchemaFigcaption>
-        <small>{'Illustration of phylogenetic relationships of SARS-CoV-2 clades, as defined by Nextstrain'}</small>
+        <small>
+          {
+            'Phylogenetic relationships of Nextstrain SARS-CoV-2 clades. Please credit/link to Nextstrain if using this figure'
+          }
+        </small>
       </CladeSchemaFigcaption>
     </CladeSchemaFigure>
   )


### PR DESCRIPTION
Just adjusts the wording underneath the clade figure slightly.

@ivan-aksamentov I wanted to also add a link to https://github.com/nextstrain/ncov-clades-schema in there, probably around "Nextstrain clades" - so people can fully see where the figure comes from - but I couldn't figure out how to get in-text links working in the TSX file.

No worries if this is a thing that's a pain, we can live without - was just thinking might be helpful for others who might want to use the figure!