### PR TITLE
fix(web): add missing country flags

### DIFF
--- a/web/src/components/Common/CountryFlag.tsx
+++ b/web/src/components/Common/CountryFlag.tsx
@@ -13,17 +13,23 @@ import { ReactComponent as SouthAmerica } from 'src/assets/images/continents/Sou
 import { FlagWrapper } from './FlagWrapper'
 
 export const missingCountryCodes: Record<string, string> = {
+  'Bolivia': 'BO',
   'Bonaire': 'BQ',
   'Brunei': 'BN',
   'Curacao': 'CW',
+  'Democratic Republic of the Congo': 'CD',
+  'Eswatini': 'SZ',
   'Iran': 'IR',
   'Kosovo': 'XK',
+  'Moldova': 'MD',
   'North Macedonia': 'MK',
   'Republic of the Congo': 'CD',
   'Russia': 'RU',
+  'Saint Martin': 'SX',
   'Sint Maarten': 'SX',
   'South Korea': 'KR',
   'USA': 'US',
+  'Venezuela': 'VE',
   'Vietnam': 'VN',
 }
 


### PR DESCRIPTION
This adds a few country names to the exceptions list, in order for flags to be rendered correctly.

This is due to inconsistent naming we use, which is not compliant with ISO-3166-1 Alpha-2 Code and with the the flag library we are using.

