### PR TITLE
implement usecols

### DIFF
--- a/scripts/allClusterDynamics_faster.py
+++ b/scripts/allClusterDynamics_faster.py
@@ -294,7 +294,8 @@ t0 = time.time()
 #}
 input_meta = "data/metadata.tsv"
 dtype={'location': str, 'sampling_strategy': str, 'clock_deviation': str, 'age': str, 'QC_frame_shifts': str, 'frame_shifts': str}
-meta = pd.read_csv(input_meta, sep="\t", dtype=dtype, index_col=False) #dtype={'location': str, 'sampling_strategy': str, 'clock_deviation': str}, index_col=False)
+cols = ['strain', 'date', 'division', 'host', 'substitutions', 'deletions', 'Nextstrain_clade', 'country']
+meta = pd.read_csv(input_meta, sep="\t", dtype=dtype, index_col=False, usecols=cols) #dtype={'location': str, 'sampling_strategy': str, 'clock_deviation': str}, index_col=False)
 meta = meta.fillna("")
 
 # Clean up metadata


### PR DESCRIPTION
Implement pandas read_csv parameter `usecols` to only read selected columns from metadata in order to speed up the script and reduce memory usage.

TODO:

 - [ ] Check list of columns for missing entries (In the line above, `dtype` is provided for columns that are apparently not used throughout the script?)