### PR TITLE
Hide "also known as" if no alt display name exists

### DIFF
--- a/web/src/components/Variants/VariantTitle.tsx
+++ b/web/src/components/Variants/VariantTitle.tsx
@@ -25,7 +25,7 @@ export function VariantTitle({ cluster }: VariantTitleProps) {
       <ClusterNameTitle>{cluster?.display_name && `Variant: ${cluster?.display_name}`}</ClusterNameTitle>
       {
         <ClusterNameSubtitle>
-          {cluster?.alt_display_name && (
+          {cluster?.alt_display_name?.length > 0 && (
             <>
               {`also known as `}
               {cluster.alt_display_name.join(', ')}


### PR DESCRIPTION
This hides the "also known as" text in the variant title if there is no alternative name.

How it is right now:

![image](https://user-images.githubusercontent.com/18666552/163165192-15c1a785-6a4d-4132-b684-b7d36b58da8f.png)
