### PR TITLE
chore(web): fix web build

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -276,6 +276,7 @@
     "ts-essentials": "7.0.0",
     "ts-jest": "26.3.0",
     "ts-node": "9.0.0",
+    "ts-toolbelt": "8.0.7",
     "typescript": "4.0.2",
     "url-loader": "4.1.0",
     "utility-types": "3.10.0",
@@ -324,6 +325,7 @@
     "style-loader": "2.0.0",
     "styled-components": "5.1.1",
     "svgo": "1.3.2",
+    "ts-toolbelt": "8.0.7",
     "webpack": "4.44.1"
   }
 }

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -12268,10 +12268,10 @@ ts-pnp@^1.1.6:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
-ts-toolbelt@^9.6.0:
-  version "9.6.0"
-  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz#50a25426cfed500d4a09bd1b3afb6f28879edfd5"
-  integrity sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==
+ts-toolbelt@8.0.7, ts-toolbelt@^9.6.0:
+  version "8.0.7"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-8.0.7.tgz#4dad2928831a811ee17dbdab6eb1919fc0a295bf"
+  integrity sha512-KICHyKxc5Nu34kyoODrEe2+zvuQQaubTJz7pnC5RQ19TH/Jged1xv+h8LBrouaSD310m75oAljYs59LNHkLDkQ==
 
 tsconfig-paths@^3.9.0:
   version "3.9.0"


### PR DESCRIPTION
This forcefully downgrades  `ts-toolbelt`  package, because of its incompatibility with `merge-anything` package (introduced in https://github.com/hodcroftlab/covariants/pull/279)

See: https://github.com/mesqueeb/merge-anything/pull/16

