### PR TITLE
fix: don't sort clusters for "per country" plots

### DIFF
--- a/web/src/components/DistributionSidebar/DistributionSidebar.tsx
+++ b/web/src/components/DistributionSidebar/DistributionSidebar.tsx
@@ -8,6 +8,7 @@ import { ClusterFilters } from './ClusterFilters'
 import { CountryFilters } from './CountryFilters'
 
 import { CountryFlagProps } from '../Common/CountryFlag'
+import { sortClusters } from 'src/io/getClusters'
 
 export interface DistributionSidebarProps {
   countries: Country[]
@@ -46,6 +47,7 @@ export function DistributionSidebar({
 }: DistributionSidebarProps) {
   const [clustersCollapsed, setClustersCollapsed] = useState(clustersCollapsedByDefault)
   const [countriesCollapsed, setCountriesCollapsed] = useState(countriesCollapsedByDefault)
+  const clustersSorted = useMemo(() => sortClusters(clusters ?? []), [clusters])
 
   const availableFilters: { [key: string]: React.ReactNode } = useMemo(
     () => ({
@@ -82,7 +84,7 @@ export function DistributionSidebar({
       clusters: clusters && (
         <ClusterFilters
           key="cluster-filters"
-          clusters={clusters}
+          clusters={clustersSorted}
           onFilterChange={onClusterFilterChange}
           onFilterSelectAll={onClusterFilterSelectAll}
           onFilterDeselectAll={onClusterFilterDeselectAll}
@@ -95,6 +97,7 @@ export function DistributionSidebar({
       Icon,
       clustersCollapsed,
       clusters,
+      clustersSorted,
       countriesCollapsed,
       onClusterFilterChange,
       onClusterFilterDeselectAll,

--- a/web/src/io/getPerCountryData.ts
+++ b/web/src/io/getPerCountryData.ts
@@ -4,7 +4,6 @@ import { pickBy } from 'lodash'
 
 import type { Cluster } from 'src/state/Clusters'
 import type { Country } from 'src/state/Places'
-import { sortClusters } from 'src/io/getClusters'
 
 import perCountryDataJson from 'src/../data/perCountryData.json'
 

--- a/web/src/io/getPerCountryData.ts
+++ b/web/src/io/getPerCountryData.ts
@@ -60,7 +60,7 @@ export function getPerCountryData(regionName: string): PerCountryData {
   }
 
   const clusterNames = copy(perCountryData.cluster_names).sort()
-  const clusters = sortClusters(clusterNames.map((cluster) => ({ cluster, enabled: true })))
+  const clusters = clusterNames.map((cluster) => ({ cluster, enabled: true }))
 
   const countryDistributions = perCountryData.distributions
 


### PR DESCRIPTION
This removes sorting of cluster state for "per country" page introduced in https://github.com/hodcroftlab/covariants/pull/279
This ensures the old ordering of colored areas on area plots.

A complication of that removal is that sidebar component requires sorted clusters. However without it being sorted globally in case of "per country" page, it comes unsorted into the component. So sidebar now additionally performs the sorting.


Without sorting:
![01](https://user-images.githubusercontent.com/9403403/157240374-400624b9-b685-48fd-85c2-d7fa34e27e93.png)

With sorting:
![02](https://user-images.githubusercontent.com/9403403/157240399-6d24e134-ccf1-4d34-90ca-3cadda706cd8.png)

