### PR TITLE
add category unknown to case count data

### DIFF
--- a/scripts/include_case_counts.py
+++ b/scripts/include_case_counts.py
@@ -92,6 +92,7 @@ for i in range(len(world_data)):
             continue  # Skip if no count data
 
         stand_estimated_cases = {c: round(float(n) * stand_total_cases) for c, n in percent_counts.items()}
+        stand_estimated_cases["Unknown"] = stand_total_cases - sum(stand_estimated_cases.values())
         percent_total_cases = total_sequences / total_cases if total_cases != 0 else None
 
         world_data_counts[-1]["distribution"].append({"week": week, "total_sequences": total_sequences, "stand_total_cases" : stand_total_cases, "stand_estimated_cases" : stand_estimated_cases, "percent_total_cases" : percent_total_cases})

--- a/scripts/include_case_counts.py
+++ b/scripts/include_case_counts.py
@@ -92,7 +92,7 @@ for i in range(len(world_data)):
             continue  # Skip if no count data
 
         stand_estimated_cases = {c: round(float(n) * stand_total_cases) for c, n in percent_counts.items()}
-        stand_estimated_cases["Unknown"] = stand_total_cases - sum(stand_estimated_cases.values())
+        stand_estimated_cases["others"] = stand_total_cases - sum(stand_estimated_cases.values())
         percent_total_cases = total_sequences / total_cases if total_cases != 0 else None
 
         world_data_counts[-1]["distribution"].append({"week": week, "total_sequences": total_sequences, "stand_total_cases" : stand_total_cases, "stand_estimated_cases" : stand_estimated_cases, "percent_total_cases" : percent_total_cases})

--- a/web/data/perCountryDataCaseCounts.json
+++ b/web/data/perCountryDataCaseCounts.json
@@ -56,7 +56,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1086
               },
               "stand_total_cases": 1086,
               "total_sequences": 5478,
@@ -86,7 +87,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 934
               },
               "stand_total_cases": 934,
               "total_sequences": 4477,
@@ -116,7 +118,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 884
               },
               "stand_total_cases": 884,
               "total_sequences": 3796,
@@ -146,7 +149,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1019
               },
               "stand_total_cases": 1019,
               "total_sequences": 5810,
@@ -176,14 +180,15 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1871
               },
               "stand_total_cases": 1871,
               "total_sequences": 8227,
               "week": "2020-06-22"
             },
             {
-              "percent_total_cases": 0.010722279494395066,
+              "percent_total_cases": 0.010723440416817586,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -206,10 +211,11 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2587
               },
               "stand_total_cases": 2587,
-              "total_sequences": 9236,
+              "total_sequences": 9237,
               "week": "2020-07-06"
             },
             {
@@ -236,7 +242,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2663
               },
               "stand_total_cases": 2663,
               "total_sequences": 6443,
@@ -266,7 +273,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2310
               },
               "stand_total_cases": 2310,
               "total_sequences": 4861,
@@ -296,7 +304,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 6,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1770
               },
               "stand_total_cases": 1777,
               "total_sequences": 4128,
@@ -326,7 +335,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 8,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1601
               },
               "stand_total_cases": 1611,
               "total_sequences": 4193,
@@ -356,7 +366,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 21,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1704
               },
               "stand_total_cases": 1729,
               "total_sequences": 5188,
@@ -386,14 +397,15 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 11,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1923
               },
               "stand_total_cases": 1942,
               "total_sequences": 5878,
               "week": "2020-09-28"
             },
             {
-              "percent_total_cases": 0.008289415524803645,
+              "percent_total_cases": 0.008292815613205943,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -416,14 +428,15 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 21,
-                "S:677P.Pelican": 3
+                "S:677P.Pelican": 3,
+                "Unknown": 2609
               },
               "stand_total_cases": 2650,
-              "total_sequences": 7314,
+              "total_sequences": 7317,
               "week": "2020-10-12"
             },
             {
-              "percent_total_cases": 0.009365568669951446,
+              "percent_total_cases": 0.009369157285427709,
               "stand_estimated_cases": {
                 "20A.EU2": 1,
                 "20A/S:126A": 0,
@@ -446,14 +459,15 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 46,
-                "S:677P.Pelican": 13
+                "S:677P.Pelican": 13,
+                "Unknown": 4097
               },
               "stand_total_cases": 4185,
-              "total_sequences": 13049,
+              "total_sequences": 13054,
               "week": "2020-10-26"
             },
             {
-              "percent_total_cases": 0.00603809958293356,
+              "percent_total_cases": 0.006040762275679231,
               "stand_estimated_cases": {
                 "20A.EU2": 2,
                 "20A/S:126A": 0,
@@ -466,7 +480,7 @@
                 "20J (Gamma, V3)": 0,
                 "21A (Delta)": 0,
                 "21B (Kappa)": 0,
-                "21C (Epsilon)": 93,
+                "21C (Epsilon)": 92,
                 "21D (Eta)": 0,
                 "21F (Iota)": 0,
                 "21G (Lambda)": 0,
@@ -476,10 +490,11 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 88,
-                "S:677P.Pelican": 27
+                "S:677P.Pelican": 27,
+                "Unknown": 6551
               },
               "stand_total_cases": 6768,
-              "total_sequences": 13606,
+              "total_sequences": 13612,
               "week": "2020-11-09"
             },
             {
@@ -506,7 +521,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 105,
-                "S:677P.Pelican": 54
+                "S:677P.Pelican": 54,
+                "Unknown": 7249
               },
               "stand_total_cases": 7752,
               "total_sequences": 13808,
@@ -536,14 +552,15 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 131,
-                "S:677P.Pelican": 157
+                "S:677P.Pelican": 157,
+                "Unknown": 7750
               },
               "stand_total_cases": 9259,
               "total_sequences": 22590,
               "week": "2020-12-07"
             },
             {
-              "percent_total_cases": 0.007821476938351701,
+              "percent_total_cases": 0.00782860583242908,
               "stand_estimated_cases": {
                 "20A.EU2": 2,
                 "20A/S:126A": 0,
@@ -556,7 +573,7 @@
                 "20J (Gamma, V3)": 0,
                 "21A (Delta)": 0,
                 "21B (Kappa)": 0,
-                "21C (Epsilon)": 1859,
+                "21C (Epsilon)": 1858,
                 "21D (Eta)": 1,
                 "21F (Iota)": 58,
                 "21G (Lambda)": 0,
@@ -565,11 +582,12 @@
                 "21J (Delta)": 3,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 346,
-                "S:677P.Pelican": 244
+                "S:677H.Robin1": 348,
+                "S:677P.Pelican": 244,
+                "Unknown": 11145
               },
               "stand_total_cases": 13904,
-              "total_sequences": 36206,
+              "total_sequences": 36239,
               "week": "2020-12-21"
             },
             {
@@ -596,7 +614,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 173,
-                "S:677P.Pelican": 154
+                "S:677P.Pelican": 154,
+                "Unknown": 5779
               },
               "stand_total_cases": 8163,
               "total_sequences": 34228,
@@ -626,7 +645,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 109,
-                "S:677P.Pelican": 96
+                "S:677P.Pelican": 96,
+                "Unknown": 3362
               },
               "stand_total_cases": 5585,
               "total_sequences": 31102,
@@ -656,7 +676,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 68,
-                "S:677P.Pelican": 53
+                "S:677P.Pelican": 53,
+                "Unknown": 1755
               },
               "stand_total_cases": 3304,
               "total_sequences": 34104,
@@ -686,14 +707,15 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 53,
-                "S:677P.Pelican": 52
+                "S:677P.Pelican": 52,
+                "Unknown": 1112
               },
               "stand_total_cases": 2689,
               "total_sequences": 37026,
               "week": "2021-02-22"
             },
             {
-              "percent_total_cases": 0.0640271082673904,
+              "percent_total_cases": 0.06402973809542593,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -716,10 +738,11 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 30,
-                "S:677P.Pelican": 21
+                "S:677P.Pelican": 21,
+                "Unknown": 653
               },
               "stand_total_cases": 2284,
-              "total_sequences": 48693,
+              "total_sequences": 48695,
               "week": "2021-03-08"
             },
             {
@@ -746,14 +769,15 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 17,
-                "S:677P.Pelican": 10
+                "S:677P.Pelican": 10,
+                "Unknown": 440
               },
               "stand_total_cases": 2682,
               "total_sequences": 66348,
               "week": "2021-03-22"
             },
             {
-              "percent_total_cases": 0.08061288324655075,
+              "percent_total_cases": 0.080608733451395,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -762,7 +786,7 @@
                 "20B/S:732A": 76,
                 "20E (EU1)": 0,
                 "20H (Beta, V2)": 24,
-                "20I (Alpha, V1)": 1793,
+                "20I (Alpha, V1)": 1794,
                 "20J (Gamma, V3)": 152,
                 "21A (Delta)": 5,
                 "21B (Kappa)": 4,
@@ -776,10 +800,11 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 8,
-                "S:677P.Pelican": 6
+                "S:677P.Pelican": 6,
+                "Unknown": 293
               },
               "stand_total_cases": 2895,
-              "total_sequences": 77703,
+              "total_sequences": 77699,
               "week": "2021-04-05"
             },
             {
@@ -806,14 +831,15 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 2,
-                "S:677P.Pelican": 2
+                "S:677P.Pelican": 2,
+                "Unknown": 158
               },
               "stand_total_cases": 2254,
               "total_sequences": 65936,
               "week": "2021-04-19"
             },
             {
-              "percent_total_cases": 0.0952642811821031,
+              "percent_total_cases": 0.09525659020554135,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -836,10 +862,11 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 1,
-                "S:677P.Pelican": 1
+                "S:677P.Pelican": 1,
+                "Unknown": 100
               },
               "stand_total_cases": 1562,
-              "total_sequences": 49546,
+              "total_sequences": 49542,
               "week": "2021-05-03"
             },
             {
@@ -866,7 +893,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 66
               },
               "stand_total_cases": 957,
               "total_sequences": 27901,
@@ -896,7 +924,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 38
               },
               "stand_total_cases": 606,
               "total_sequences": 19341,
@@ -926,7 +955,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 24
               },
               "stand_total_cases": 505,
               "total_sequences": 22718,
@@ -956,7 +986,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 18
               },
               "stand_total_cases": 699,
               "total_sequences": 38676,
@@ -986,14 +1017,15 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 18
               },
               "stand_total_cases": 1808,
               "total_sequences": 86113,
               "week": "2021-07-12"
             },
             {
-              "percent_total_cases": 0.10974515454427948,
+              "percent_total_cases": 0.10975860324756298,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -1012,18 +1044,19 @@
                 "21G (Lambda)": 2,
                 "21H (Mu)": 23,
                 "21I (Delta)": 528,
-                "21J (Delta)": 3088,
+                "21J (Delta)": 3089,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 18
               },
               "stand_total_cases": 4020,
-              "total_sequences": 146885,
+              "total_sequences": 146903,
               "week": "2021-07-26"
             },
             {
-              "percent_total_cases": 0.06545780074566512,
+              "percent_total_cases": 0.06546237849880215,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -1042,18 +1075,19 @@
                 "21G (Lambda)": 2,
                 "21H (Mu)": 12,
                 "21I (Delta)": 669,
-                "21J (Delta)": 4860,
+                "21J (Delta)": 4861,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 14
               },
               "stand_total_cases": 5905,
-              "total_sequences": 128692,
+              "total_sequences": 128701,
               "week": "2021-08-09"
             },
             {
-              "percent_total_cases": 0.059632728977681,
+              "percent_total_cases": 0.05964069830815542,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -1071,19 +1105,20 @@
                 "21F (Iota)": 0,
                 "21G (Lambda)": 0,
                 "21H (Mu)": 6,
-                "21I (Delta)": 698,
+                "21I (Delta)": 697,
                 "21J (Delta)": 5813,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 18
               },
               "stand_total_cases": 6784,
-              "total_sequences": 134690,
+              "total_sequences": 134708,
               "week": "2021-08-23"
             },
             {
-              "percent_total_cases": 0.0642320022889171,
+              "percent_total_cases": 0.06426232554954796,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -1106,14 +1141,15 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 12
               },
               "stand_total_cases": 6141,
-              "total_sequences": 131331,
+              "total_sequences": 131393,
               "week": "2021-09-06"
             },
             {
-              "percent_total_cases": 0.0685501424385096,
+              "percent_total_cases": 0.06860479359764811,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -1136,14 +1172,15 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 9
               },
               "stand_total_cases": 4781,
-              "total_sequences": 109126,
+              "total_sequences": 109213,
               "week": "2021-09-20"
             },
             {
-              "percent_total_cases": 0.08528973928244629,
+              "percent_total_cases": 0.08532267743824698,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -1166,14 +1203,15 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 7
               },
               "stand_total_cases": 3738,
-              "total_sequences": 106165,
+              "total_sequences": 106206,
               "week": "2021-10-04"
             },
             {
-              "percent_total_cases": 0.10259300460215777,
+              "percent_total_cases": 0.10261661045522905,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -1196,14 +1234,15 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 8
               },
               "stand_total_cases": 3053,
-              "total_sequences": 104306,
+              "total_sequences": 104330,
               "week": "2021-10-18"
             },
             {
-              "percent_total_cases": 0.11004082555880215,
+              "percent_total_cases": 0.11004916865665,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -1226,14 +1265,15 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 13
               },
               "stand_total_cases": 3240,
-              "total_sequences": 118705,
+              "total_sequences": 118714,
               "week": "2021-11-01"
             },
             {
-              "percent_total_cases": 0.08822659173299692,
+              "percent_total_cases": 0.08822830698562362,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -1256,14 +1296,15 @@
                 "21K (Omicron)": 2,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 14
               },
               "stand_total_cases": 3502,
-              "total_sequences": 102873,
+              "total_sequences": 102875,
               "week": "2021-11-15"
             },
             {
-              "percent_total_cases": 0.07223966727719434,
+              "percent_total_cases": 0.0722438044443814,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -1286,14 +1327,15 @@
                 "21K (Omicron)": 176,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 5
               },
               "stand_total_cases": 5082,
-              "total_sequences": 122228,
+              "total_sequences": 122235,
               "week": "2021-11-29"
             },
             {
-              "percent_total_cases": 0.05992803639784326,
+              "percent_total_cases": 0.059948922049734586,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -1312,18 +1354,19 @@
                 "21G (Lambda)": 0,
                 "21H (Mu)": 1,
                 "21I (Delta)": 72,
-                "21J (Delta)": 2839,
-                "21K (Omicron)": 4260,
-                "21L (Omicron)": 0,
+                "21J (Delta)": 2840,
+                "21K (Omicron)": 4259,
+                "21L (Omicron)": 1,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 6
               },
               "stand_total_cases": 7190,
-              "total_sequences": 143467,
+              "total_sequences": 143517,
               "week": "2021-12-13"
             },
             {
-              "percent_total_cases": 0.02245672064428311,
+              "percent_total_cases": 0.022547523879014812,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -1341,19 +1384,20 @@
                 "21F (Iota)": 0,
                 "21G (Lambda)": 0,
                 "21H (Mu)": 0,
-                "21I (Delta)": 36,
-                "21J (Delta)": 1605,
-                "21K (Omicron)": 22489,
+                "21I (Delta)": 37,
+                "21J (Delta)": 1612,
+                "21K (Omicron)": 22481,
                 "21L (Omicron)": 15,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 31
               },
               "stand_total_cases": 24181,
-              "total_sequences": 180785,
+              "total_sequences": 181516,
               "week": "2021-12-27"
             },
             {
-              "percent_total_cases": 0.01608609961764166,
+              "percent_total_cases": 0.016192202855054207,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -1372,18 +1416,19 @@
                 "21G (Lambda)": 0,
                 "21H (Mu)": 0,
                 "21I (Delta)": 8,
-                "21J (Delta)": 402,
-                "21K (Omicron)": 31308,
-                "21L (Omicron)": 122,
+                "21J (Delta)": 409,
+                "21K (Omicron)": 31298,
+                "21L (Omicron)": 124,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 8
               },
               "stand_total_cases": 31848,
-              "total_sequences": 170559,
+              "total_sequences": 171684,
               "week": "2022-01-10"
             },
             {
-              "percent_total_cases": 0.025295460119639006,
+              "percent_total_cases": 0.025451257959109755,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -1402,18 +1447,19 @@
                 "21G (Lambda)": 0,
                 "21H (Mu)": 0,
                 "21I (Delta)": 2,
-                "21J (Delta)": 52,
-                "21K (Omicron)": 16392,
-                "21L (Omicron)": 171,
+                "21J (Delta)": 54,
+                "21K (Omicron)": 16380,
+                "21L (Omicron)": 182,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 16619,
-              "total_sequences": 139955,
+              "total_sequences": 140817,
               "week": "2022-01-24"
             },
             {
-              "percent_total_cases": 0.052815807374972,
+              "percent_total_cases": 0.05291335445304992,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -1436,14 +1482,15 @@
                 "21K (Omicron)": 5611,
                 "21L (Omicron)": 199,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 5819,
-              "total_sequences": 102332,
+              "total_sequences": 102521,
               "week": "2022-02-07"
             },
             {
-              "percent_total_cases": 0.061382186822609326,
+              "percent_total_cases": 0.06172111928652187,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -1463,17 +1510,18 @@
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 3,
-                "21K (Omicron)": 2076,
-                "21L (Omicron)": 292,
+                "21K (Omicron)": 2070,
+                "21L (Omicron)": 298,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 2375,
-              "total_sequences": 48536,
+              "total_sequences": 48804,
               "week": "2022-02-21"
             },
             {
-              "percent_total_cases": 0.06451773539479468,
+              "percent_total_cases": 0.06550285468083218,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -1493,17 +1541,18 @@
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 1,
-                "21K (Omicron)": 805,
-                "21L (Omicron)": 579,
+                "21K (Omicron)": 804,
+                "21L (Omicron)": 580,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 1387,
-              "total_sequences": 29799,
+              "total_sequences": 30254,
               "week": "2022-03-07"
             },
             {
-              "percent_total_cases": 0.05746855137632135,
+              "percent_total_cases": 0.06733124438524955,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -1523,17 +1572,18 @@
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 318,
-                "21L (Omicron)": 927,
+                "21K (Omicron)": 306,
+                "21L (Omicron)": 939,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 1247,
-              "total_sequences": 23861,
+              "total_sequences": 27956,
               "week": "2022-03-21"
             },
             {
-              "percent_total_cases": 0.003032050095106637,
+              "percent_total_cases": 0.011438046021512617,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -1552,14 +1602,15 @@
                 "21G (Lambda)": 0,
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 1,
-                "21K (Omicron)": 162,
-                "21L (Omicron)": 1263,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 145,
+                "21L (Omicron)": 1279,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 1427,
-              "total_sequences": 1441,
+              "total_sequences": 5436,
               "week": "2022-04-04"
             }
           ]
@@ -1593,7 +1644,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 776
               },
               "stand_total_cases": 776,
               "total_sequences": 4667,
@@ -1625,7 +1677,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 513
               },
               "stand_total_cases": 513,
               "total_sequences": 2715,
@@ -1657,7 +1710,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 272
               },
               "stand_total_cases": 272,
               "total_sequences": 1720,
@@ -1689,7 +1743,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 198
               },
               "stand_total_cases": 198,
               "total_sequences": 4681,
@@ -1721,7 +1776,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 111
               },
               "stand_total_cases": 111,
               "total_sequences": 2274,
@@ -1753,7 +1809,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 135
               },
               "stand_total_cases": 137,
               "total_sequences": 1076,
@@ -1785,7 +1842,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 141
               },
               "stand_total_cases": 145,
               "total_sequences": 1185,
@@ -1817,7 +1875,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 179
               },
               "stand_total_cases": 202,
               "total_sequences": 2342,
@@ -1849,7 +1908,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 143
               },
               "stand_total_cases": 234,
               "total_sequences": 4113,
@@ -1881,7 +1941,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 283
               },
               "stand_total_cases": 499,
               "total_sequences": 5636,
@@ -1913,7 +1974,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 444
               },
               "stand_total_cases": 974,
               "total_sequences": 9665,
@@ -1945,7 +2007,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 873
               },
               "stand_total_cases": 2474,
               "total_sequences": 11440,
@@ -1977,7 +2040,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1128
               },
               "stand_total_cases": 3961,
               "total_sequences": 16068,
@@ -2009,7 +2073,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1067
               },
               "stand_total_cases": 4667,
               "total_sequences": 17807,
@@ -2041,7 +2106,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 856
               },
               "stand_total_cases": 4694,
               "total_sequences": 17846,
@@ -2073,7 +2139,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 407
               },
               "stand_total_cases": 3102,
               "total_sequences": 8362,
@@ -2105,7 +2172,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 321
               },
               "stand_total_cases": 4660,
               "total_sequences": 21412,
@@ -2137,7 +2205,8 @@
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 481
               },
               "stand_total_cases": 15143,
               "total_sequences": 31023,
@@ -2169,7 +2238,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 123
               },
               "stand_total_cases": 8434,
               "total_sequences": 30549,
@@ -2201,7 +2271,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 37
               },
               "stand_total_cases": 4378,
               "total_sequences": 33290,
@@ -2233,7 +2304,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 13
               },
               "stand_total_cases": 2491,
               "total_sequences": 32800,
@@ -2265,7 +2337,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 13
               },
               "stand_total_cases": 1510,
               "total_sequences": 30242,
@@ -2297,7 +2370,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 8
               },
               "stand_total_cases": 1144,
               "total_sequences": 35271,
@@ -2329,7 +2403,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 7
               },
               "stand_total_cases": 920,
               "total_sequences": 29811,
@@ -2361,7 +2436,8 @@
                 "21J (Delta)": 2,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 6
               },
               "stand_total_cases": 488,
               "total_sequences": 16089,
@@ -2393,7 +2469,8 @@
                 "21J (Delta)": 23,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 474,
               "total_sequences": 14619,
@@ -2425,7 +2502,8 @@
                 "21J (Delta)": 113,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 448,
               "total_sequences": 14707,
@@ -2457,7 +2535,8 @@
                 "21J (Delta)": 317,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 522,
               "total_sequences": 24167,
@@ -2489,7 +2568,8 @@
                 "21J (Delta)": 941,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 1199,
               "total_sequences": 37723,
@@ -2521,7 +2601,8 @@
                 "21J (Delta)": 2213,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 6
               },
               "stand_total_cases": 2445,
               "total_sequences": 45042,
@@ -2553,7 +2634,8 @@
                 "21J (Delta)": 5368,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 5717,
               "total_sequences": 59643,
@@ -2585,7 +2667,8 @@
                 "21J (Delta)": 8198,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 8501,
               "total_sequences": 59720,
@@ -2617,7 +2700,8 @@
                 "21J (Delta)": 5319,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 5461,
               "total_sequences": 65226,
@@ -2649,7 +2733,8 @@
                 "21J (Delta)": 6113,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 6218,
               "total_sequences": 65943,
@@ -2681,7 +2766,8 @@
                 "21J (Delta)": 7017,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 7121,
               "total_sequences": 79686,
@@ -2713,7 +2799,8 @@
                 "21J (Delta)": 6557,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 6628,
               "total_sequences": 79891,
@@ -2745,7 +2832,8 @@
                 "21J (Delta)": 6845,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 6910,
               "total_sequences": 76801,
@@ -2777,7 +2865,8 @@
                 "21J (Delta)": 7986,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 8049,
               "total_sequences": 78497,
@@ -2809,7 +2898,8 @@
                 "21J (Delta)": 8867,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 8934,
               "total_sequences": 87482,
@@ -2841,7 +2931,8 @@
                 "21J (Delta)": 7356,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 7405,
               "total_sequences": 99147,
@@ -2873,7 +2964,8 @@
                 "21J (Delta)": 8561,
                 "21K (Omicron)": 15,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 8628,
               "total_sequences": 114007,
@@ -2905,7 +2997,8 @@
                 "21J (Delta)": 8939,
                 "21K (Omicron)": 920,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 9905,
               "total_sequences": 130510,
@@ -2937,7 +3030,8 @@
                 "21J (Delta)": 5611,
                 "21K (Omicron)": 13650,
                 "21L (Omicron)": 2,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 19295,
               "total_sequences": 120518,
@@ -2969,14 +3063,15 @@
                 "21J (Delta)": 1139,
                 "21K (Omicron)": 33248,
                 "21L (Omicron)": 91,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 34484,
               "total_sequences": 144769,
               "week": "2021-12-27"
             },
             {
-              "percent_total_cases": 0.09754370512372144,
+              "percent_total_cases": 0.09754442472730622,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -3001,10 +3096,11 @@
                 "21J (Delta)": 121,
                 "21K (Omicron)": 19709,
                 "21L (Omicron)": 540,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 20374,
-              "total_sequences": 135552,
+              "total_sequences": 135553,
               "week": "2022-01-10"
             },
             {
@@ -3033,7 +3129,8 @@
                 "21J (Delta)": 20,
                 "21K (Omicron)": 14200,
                 "21L (Omicron)": 1926,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 9
               },
               "stand_total_cases": 16155,
               "total_sequences": 136316,
@@ -3065,14 +3162,15 @@
                 "21J (Delta)": 3,
                 "21K (Omicron)": 7951,
                 "21L (Omicron)": 4011,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 16
               },
               "stand_total_cases": 11981,
               "total_sequences": 143287,
               "week": "2022-02-07"
             },
             {
-              "percent_total_cases": 0.23047314595647145,
+              "percent_total_cases": 0.23051847588940286,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -3097,14 +3195,15 @@
                 "21J (Delta)": 1,
                 "21K (Omicron)": 2472,
                 "21L (Omicron)": 4938,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 27
               },
               "stand_total_cases": 7438,
-              "total_sequences": 116940,
+              "total_sequences": 116963,
               "week": "2022-02-21"
             },
             {
-              "percent_total_cases": 0.14857598980239078,
+              "percent_total_cases": 0.14866151288293214,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -3127,16 +3226,17 @@
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 1,
-                "21K (Omicron)": 1699,
-                "21L (Omicron)": 12619,
-                "S:677P.Pelican": 0
+                "21K (Omicron)": 1698,
+                "21L (Omicron)": 12620,
+                "S:677P.Pelican": 0,
+                "Unknown": 81
               },
               "stand_total_cases": 14400,
-              "total_sequences": 145930,
+              "total_sequences": 146014,
               "week": "2022-03-07"
             },
             {
-              "percent_total_cases": 0.06774281646148583,
+              "percent_total_cases": 0.07308909611725224,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -3158,17 +3258,18 @@
                 "21G (Lambda)": 0,
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 752,
-                "21L (Omicron)": 15737,
-                "S:677P.Pelican": 0
+                "21J (Delta)": 1,
+                "21K (Omicron)": 750,
+                "21L (Omicron)": 15732,
+                "S:677P.Pelican": 0,
+                "Unknown": 105
               },
               "stand_total_cases": 16588,
-              "total_sequences": 76647,
+              "total_sequences": 82696,
               "week": "2022-03-21"
             },
             {
-              "percent_total_cases": 0.009557705701297827,
+              "percent_total_cases": 0.020725524410062084,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -3191,12 +3292,13 @@
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 172,
-                "21L (Omicron)": 7592,
-                "S:677P.Pelican": 0
+                "21K (Omicron)": 154,
+                "21L (Omicron)": 7614,
+                "S:677P.Pelican": 0,
+                "Unknown": 62
               },
               "stand_total_cases": 7830,
-              "total_sequences": 5105,
+              "total_sequences": 11070,
               "week": "2022-04-04"
             }
           ]
@@ -3228,7 +3330,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 179
               },
               "stand_total_cases": 179,
               "total_sequences": 94,
@@ -3258,7 +3361,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 107
               },
               "stand_total_cases": 108,
               "total_sequences": 86,
@@ -3288,7 +3392,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 67
               },
               "stand_total_cases": 67,
               "total_sequences": 67,
@@ -3318,7 +3423,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 69
               },
               "stand_total_cases": 69,
               "total_sequences": 1365,
@@ -3348,7 +3454,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 77
               },
               "stand_total_cases": 77,
               "total_sequences": 323,
@@ -3378,7 +3485,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 62
               },
               "stand_total_cases": 62,
               "total_sequences": 75,
@@ -3408,7 +3516,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 99
               },
               "stand_total_cases": 99,
               "total_sequences": 49,
@@ -3438,7 +3547,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 136
               },
               "stand_total_cases": 161,
               "total_sequences": 142,
@@ -3468,7 +3578,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 139
               },
               "stand_total_cases": 218,
               "total_sequences": 172,
@@ -3498,7 +3609,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 160
               },
               "stand_total_cases": 210,
               "total_sequences": 111,
@@ -3528,7 +3640,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 200
               },
               "stand_total_cases": 294,
               "total_sequences": 313,
@@ -3558,7 +3671,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 317
               },
               "stand_total_cases": 461,
               "total_sequences": 314,
@@ -3588,7 +3702,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 620
               },
               "stand_total_cases": 1267,
               "total_sequences": 333,
@@ -3618,7 +3733,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1333
               },
               "stand_total_cases": 2733,
               "total_sequences": 365,
@@ -3648,7 +3764,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1248
               },
               "stand_total_cases": 3096,
               "total_sequences": 422,
@@ -3678,7 +3795,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1282
               },
               "stand_total_cases": 3016,
               "total_sequences": 586,
@@ -3708,7 +3826,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1310
               },
               "stand_total_cases": 3846,
               "total_sequences": 822,
@@ -3738,7 +3857,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 5,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1322
               },
               "stand_total_cases": 4940,
               "total_sequences": 1028,
@@ -3768,7 +3888,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 624
               },
               "stand_total_cases": 2698,
               "total_sequences": 3043,
@@ -3798,7 +3919,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 366
               },
               "stand_total_cases": 1776,
               "total_sequences": 6098,
@@ -3828,7 +3950,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 177
               },
               "stand_total_cases": 1222,
               "total_sequences": 8844,
@@ -3858,7 +3981,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 184
               },
               "stand_total_cases": 1354,
               "total_sequences": 11235,
@@ -3888,7 +4012,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 107
               },
               "stand_total_cases": 1899,
               "total_sequences": 14190,
@@ -3918,7 +4043,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 73
               },
               "stand_total_cases": 2692,
               "total_sequences": 16198,
@@ -3948,7 +4074,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 53
               },
               "stand_total_cases": 3061,
               "total_sequences": 19153,
@@ -3978,7 +4105,8 @@
                 "21I (Delta)": 5,
                 "21J (Delta)": 6,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 41
               },
               "stand_total_cases": 3272,
               "total_sequences": 19177,
@@ -4008,7 +4136,8 @@
                 "21I (Delta)": 11,
                 "21J (Delta)": 14,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 34
               },
               "stand_total_cases": 2105,
               "total_sequences": 15505,
@@ -4038,7 +4167,8 @@
                 "21I (Delta)": 12,
                 "21J (Delta)": 18,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 27
               },
               "stand_total_cases": 1021,
               "total_sequences": 9710,
@@ -4068,7 +4198,8 @@
                 "21I (Delta)": 10,
                 "21J (Delta)": 40,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 18
               },
               "stand_total_cases": 426,
               "total_sequences": 5328,
@@ -4098,7 +4229,8 @@
                 "21I (Delta)": 8,
                 "21J (Delta)": 54,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 5
               },
               "stand_total_cases": 139,
               "total_sequences": 2582,
@@ -4128,7 +4260,8 @@
                 "21I (Delta)": 9,
                 "21J (Delta)": 75,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 112,
               "total_sequences": 2620,
@@ -4158,7 +4291,8 @@
                 "21I (Delta)": 37,
                 "21J (Delta)": 181,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 235,
               "total_sequences": 4559,
@@ -4188,7 +4322,8 @@
                 "21I (Delta)": 55,
                 "21J (Delta)": 343,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 415,
               "total_sequences": 6144,
@@ -4218,7 +4353,8 @@
                 "21I (Delta)": 89,
                 "21J (Delta)": 816,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 922,
               "total_sequences": 13058,
@@ -4248,7 +4384,8 @@
                 "21I (Delta)": 118,
                 "21J (Delta)": 1503,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 1638,
               "total_sequences": 19038,
@@ -4278,7 +4415,8 @@
                 "21I (Delta)": 112,
                 "21J (Delta)": 1506,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 1626,
               "total_sequences": 19681,
@@ -4308,7 +4446,8 @@
                 "21I (Delta)": 83,
                 "21J (Delta)": 1225,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 1313,
               "total_sequences": 15507,
@@ -4338,7 +4477,8 @@
                 "21I (Delta)": 77,
                 "21J (Delta)": 1364,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1448,
               "total_sequences": 12219,
@@ -4368,7 +4508,8 @@
                 "21I (Delta)": 126,
                 "21J (Delta)": 2518,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2666,
               "total_sequences": 15414,
@@ -4398,7 +4539,8 @@
                 "21I (Delta)": 175,
                 "21J (Delta)": 4836,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 5052,
               "total_sequences": 17992,
@@ -4428,7 +4570,8 @@
                 "21I (Delta)": 208,
                 "21J (Delta)": 8546,
                 "21K (Omicron)": 16,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 8822,
               "total_sequences": 23291,
@@ -4458,7 +4601,8 @@
                 "21I (Delta)": 168,
                 "21J (Delta)": 8485,
                 "21K (Omicron)": 213,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 10
               },
               "stand_total_cases": 8917,
               "total_sequences": 24116,
@@ -4488,7 +4632,8 @@
                 "21I (Delta)": 81,
                 "21J (Delta)": 4642,
                 "21K (Omicron)": 986,
-                "21L (Omicron)": 2
+                "21L (Omicron)": 2,
+                "Unknown": 8
               },
               "stand_total_cases": 5739,
               "total_sequences": 21695,
@@ -4518,7 +4663,8 @@
                 "21I (Delta)": 28,
                 "21J (Delta)": 2126,
                 "21K (Omicron)": 3950,
-                "21L (Omicron)": 71
+                "21L (Omicron)": 71,
+                "Unknown": 5
               },
               "stand_total_cases": 6186,
               "total_sequences": 24045,
@@ -4548,7 +4694,8 @@
                 "21I (Delta)": 28,
                 "21J (Delta)": 1466,
                 "21K (Omicron)": 11495,
-                "21L (Omicron)": 945
+                "21L (Omicron)": 945,
+                "Unknown": 20
               },
               "stand_total_cases": 13957,
               "total_sequences": 24528,
@@ -4578,7 +4725,8 @@
                 "21I (Delta)": 3,
                 "21J (Delta)": 389,
                 "21K (Omicron)": 22340,
-                "21L (Omicron)": 5153
+                "21L (Omicron)": 5153,
+                "Unknown": 15
               },
               "stand_total_cases": 27903,
               "total_sequences": 28061,
@@ -4608,7 +4756,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 74,
                 "21K (Omicron)": 19178,
-                "21L (Omicron)": 10989
+                "21L (Omicron)": 10989,
+                "Unknown": 37
               },
               "stand_total_cases": 30280,
               "total_sequences": 33583,
@@ -4638,14 +4787,15 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 12,
                 "21K (Omicron)": 9729,
-                "21L (Omicron)": 16706
+                "21L (Omicron)": 16706,
+                "Unknown": 104
               },
               "stand_total_cases": 26553,
               "total_sequences": 32317,
               "week": "2022-02-21"
             },
             {
-              "percent_total_cases": 0.01184654492791347,
+              "percent_total_cases": 0.011886696840598291,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -4667,11 +4817,12 @@
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 5,
-                "21K (Omicron)": 7125,
-                "21L (Omicron)": 27200
+                "21K (Omicron)": 7124,
+                "21L (Omicron)": 27202,
+                "Unknown": 99
               },
               "stand_total_cases": 34433,
-              "total_sequences": 34225,
+              "total_sequences": 34341,
               "week": "2022-03-07"
             },
             {
@@ -4698,7 +4849,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 4,
                 "21K (Omicron)": 3343,
-                "21L (Omicron)": 32134
+                "21L (Omicron)": 32134,
+                "Unknown": 131
               },
               "stand_total_cases": 35622,
               "total_sequences": 18669,
@@ -4728,7 +4880,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 60,
                 "21K (Omicron)": 1229,
-                "21L (Omicron)": 19730
+                "21L (Omicron)": 19730,
+                "Unknown": 59
               },
               "stand_total_cases": 21078,
               "total_sequences": 1767,
@@ -4764,7 +4917,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 318
               },
               "stand_total_cases": 318,
               "total_sequences": 155,
@@ -4795,7 +4949,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 160
               },
               "stand_total_cases": 160,
               "total_sequences": 136,
@@ -4826,7 +4981,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 101
               },
               "stand_total_cases": 101,
               "total_sequences": 121,
@@ -4857,7 +5013,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 76
               },
               "stand_total_cases": 76,
               "total_sequences": 160,
@@ -4888,7 +5045,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 75
               },
               "stand_total_cases": 75,
               "total_sequences": 57,
@@ -4919,7 +5077,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 58
               },
               "stand_total_cases": 58,
               "total_sequences": 100,
@@ -4950,7 +5109,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 103
               },
               "stand_total_cases": 105,
               "total_sequences": 152,
@@ -4981,7 +5141,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 275
               },
               "stand_total_cases": 314,
               "total_sequences": 422,
@@ -5012,7 +5173,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 157
               },
               "stand_total_cases": 219,
               "total_sequences": 582,
@@ -5043,7 +5205,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 190
               },
               "stand_total_cases": 515,
               "total_sequences": 963,
@@ -5074,7 +5237,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 349
               },
               "stand_total_cases": 1160,
               "total_sequences": 1589,
@@ -5105,7 +5269,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 312
               },
               "stand_total_cases": 995,
               "total_sequences": 809,
@@ -5136,7 +5301,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 446
               },
               "stand_total_cases": 1364,
               "total_sequences": 1417,
@@ -5167,7 +5333,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 739
               },
               "stand_total_cases": 2539,
               "total_sequences": 2921,
@@ -5198,7 +5365,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1026
               },
               "stand_total_cases": 2642,
               "total_sequences": 3061,
@@ -5229,7 +5397,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 1
+                "S:677P.Pelican": 1,
+                "Unknown": 847
               },
               "stand_total_cases": 3460,
               "total_sequences": 4974,
@@ -5260,7 +5429,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1168
               },
               "stand_total_cases": 7539,
               "total_sequences": 9137,
@@ -5291,7 +5461,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 926
               },
               "stand_total_cases": 8093,
               "total_sequences": 11634,
@@ -5322,7 +5493,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 228
               },
               "stand_total_cases": 2268,
               "total_sequences": 8005,
@@ -5353,7 +5525,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 109
               },
               "stand_total_cases": 1195,
               "total_sequences": 4714,
@@ -5384,7 +5557,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 89
               },
               "stand_total_cases": 1024,
               "total_sequences": 4348,
@@ -5415,7 +5589,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 45
               },
               "stand_total_cases": 1249,
               "total_sequences": 5309,
@@ -5446,7 +5621,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 18
               },
               "stand_total_cases": 1834,
               "total_sequences": 6333,
@@ -5477,7 +5653,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 11
               },
               "stand_total_cases": 1688,
               "total_sequences": 7143,
@@ -5508,7 +5685,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 1602,
               "total_sequences": 6942,
@@ -5539,7 +5717,8 @@
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 1768,
               "total_sequences": 7601,
@@ -5570,7 +5749,8 @@
                 "21J (Delta)": 5,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 2337,
               "total_sequences": 9576,
@@ -5601,7 +5781,8 @@
                 "21J (Delta)": 5,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 2387,
               "total_sequences": 9468,
@@ -5632,7 +5813,8 @@
                 "21J (Delta)": 21,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 1632,
               "total_sequences": 5858,
@@ -5663,7 +5845,8 @@
                 "21J (Delta)": 96,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 527,
               "total_sequences": 2020,
@@ -5694,7 +5877,8 @@
                 "21J (Delta)": 769,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 1080,
               "total_sequences": 5116,
@@ -5725,7 +5909,8 @@
                 "21J (Delta)": 1715,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2115,
               "total_sequences": 10867,
@@ -5756,7 +5941,8 @@
                 "21J (Delta)": 1832,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 2109,
               "total_sequences": 10878,
@@ -5787,7 +5973,8 @@
                 "21J (Delta)": 2135,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 2353,
               "total_sequences": 11178,
@@ -5818,7 +6005,8 @@
                 "21J (Delta)": 1823,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1980,
               "total_sequences": 8705,
@@ -5849,7 +6037,8 @@
                 "21J (Delta)": 913,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 974,
               "total_sequences": 4571,
@@ -5880,7 +6069,8 @@
                 "21J (Delta)": 884,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 926,
               "total_sequences": 4847,
@@ -5911,7 +6101,8 @@
                 "21J (Delta)": 1448,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1482,
               "total_sequences": 7608,
@@ -5942,7 +6133,8 @@
                 "21J (Delta)": 3215,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 3291,
               "total_sequences": 15373,
@@ -5973,7 +6165,8 @@
                 "21J (Delta)": 5973,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 6113,
               "total_sequences": 22107,
@@ -6004,7 +6197,8 @@
                 "21J (Delta)": 9408,
                 "21K (Omicron)": 4,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 9565,
               "total_sequences": 23565,
@@ -6035,7 +6229,8 @@
                 "21J (Delta)": 12153,
                 "21K (Omicron)": 660,
                 "21L (Omicron)": 2,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 12980,
               "total_sequences": 30293,
@@ -6066,7 +6261,8 @@
                 "21J (Delta)": 9476,
                 "21K (Omicron)": 11781,
                 "21L (Omicron)": 1107,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 22473,
               "total_sequences": 11474,
@@ -6097,7 +6293,8 @@
                 "21J (Delta)": 2921,
                 "21K (Omicron)": 33878,
                 "21L (Omicron)": 12062,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 30
               },
               "stand_total_cases": 48930,
               "total_sequences": 19046,
@@ -6128,14 +6325,15 @@
                 "21J (Delta)": 381,
                 "21K (Omicron)": 26690,
                 "21L (Omicron)": 46505,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 103
               },
               "stand_total_cases": 73684,
               "total_sequences": 28819,
               "week": "2022-01-10"
             },
             {
-              "percent_total_cases": 0.04118742450954959,
+              "percent_total_cases": 0.04124525577114683,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:439K": 0,
@@ -6157,12 +6355,13 @@
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 54,
-                "21K (Omicron)": 15524,
-                "21L (Omicron)": 88320,
-                "S:677P.Pelican": 0
+                "21K (Omicron)": 15531,
+                "21L (Omicron)": 88313,
+                "S:677P.Pelican": 0,
+                "Unknown": 209
               },
               "stand_total_cases": 104107,
-              "total_sequences": 24927,
+              "total_sequences": 24962,
               "week": "2022-01-24"
             },
             {
@@ -6190,7 +6389,8 @@
                 "21J (Delta)": 4,
                 "21K (Omicron)": 5056,
                 "21L (Omicron)": 93560,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 292
               },
               "stand_total_cases": 98912,
               "total_sequences": 26392,
@@ -6221,7 +6421,8 @@
                 "21J (Delta)": 4,
                 "21K (Omicron)": 1131,
                 "21L (Omicron)": 47884,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 180
               },
               "stand_total_cases": 49199,
               "total_sequences": 26496,
@@ -6252,14 +6453,15 @@
                 "21J (Delta)": 1,
                 "21K (Omicron)": 296,
                 "21L (Omicron)": 23839,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 91
               },
               "stand_total_cases": 24227,
               "total_sequences": 26353,
               "week": "2022-03-07"
             },
             {
-              "percent_total_cases": 0.4014369397067866,
+              "percent_total_cases": 0.4014531214602414,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:439K": 0,
@@ -6283,14 +6485,15 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 87,
                 "21L (Omicron)": 10501,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 42
               },
               "stand_total_cases": 10630,
-              "total_sequences": 24808,
+              "total_sequences": 24809,
               "week": "2022-03-21"
             },
             {
-              "percent_total_cases": 0.13099602092928533,
+              "percent_total_cases": 0.18726697371306827,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:439K": 0,
@@ -6313,11 +6516,12 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 17,
-                "21L (Omicron)": 5443,
-                "S:677P.Pelican": 0
+                "21L (Omicron)": 5447,
+                "S:677P.Pelican": 0,
+                "Unknown": 26
               },
               "stand_total_cases": 5490,
-              "total_sequences": 4181,
+              "total_sequences": 5977,
               "week": "2022-04-04"
             }
           ]
@@ -6350,7 +6554,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 522
               },
               "stand_total_cases": 522,
               "total_sequences": 946,
@@ -6381,7 +6586,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 407
               },
               "stand_total_cases": 407,
               "total_sequences": 622,
@@ -6412,7 +6618,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 265
               },
               "stand_total_cases": 265,
               "total_sequences": 212,
@@ -6443,7 +6650,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 142
               },
               "stand_total_cases": 142,
               "total_sequences": 203,
@@ -6474,7 +6682,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 111
               },
               "stand_total_cases": 111,
               "total_sequences": 104,
@@ -6505,7 +6714,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 134
               },
               "stand_total_cases": 135,
               "total_sequences": 204,
@@ -6536,7 +6746,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 165
               },
               "stand_total_cases": 165,
               "total_sequences": 296,
@@ -6567,7 +6778,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 134
               },
               "stand_total_cases": 134,
               "total_sequences": 584,
@@ -6598,7 +6810,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 160
               },
               "stand_total_cases": 160,
               "total_sequences": 728,
@@ -6629,7 +6842,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 251
               },
               "stand_total_cases": 253,
               "total_sequences": 727,
@@ -6660,7 +6874,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 471
               },
               "stand_total_cases": 477,
               "total_sequences": 758,
@@ -6691,7 +6906,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 739
               },
               "stand_total_cases": 757,
               "total_sequences": 1061,
@@ -6722,7 +6938,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 852
               },
               "stand_total_cases": 894,
               "total_sequences": 1101,
@@ -6753,7 +6970,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1222
               },
               "stand_total_cases": 1286,
               "total_sequences": 1438,
@@ -6784,7 +7002,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 1,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1650
               },
               "stand_total_cases": 1757,
               "total_sequences": 1939,
@@ -6815,7 +7034,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 4,
-                "S:677P.Pelican": 3
+                "S:677P.Pelican": 3,
+                "Unknown": 2119
               },
               "stand_total_cases": 2257,
               "total_sequences": 2390,
@@ -6846,7 +7066,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 1,
-                "S:677P.Pelican": 2
+                "S:677P.Pelican": 2,
+                "Unknown": 2119
               },
               "stand_total_cases": 2488,
               "total_sequences": 2430,
@@ -6877,7 +7098,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 1,
-                "S:677P.Pelican": 2
+                "S:677P.Pelican": 2,
+                "Unknown": 3244
               },
               "stand_total_cases": 4039,
               "total_sequences": 4770,
@@ -6908,7 +7130,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 6,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1799
               },
               "stand_total_cases": 2178,
               "total_sequences": 4782,
@@ -6939,7 +7162,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 1,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1208
               },
               "stand_total_cases": 1447,
               "total_sequences": 3206,
@@ -6970,7 +7194,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 2,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 806
               },
               "stand_total_cases": 1099,
               "total_sequences": 4250,
@@ -7001,7 +7226,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 632
               },
               "stand_total_cases": 1094,
               "total_sequences": 4851,
@@ -7032,7 +7258,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 1,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 521
               },
               "stand_total_cases": 1264,
               "total_sequences": 7478,
@@ -7063,7 +7290,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 454
               },
               "stand_total_cases": 1910,
               "total_sequences": 10004,
@@ -7094,7 +7322,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 595
               },
               "stand_total_cases": 3179,
               "total_sequences": 10754,
@@ -7125,7 +7354,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 370
               },
               "stand_total_cases": 2926,
               "total_sequences": 11130,
@@ -7156,7 +7386,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 171
               },
               "stand_total_cases": 2412,
               "total_sequences": 8629,
@@ -7187,7 +7418,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 2,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 52
               },
               "stand_total_cases": 1273,
               "total_sequences": 5921,
@@ -7218,7 +7450,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 22
               },
               "stand_total_cases": 586,
               "total_sequences": 4261,
@@ -7249,7 +7482,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 16
               },
               "stand_total_cases": 283,
               "total_sequences": 3752,
@@ -7280,7 +7514,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 176,
               "total_sequences": 1724,
@@ -7311,7 +7546,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 149,
               "total_sequences": 2707,
@@ -7342,7 +7578,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 346,
               "total_sequences": 7265,
@@ -7373,7 +7610,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 788,
               "total_sequences": 13152,
@@ -7404,7 +7642,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1223,
               "total_sequences": 14067,
@@ -7435,7 +7674,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 1530,
               "total_sequences": 8995,
@@ -7466,7 +7706,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 1555,
               "total_sequences": 7230,
@@ -7497,7 +7738,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1236,
               "total_sequences": 8048,
@@ -7528,7 +7770,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 933,
               "total_sequences": 6832,
@@ -7559,7 +7802,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 873,
               "total_sequences": 7122,
@@ -7590,7 +7834,8 @@
                 "21K (Omicron)": 4,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1008,
               "total_sequences": 7015,
@@ -7621,7 +7866,8 @@
                 "21K (Omicron)": 182,
                 "21L (Omicron)": 1,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 1326,
               "total_sequences": 12922,
@@ -7652,7 +7898,8 @@
                 "21K (Omicron)": 3699,
                 "21L (Omicron)": 1,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 4990,
               "total_sequences": 14666,
@@ -7683,7 +7930,8 @@
                 "21K (Omicron)": 13008,
                 "21L (Omicron)": 107,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 13728,
               "total_sequences": 14356,
@@ -7714,7 +7962,8 @@
                 "21K (Omicron)": 9418,
                 "21L (Omicron)": 398,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 9999,
               "total_sequences": 10220,
@@ -7745,7 +7994,8 @@
                 "21K (Omicron)": 4856,
                 "21L (Omicron)": 471,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 5350,
               "total_sequences": 10300,
@@ -7776,7 +8026,8 @@
                 "21K (Omicron)": 2590,
                 "21L (Omicron)": 400,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2994,
               "total_sequences": 7803,
@@ -7807,14 +8058,15 @@
                 "21K (Omicron)": 1691,
                 "21L (Omicron)": 509,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 2202,
               "total_sequences": 5645,
               "week": "2022-02-21"
             },
             {
-              "percent_total_cases": 0.0771735447084997,
+              "percent_total_cases": 0.07718827810764221,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -7836,16 +8088,17 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 1058,
-                "21L (Omicron)": 724,
+                "21L (Omicron)": 723,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 1782,
-              "total_sequences": 5238,
+              "total_sequences": 5239,
               "week": "2022-03-07"
             },
             {
-              "percent_total_cases": 0.03951914840373825,
+              "percent_total_cases": 0.04310917333179338,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -7866,17 +8119,18 @@
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 959,
-                "21L (Omicron)": 1769,
+                "21K (Omicron)": 975,
+                "21L (Omicron)": 1752,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 2729,
-              "total_sequences": 4106,
+              "total_sequences": 4479,
               "week": "2022-03-21"
             },
             {
-              "percent_total_cases": 0.0013326521999866734,
+              "percent_total_cases": 0.0024580029466420867,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -7897,13 +8151,14 @@
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 532,
-                "21L (Omicron)": 2996,
+                "21K (Omicron)": 534,
+                "21L (Omicron)": 3003,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 11
               },
               "stand_total_cases": 3548,
-              "total_sequences": 180,
+              "total_sequences": 332,
               "week": "2022-04-04"
             }
           ]
@@ -7935,7 +8190,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 19
               },
               "stand_total_cases": 19,
               "total_sequences": 421,
@@ -7965,7 +8221,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 4,
               "total_sequences": 117,
@@ -7995,7 +8252,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 4,
               "total_sequences": 146,
@@ -8025,7 +8283,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 5
               },
               "stand_total_cases": 5,
               "total_sequences": 190,
@@ -8055,7 +8314,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 14
               },
               "stand_total_cases": 14,
               "total_sequences": 390,
@@ -8085,7 +8345,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 44
               },
               "stand_total_cases": 44,
               "total_sequences": 806,
@@ -8115,7 +8376,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 109
               },
               "stand_total_cases": 109,
               "total_sequences": 1920,
@@ -8145,7 +8407,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 134
               },
               "stand_total_cases": 134,
               "total_sequences": 2167,
@@ -8175,7 +8438,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 94
               },
               "stand_total_cases": 94,
               "total_sequences": 1498,
@@ -8205,7 +8469,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 61
               },
               "stand_total_cases": 61,
               "total_sequences": 788,
@@ -8235,7 +8500,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 51
               },
               "stand_total_cases": 51,
               "total_sequences": 535,
@@ -8265,7 +8531,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 56
               },
               "stand_total_cases": 56,
               "total_sequences": 560,
@@ -8295,7 +8562,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 61
               },
               "stand_total_cases": 61,
               "total_sequences": 700,
@@ -8325,7 +8593,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 89
               },
               "stand_total_cases": 89,
               "total_sequences": 836,
@@ -8355,7 +8624,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 194
               },
               "stand_total_cases": 194,
               "total_sequences": 1843,
@@ -8385,7 +8655,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 236
               },
               "stand_total_cases": 236,
               "total_sequences": 2030,
@@ -8415,7 +8686,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 287
               },
               "stand_total_cases": 288,
               "total_sequences": 2336,
@@ -8445,7 +8717,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 1
+                "S:677H.Robin1": 1,
+                "Unknown": 704
               },
               "stand_total_cases": 714,
               "total_sequences": 4997,
@@ -8475,7 +8748,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 604
               },
               "stand_total_cases": 613,
               "total_sequences": 3854,
@@ -8505,7 +8779,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 302
               },
               "stand_total_cases": 316,
               "total_sequences": 2503,
@@ -8535,7 +8810,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 140
               },
               "stand_total_cases": 152,
               "total_sequences": 1349,
@@ -8565,7 +8841,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 95
               },
               "stand_total_cases": 113,
               "total_sequences": 1321,
@@ -8595,7 +8872,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 98
               },
               "stand_total_cases": 133,
               "total_sequences": 2208,
@@ -8625,7 +8903,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 100
               },
               "stand_total_cases": 229,
               "total_sequences": 4115,
@@ -8655,7 +8934,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 128
               },
               "stand_total_cases": 389,
               "total_sequences": 5705,
@@ -8685,7 +8965,8 @@
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 72
               },
               "stand_total_cases": 554,
               "total_sequences": 10533,
@@ -8715,7 +8996,8 @@
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 52
               },
               "stand_total_cases": 633,
               "total_sequences": 9747,
@@ -8745,7 +9027,8 @@
                 "21J (Delta)": 5,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 28
               },
               "stand_total_cases": 477,
               "total_sequences": 6109,
@@ -8775,7 +9058,8 @@
                 "21J (Delta)": 6,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 6
               },
               "stand_total_cases": 240,
               "total_sequences": 4322,
@@ -8805,7 +9089,8 @@
                 "21J (Delta)": 17,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 162,
               "total_sequences": 4265,
@@ -8835,7 +9120,8 @@
                 "21J (Delta)": 54,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 198,
               "total_sequences": 5733,
@@ -8865,7 +9151,8 @@
                 "21J (Delta)": 239,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 398,
               "total_sequences": 10226,
@@ -8895,7 +9182,8 @@
                 "21J (Delta)": 1066,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 1290,
               "total_sequences": 17561,
@@ -8925,7 +9213,8 @@
                 "21J (Delta)": 2062,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 2183,
               "total_sequences": 29423,
@@ -8955,7 +9244,8 @@
                 "21J (Delta)": 2088,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 2140,
               "total_sequences": 25137,
@@ -8985,7 +9275,8 @@
                 "21J (Delta)": 801,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 814,
               "total_sequences": 9896,
@@ -9015,7 +9306,8 @@
                 "21J (Delta)": 217,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 220,
               "total_sequences": 2878,
@@ -9045,7 +9337,8 @@
                 "21J (Delta)": 75,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 76,
               "total_sequences": 1222,
@@ -9075,7 +9368,8 @@
                 "21J (Delta)": 31,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 31,
               "total_sequences": 575,
@@ -9105,7 +9399,8 @@
                 "21J (Delta)": 20,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 20,
               "total_sequences": 482,
@@ -9135,7 +9430,8 @@
                 "21J (Delta)": 12,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 12,
               "total_sequences": 309,
@@ -9165,7 +9461,8 @@
                 "21J (Delta)": 11,
                 "21K (Omicron)": 1,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 12,
               "total_sequences": 472,
@@ -9195,7 +9492,8 @@
                 "21J (Delta)": 12,
                 "21K (Omicron)": 7,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 20,
               "total_sequences": 1244,
@@ -9225,14 +9523,15 @@
                 "21J (Delta)": 35,
                 "21K (Omicron)": 228,
                 "21L (Omicron)": 4,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 267,
               "total_sequences": 9553,
               "week": "2021-12-27"
             },
             {
-              "percent_total_cases": 0.061564411735396986,
+              "percent_total_cases": 0.061608160626484124,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:439K": 0,
@@ -9255,14 +9554,15 @@
                 "21J (Delta)": 92,
                 "21K (Omicron)": 3104,
                 "21L (Omicron)": 67,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 3264,
-              "total_sequences": 25330,
+              "total_sequences": 25348,
               "week": "2022-01-10"
             },
             {
-              "percent_total_cases": 0.01101947570828776,
+              "percent_total_cases": 0.011097978336802738,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:439K": 0,
@@ -9282,17 +9582,18 @@
                 "21G (Lambda)": 0,
                 "21H (Mu)": 0,
                 "21I (Delta)": 1,
-                "21J (Delta)": 100,
-                "21K (Omicron)": 8659,
-                "21L (Omicron)": 234,
-                "S:677H.Robin1": 0
+                "21J (Delta)": 99,
+                "21K (Omicron)": 8662,
+                "21L (Omicron)": 232,
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 8994,
-              "total_sequences": 12493,
+              "total_sequences": 12582,
               "week": "2022-01-24"
             },
             {
-              "percent_total_cases": 0.00725297106853499,
+              "percent_total_cases": 0.007508619675292409,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:439K": 0,
@@ -9312,13 +9613,14 @@
                 "21G (Lambda)": 0,
                 "21H (Mu)": 0,
                 "21I (Delta)": 1,
-                "21J (Delta)": 31,
-                "21K (Omicron)": 8822,
-                "21L (Omicron)": 517,
-                "S:677H.Robin1": 0
+                "21J (Delta)": 32,
+                "21K (Omicron)": 8830,
+                "21L (Omicron)": 508,
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 9371,
-              "total_sequences": 8568,
+              "total_sequences": 8870,
               "week": "2022-02-07"
             },
             {
@@ -9345,14 +9647,15 @@
                 "21J (Delta)": 12,
                 "21K (Omicron)": 6038,
                 "21L (Omicron)": 1124,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 7174,
               "total_sequences": 7403,
               "week": "2022-02-21"
             },
             {
-              "percent_total_cases": 0.0056353766655133095,
+              "percent_total_cases": 0.005658065650578285,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:439K": 0,
@@ -9373,16 +9676,17 @@
                 "21H (Mu)": 0,
                 "21I (Delta)": 1,
                 "21J (Delta)": 3,
-                "21K (Omicron)": 3010,
-                "21L (Omicron)": 2579,
-                "S:677H.Robin1": 0
+                "21K (Omicron)": 3009,
+                "21L (Omicron)": 2580,
+                "S:677H.Robin1": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 5594,
-              "total_sequences": 3974,
+              "total_sequences": 3990,
               "week": "2022-03-07"
             },
             {
-              "percent_total_cases": 0.0006796533767778433,
+              "percent_total_cases": 0.0016108451356474864,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:439K": 0,
@@ -9401,18 +9705,19 @@
                 "21F (Iota)": 0,
                 "21G (Lambda)": 0,
                 "21H (Mu)": 0,
-                "21I (Delta)": 0,
+                "21I (Delta)": 5,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 980,
-                "21L (Omicron)": 3782,
-                "S:677H.Robin1": 0
+                "21K (Omicron)": 606,
+                "21L (Omicron)": 4142,
+                "S:677H.Robin1": 0,
+                "Unknown": 9
               },
               "stand_total_cases": 4762,
-              "total_sequences": 408,
+              "total_sequences": 967,
               "week": "2022-03-21"
             },
             {
-              "percent_total_cases": 6.409979294276186e-05,
+              "percent_total_cases": 7.006256437929785e-05,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:439K": 0,
@@ -9433,12 +9738,13 @@
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 1732,
-                "21L (Omicron)": 3589,
-                "S:677H.Robin1": 0
+                "21K (Omicron)": 1585,
+                "21L (Omicron)": 3736,
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 5321,
-              "total_sequences": 43,
+              "total_sequences": 47,
               "week": "2022-04-04"
             }
           ]
@@ -9470,7 +9776,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 785
               },
               "stand_total_cases": 785,
               "total_sequences": 52,
@@ -9500,7 +9807,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 741
               },
               "stand_total_cases": 741,
               "total_sequences": 81,
@@ -9530,7 +9838,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1014
               },
               "stand_total_cases": 1014,
               "total_sequences": 83,
@@ -9560,7 +9869,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1400
               },
               "stand_total_cases": 1400,
               "total_sequences": 36,
@@ -9590,7 +9900,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1157
               },
               "stand_total_cases": 1157,
               "total_sequences": 43,
@@ -9620,7 +9931,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 361
               },
               "stand_total_cases": 380,
               "total_sequences": 40,
@@ -9650,7 +9962,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 226
               },
               "stand_total_cases": 282,
               "total_sequences": 15,
@@ -9680,7 +9993,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 341
               },
               "stand_total_cases": 400,
               "total_sequences": 41,
@@ -9710,7 +10024,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 118
               },
               "stand_total_cases": 243,
               "total_sequences": 43,
@@ -9740,7 +10055,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 72
               },
               "stand_total_cases": 250,
               "total_sequences": 38,
@@ -9770,7 +10086,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 177
               },
               "stand_total_cases": 434,
               "total_sequences": 54,
@@ -9800,7 +10117,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 330
               },
               "stand_total_cases": 740,
               "total_sequences": 45,
@@ -9830,7 +10148,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 500
               },
               "stand_total_cases": 1195,
               "total_sequences": 43,
@@ -9860,7 +10179,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 940
               },
               "stand_total_cases": 3530,
               "total_sequences": 124,
@@ -9890,7 +10210,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 994
               },
               "stand_total_cases": 6085,
               "total_sequences": 104,
@@ -9920,7 +10241,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1389
               },
               "stand_total_cases": 6950,
               "total_sequences": 145,
@@ -9950,7 +10272,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1212
               },
               "stand_total_cases": 8681,
               "total_sequences": 172,
@@ -9980,7 +10303,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1099
               },
               "stand_total_cases": 12042,
               "total_sequences": 822,
@@ -10010,7 +10334,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 3,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 530
               },
               "stand_total_cases": 5678,
               "total_sequences": 2186,
@@ -10040,7 +10365,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 385
               },
               "stand_total_cases": 4025,
               "total_sequences": 5503,
@@ -10070,7 +10396,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 200
               },
               "stand_total_cases": 4242,
               "total_sequences": 9224,
@@ -10100,7 +10427,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 110
               },
               "stand_total_cases": 5294,
               "total_sequences": 11195,
@@ -10130,7 +10458,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 54
               },
               "stand_total_cases": 5837,
               "total_sequences": 13232,
@@ -10160,7 +10489,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 59
               },
               "stand_total_cases": 6783,
               "total_sequences": 10161,
@@ -10190,7 +10520,8 @@
                 "21I (Delta)": 2,
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 67
               },
               "stand_total_cases": 8557,
               "total_sequences": 7247,
@@ -10220,7 +10551,8 @@
                 "21I (Delta)": 6,
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 58
               },
               "stand_total_cases": 7230,
               "total_sequences": 6545,
@@ -10250,7 +10582,8 @@
                 "21I (Delta)": 15,
                 "21J (Delta)": 10,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 31
               },
               "stand_total_cases": 6252,
               "total_sequences": 6880,
@@ -10280,7 +10613,8 @@
                 "21I (Delta)": 42,
                 "21J (Delta)": 19,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 20
               },
               "stand_total_cases": 3085,
               "total_sequences": 5141,
@@ -10310,7 +10644,8 @@
                 "21I (Delta)": 202,
                 "21J (Delta)": 92,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 12
               },
               "stand_total_cases": 1474,
               "total_sequences": 3745,
@@ -10340,7 +10675,8 @@
                 "21I (Delta)": 114,
                 "21J (Delta)": 71,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 535,
               "total_sequences": 3240,
@@ -10370,7 +10706,8 @@
                 "21I (Delta)": 85,
                 "21J (Delta)": 158,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 358,
               "total_sequences": 2103,
@@ -10400,7 +10737,8 @@
                 "21I (Delta)": 93,
                 "21J (Delta)": 300,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 419,
               "total_sequences": 3215,
@@ -10430,7 +10768,8 @@
                 "21I (Delta)": 161,
                 "21J (Delta)": 585,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 761,
               "total_sequences": 4426,
@@ -10460,7 +10799,8 @@
                 "21I (Delta)": 183,
                 "21J (Delta)": 984,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 1185,
               "total_sequences": 5932,
@@ -10490,7 +10830,8 @@
                 "21I (Delta)": 170,
                 "21J (Delta)": 1184,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 1372,
               "total_sequences": 4689,
@@ -10520,7 +10861,8 @@
                 "21I (Delta)": 143,
                 "21J (Delta)": 1269,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 1422,
               "total_sequences": 3902,
@@ -10550,7 +10892,8 @@
                 "21I (Delta)": 76,
                 "21J (Delta)": 775,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 853,
               "total_sequences": 3172,
@@ -10580,7 +10923,8 @@
                 "21I (Delta)": 97,
                 "21J (Delta)": 717,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 814,
               "total_sequences": 2629,
@@ -10610,7 +10954,8 @@
                 "21I (Delta)": 96,
                 "21J (Delta)": 845,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 942,
               "total_sequences": 4664,
@@ -10640,7 +10985,8 @@
                 "21I (Delta)": 77,
                 "21J (Delta)": 1001,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1078,
               "total_sequences": 4632,
@@ -10670,7 +11016,8 @@
                 "21I (Delta)": 77,
                 "21J (Delta)": 1531,
                 "21K (Omicron)": 1,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 1611,
               "total_sequences": 4140,
@@ -10700,7 +11047,8 @@
                 "21I (Delta)": 155,
                 "21J (Delta)": 2709,
                 "21K (Omicron)": 123,
-                "21L (Omicron)": 1
+                "21L (Omicron)": 1,
+                "Unknown": 1
               },
               "stand_total_cases": 2989,
               "total_sequences": 5625,
@@ -10730,7 +11078,8 @@
                 "21I (Delta)": 125,
                 "21J (Delta)": 2618,
                 "21K (Omicron)": 1503,
-                "21L (Omicron)": 94
+                "21L (Omicron)": 94,
+                "Unknown": 0
               },
               "stand_total_cases": 4340,
               "total_sequences": 6027,
@@ -10760,7 +11109,8 @@
                 "21I (Delta)": 72,
                 "21J (Delta)": 2432,
                 "21K (Omicron)": 10022,
-                "21L (Omicron)": 1581
+                "21L (Omicron)": 1581,
+                "Unknown": 0
               },
               "stand_total_cases": 14107,
               "total_sequences": 5266,
@@ -10790,7 +11140,8 @@
                 "21I (Delta)": 24,
                 "21J (Delta)": 941,
                 "21K (Omicron)": 22685,
-                "21L (Omicron)": 12501
+                "21L (Omicron)": 12501,
+                "Unknown": 5
               },
               "stand_total_cases": 36156,
               "total_sequences": 6071,
@@ -10820,7 +11171,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 161,
                 "21K (Omicron)": 19663,
-                "21L (Omicron)": 29732
+                "21L (Omicron)": 29732,
+                "Unknown": 27
               },
               "stand_total_cases": 49583,
               "total_sequences": 7391,
@@ -10850,7 +11202,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 2,
                 "21K (Omicron)": 3140,
-                "21L (Omicron)": 10150
+                "21L (Omicron)": 10150,
+                "Unknown": 2
               },
               "stand_total_cases": 13294,
               "total_sequences": 5907,
@@ -10880,7 +11233,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 1,
                 "21K (Omicron)": 398,
-                "21L (Omicron)": 2858
+                "21L (Omicron)": 2858,
+                "Unknown": 1
               },
               "stand_total_cases": 3258,
               "total_sequences": 5496,
@@ -10910,14 +11264,15 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 93,
-                "21L (Omicron)": 1844
+                "21L (Omicron)": 1844,
+                "Unknown": 4
               },
               "stand_total_cases": 1941,
               "total_sequences": 4631,
               "week": "2022-03-07"
             },
             {
-              "percent_total_cases": 0.20657624332100288,
+              "percent_total_cases": 0.20764488286066585,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -10940,11 +11295,43 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 20,
-                "21L (Omicron)": 1172
+                "21L (Omicron)": 1172,
+                "Unknown": 5
               },
               "stand_total_cases": 1197,
-              "total_sequences": 2513,
+              "total_sequences": 2526,
               "week": "2022-03-21"
+            },
+            {
+              "percent_total_cases": 0.01829567779960707,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:1122L": 0,
+                "20B/S:626S": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21G (Lambda)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 11,
+                "21L (Omicron)": 785,
+                "Unknown": 5
+              },
+              "stand_total_cases": 801,
+              "total_sequences": 149,
+              "week": "2022-04-04"
             }
           ]
         },
@@ -10975,7 +11362,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 142
               },
               "stand_total_cases": 142,
               "total_sequences": 60,
@@ -11005,7 +11393,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 49
               },
               "stand_total_cases": 49,
               "total_sequences": 13,
@@ -11035,7 +11424,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 26
               },
               "stand_total_cases": 26,
               "total_sequences": 19,
@@ -11065,7 +11455,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 37
               },
               "stand_total_cases": 37,
               "total_sequences": 20,
@@ -11095,7 +11486,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 111
               },
               "stand_total_cases": 111,
               "total_sequences": 65,
@@ -11125,7 +11517,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 150
               },
               "stand_total_cases": 151,
               "total_sequences": 144,
@@ -11155,7 +11548,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 198
               },
               "stand_total_cases": 224,
               "total_sequences": 120,
@@ -11185,7 +11579,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 205
               },
               "stand_total_cases": 295,
               "total_sequences": 151,
@@ -11215,7 +11610,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 202
               },
               "stand_total_cases": 446,
               "total_sequences": 231,
@@ -11245,7 +11641,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 191
               },
               "stand_total_cases": 592,
               "total_sequences": 267,
@@ -11275,7 +11672,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 239
               },
               "stand_total_cases": 537,
               "total_sequences": 45,
@@ -11305,7 +11703,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 374
               },
               "stand_total_cases": 975,
               "total_sequences": 392,
@@ -11335,7 +11734,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1524
               },
               "stand_total_cases": 4966,
               "total_sequences": 948,
@@ -11365,7 +11765,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 3132
               },
               "stand_total_cases": 12421,
               "total_sequences": 1491,
@@ -11395,7 +11796,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2762
               },
               "stand_total_cases": 9028,
               "total_sequences": 1517,
@@ -11425,7 +11827,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1917
               },
               "stand_total_cases": 6183,
               "total_sequences": 1219,
@@ -11455,7 +11858,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1673
               },
               "stand_total_cases": 6826,
               "total_sequences": 2027,
@@ -11485,7 +11889,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1618
               },
               "stand_total_cases": 8489,
               "total_sequences": 4187,
@@ -11515,7 +11920,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 706
               },
               "stand_total_cases": 3590,
               "total_sequences": 3095,
@@ -11545,7 +11951,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 382
               },
               "stand_total_cases": 2592,
               "total_sequences": 2875,
@@ -11575,7 +11982,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 220
               },
               "stand_total_cases": 1824,
               "total_sequences": 1745,
@@ -11605,7 +12013,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 133
               },
               "stand_total_cases": 1665,
               "total_sequences": 1866,
@@ -11635,7 +12044,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 118
               },
               "stand_total_cases": 2101,
               "total_sequences": 2440,
@@ -11665,7 +12075,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 99
               },
               "stand_total_cases": 2837,
               "total_sequences": 2428,
@@ -11695,7 +12106,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 88
               },
               "stand_total_cases": 3104,
               "total_sequences": 3092,
@@ -11725,7 +12137,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 10,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 82
               },
               "stand_total_cases": 3163,
               "total_sequences": 3853,
@@ -11755,7 +12168,8 @@
                 "21I (Delta)": 3,
                 "21J (Delta)": 14,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 76
               },
               "stand_total_cases": 2241,
               "total_sequences": 2742,
@@ -11785,7 +12199,8 @@
                 "21I (Delta)": 4,
                 "21J (Delta)": 34,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 59
               },
               "stand_total_cases": 1550,
               "total_sequences": 2122,
@@ -11815,7 +12230,8 @@
                 "21I (Delta)": 10,
                 "21J (Delta)": 66,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 27
               },
               "stand_total_cases": 806,
               "total_sequences": 1068,
@@ -11845,7 +12261,8 @@
                 "21I (Delta)": 11,
                 "21J (Delta)": 58,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 7
               },
               "stand_total_cases": 281,
               "total_sequences": 452,
@@ -11875,7 +12292,8 @@
                 "21I (Delta)": 25,
                 "21J (Delta)": 192,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 279,
               "total_sequences": 920,
@@ -11905,7 +12323,8 @@
                 "21I (Delta)": 91,
                 "21J (Delta)": 750,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 5
               },
               "stand_total_cases": 886,
               "total_sequences": 2831,
@@ -11935,7 +12354,8 @@
                 "21I (Delta)": 124,
                 "21J (Delta)": 1120,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 16
               },
               "stand_total_cases": 1296,
               "total_sequences": 4482,
@@ -11965,7 +12385,8 @@
                 "21I (Delta)": 255,
                 "21J (Delta)": 2995,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 3303,
               "total_sequences": 6246,
@@ -11995,7 +12416,8 @@
                 "21I (Delta)": 238,
                 "21J (Delta)": 3511,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 3778,
               "total_sequences": 4062,
@@ -12025,7 +12447,8 @@
                 "21I (Delta)": 220,
                 "21J (Delta)": 4042,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 4289,
               "total_sequences": 4139,
@@ -12055,7 +12478,8 @@
                 "21I (Delta)": 77,
                 "21J (Delta)": 2032,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2122,
               "total_sequences": 3513,
@@ -12085,7 +12509,8 @@
                 "21I (Delta)": 58,
                 "21J (Delta)": 1429,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1493,
               "total_sequences": 3057,
@@ -12115,7 +12540,8 @@
                 "21I (Delta)": 65,
                 "21J (Delta)": 1981,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2061,
               "total_sequences": 4657,
@@ -12145,7 +12571,8 @@
                 "21I (Delta)": 102,
                 "21J (Delta)": 4065,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 4185,
               "total_sequences": 6044,
@@ -12175,7 +12602,8 @@
                 "21I (Delta)": 202,
                 "21J (Delta)": 8678,
                 "21K (Omicron)": 32,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 8926,
               "total_sequences": 6058,
@@ -12205,7 +12633,8 @@
                 "21I (Delta)": 287,
                 "21J (Delta)": 13356,
                 "21K (Omicron)": 682,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 14352,
               "total_sequences": 5851,
@@ -12235,7 +12664,8 @@
                 "21I (Delta)": 174,
                 "21J (Delta)": 7863,
                 "21K (Omicron)": 5187,
-                "21L (Omicron)": 3
+                "21L (Omicron)": 3,
+                "Unknown": 6
               },
               "stand_total_cases": 13249,
               "total_sequences": 5109,
@@ -12265,7 +12695,8 @@
                 "21I (Delta)": 131,
                 "21J (Delta)": 5664,
                 "21K (Omicron)": 23491,
-                "21L (Omicron)": 65
+                "21L (Omicron)": 65,
+                "Unknown": 0
               },
               "stand_total_cases": 29351,
               "total_sequences": 4488,
@@ -12295,7 +12726,8 @@
                 "21I (Delta)": 36,
                 "21J (Delta)": 1856,
                 "21K (Omicron)": 43059,
-                "21L (Omicron)": 497
+                "21L (Omicron)": 497,
+                "Unknown": 0
               },
               "stand_total_cases": 45448,
               "total_sequences": 5117,
@@ -12325,7 +12757,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 581,
                 "21K (Omicron)": 51206,
-                "21L (Omicron)": 3894
+                "21L (Omicron)": 3894,
+                "Unknown": 0
               },
               "stand_total_cases": 55681,
               "total_sequences": 4790,
@@ -12355,7 +12788,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 105,
                 "21K (Omicron)": 25685,
-                "21L (Omicron)": 8576
+                "21L (Omicron)": 8576,
+                "Unknown": 7
               },
               "stand_total_cases": 34373,
               "total_sequences": 4894,
@@ -12385,7 +12819,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 20,
                 "21K (Omicron)": 12151,
-                "21L (Omicron)": 13781
+                "21L (Omicron)": 13781,
+                "Unknown": 21
               },
               "stand_total_cases": 25973,
               "total_sequences": 3807,
@@ -12415,14 +12850,15 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 13,
                 "21K (Omicron)": 8421,
-                "21L (Omicron)": 34941
+                "21L (Omicron)": 34941,
+                "Unknown": 40
               },
               "stand_total_cases": 43415,
               "total_sequences": 3248,
               "week": "2022-03-07"
             },
             {
-              "percent_total_cases": 0.007849603114668815,
+              "percent_total_cases": 0.0095025927604088,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -12443,16 +12879,17 @@
                 "21G (Lambda)": 0,
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 15,
-                "21K (Omicron)": 2163,
-                "21L (Omicron)": 25082
+                "21J (Delta)": 12,
+                "21K (Omicron)": 2053,
+                "21L (Omicron)": 25187,
+                "Unknown": 96
               },
               "stand_total_cases": 27348,
-              "total_sequences": 1871,
+              "total_sequences": 2265,
               "week": "2022-03-21"
             },
             {
-              "percent_total_cases": 0.0022672777986200597,
+              "percent_total_cases": 0.0048934053207627184,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -12474,11 +12911,12 @@
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 202,
-                "21L (Omicron)": 6832
+                "21K (Omicron)": 211,
+                "21L (Omicron)": 6823,
+                "Unknown": 0
               },
               "stand_total_cases": 7034,
-              "total_sequences": 139,
+              "total_sequences": 300,
               "week": "2022-04-04"
             }
           ]
@@ -12511,7 +12949,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 264
               },
               "stand_total_cases": 264,
               "total_sequences": 172,
@@ -12542,7 +12981,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 154
               },
               "stand_total_cases": 154,
               "total_sequences": 226,
@@ -12573,7 +13013,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 133
               },
               "stand_total_cases": 133,
               "total_sequences": 107,
@@ -12604,7 +13045,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 103
               },
               "stand_total_cases": 111,
               "total_sequences": 78,
@@ -12635,7 +13077,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 58
               },
               "stand_total_cases": 58,
               "total_sequences": 76,
@@ -12666,7 +13109,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 65
               },
               "stand_total_cases": 73,
               "total_sequences": 41,
@@ -12697,7 +13141,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 202
               },
               "stand_total_cases": 211,
               "total_sequences": 85,
@@ -12728,7 +13173,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 415
               },
               "stand_total_cases": 476,
               "total_sequences": 108,
@@ -12759,7 +13205,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 212
               },
               "stand_total_cases": 426,
               "total_sequences": 95,
@@ -12790,7 +13237,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 291
               },
               "stand_total_cases": 746,
               "total_sequences": 95,
@@ -12821,7 +13269,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 377
               },
               "stand_total_cases": 1818,
               "total_sequences": 251,
@@ -12852,7 +13301,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 579
               },
               "stand_total_cases": 3902,
               "total_sequences": 283,
@@ -12883,7 +13333,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 1090
               },
               "stand_total_cases": 6997,
               "total_sequences": 417,
@@ -12914,7 +13365,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 792
               },
               "stand_total_cases": 6594,
               "total_sequences": 408,
@@ -12945,7 +13397,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 343
               },
               "stand_total_cases": 4378,
               "total_sequences": 433,
@@ -12976,7 +13429,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 300
               },
               "stand_total_cases": 4344,
               "total_sequences": 536,
@@ -13007,7 +13461,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 259
               },
               "stand_total_cases": 7964,
               "total_sequences": 826,
@@ -13038,7 +13493,8 @@
                 "21J (Delta)": 16,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 440
               },
               "stand_total_cases": 10342,
               "total_sequences": 1929,
@@ -13069,7 +13525,8 @@
                 "21J (Delta)": 35,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 169
               },
               "stand_total_cases": 4360,
               "total_sequences": 1740,
@@ -13100,7 +13557,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 153
               },
               "stand_total_cases": 3214,
               "total_sequences": 2247,
@@ -13131,7 +13589,8 @@
                 "21J (Delta)": 15,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 1
+                "S:677H.Robin1": 1,
+                "Unknown": 96
               },
               "stand_total_cases": 3081,
               "total_sequences": 2402,
@@ -13162,7 +13621,8 @@
                 "21J (Delta)": 5,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 35
               },
               "stand_total_cases": 3676,
               "total_sequences": 3153,
@@ -13193,7 +13653,8 @@
                 "21J (Delta)": 15,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 41
               },
               "stand_total_cases": 4887,
               "total_sequences": 4027,
@@ -13224,7 +13685,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 31
               },
               "stand_total_cases": 5806,
               "total_sequences": 3842,
@@ -13255,7 +13717,8 @@
                 "21J (Delta)": 32,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 10
               },
               "stand_total_cases": 6029,
               "total_sequences": 3594,
@@ -13286,7 +13749,8 @@
                 "21J (Delta)": 16,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 15
               },
               "stand_total_cases": 6165,
               "total_sequences": 3926,
@@ -13317,7 +13781,8 @@
                 "21J (Delta)": 28,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 6
               },
               "stand_total_cases": 4905,
               "total_sequences": 3482,
@@ -13348,7 +13813,8 @@
                 "21J (Delta)": 28,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 11
               },
               "stand_total_cases": 2829,
               "total_sequences": 2964,
@@ -13379,7 +13845,8 @@
                 "21J (Delta)": 90,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 14
               },
               "stand_total_cases": 1411,
               "total_sequences": 2622,
@@ -13410,7 +13877,8 @@
                 "21J (Delta)": 134,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 7
               },
               "stand_total_cases": 600,
               "total_sequences": 1903,
@@ -13441,7 +13909,8 @@
                 "21J (Delta)": 1360,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 18
               },
               "stand_total_cases": 3091,
               "total_sequences": 3553,
@@ -13472,7 +13941,8 @@
                 "21J (Delta)": 3469,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 6438,
               "total_sequences": 4831,
@@ -13503,7 +13973,8 @@
                 "21J (Delta)": 1500,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 2370,
               "total_sequences": 3150,
@@ -13534,7 +14005,8 @@
                 "21J (Delta)": 1403,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 1966,
               "total_sequences": 3160,
@@ -13565,7 +14037,8 @@
                 "21J (Delta)": 1621,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2074,
               "total_sequences": 3443,
@@ -13596,7 +14069,8 @@
                 "21J (Delta)": 1404,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1756,
               "total_sequences": 2736,
@@ -13627,7 +14101,8 @@
                 "21J (Delta)": 1125,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1376,
               "total_sequences": 2360,
@@ -13658,14 +14133,15 @@
                 "21J (Delta)": 2068,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 2418,
               "total_sequences": 2861,
               "week": "2021-10-04"
             },
             {
-              "percent_total_cases": 0.03683042003358465,
+              "percent_total_cases": 0.036841690051954784,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -13689,14 +14165,15 @@
                 "21J (Delta)": 4453,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 5166,
-              "total_sequences": 3268,
+              "total_sequences": 3269,
               "week": "2021-10-18"
             },
             {
-              "percent_total_cases": 0.02147815528419895,
+              "percent_total_cases": 0.021501065316502095,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -13716,14 +14193,15 @@
                 "21F (Iota)": 0,
                 "21G (Lambda)": 0,
                 "21H (Mu)": 0,
-                "21I (Delta)": 1093,
-                "21J (Delta)": 9068,
+                "21I (Delta)": 1094,
+                "21J (Delta)": 9067,
                 "21K (Omicron)": 3,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 10166,
-              "total_sequences": 3750,
+              "total_sequences": 3754,
               "week": "2021-11-01"
             },
             {
@@ -13751,7 +14229,8 @@
                 "21J (Delta)": 15995,
                 "21K (Omicron)": 309,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 17862,
               "total_sequences": 3933,
@@ -13782,7 +14261,8 @@
                 "21J (Delta)": 14085,
                 "21K (Omicron)": 871,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 15911,
               "total_sequences": 4166,
@@ -13813,7 +14293,8 @@
                 "21J (Delta)": 7251,
                 "21K (Omicron)": 2931,
                 "21L (Omicron)": 5,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 10619,
               "total_sequences": 4036,
@@ -13844,7 +14325,8 @@
                 "21J (Delta)": 3944,
                 "21K (Omicron)": 13058,
                 "21L (Omicron)": 79,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 17266,
               "total_sequences": 3927,
@@ -13875,7 +14357,8 @@
                 "21J (Delta)": 1222,
                 "21K (Omicron)": 31546,
                 "21L (Omicron)": 1294,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 34102,
               "total_sequences": 4243,
@@ -13906,7 +14389,8 @@
                 "21J (Delta)": 515,
                 "21K (Omicron)": 50749,
                 "21L (Omicron)": 7846,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 16
               },
               "stand_total_cases": 59143,
               "total_sequences": 3558,
@@ -13937,7 +14421,8 @@
                 "21J (Delta)": 41,
                 "21K (Omicron)": 46625,
                 "21L (Omicron)": 20180,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 20
               },
               "stand_total_cases": 66907,
               "total_sequences": 3289,
@@ -13968,7 +14453,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 15080,
                 "21L (Omicron)": 23974,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 125
               },
               "stand_total_cases": 39179,
               "total_sequences": 3110,
@@ -13999,7 +14485,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 7668,
                 "21L (Omicron)": 39040,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 124
               },
               "stand_total_cases": 46832,
               "total_sequences": 3023,
@@ -14030,14 +14517,15 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 1542,
                 "21L (Omicron)": 21602,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 92
               },
               "stand_total_cases": 23236,
               "total_sequences": 2019,
               "week": "2022-03-21"
             },
             {
-              "percent_total_cases": 0.0004459203036053131,
+              "percent_total_cases": 0.0011005692599620493,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -14059,12 +14547,13 @@
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 653,
-                "21L (Omicron)": 5484,
-                "S:677H.Robin1": 0
+                "21K (Omicron)": 317,
+                "21L (Omicron)": 5820,
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 6137,
-              "total_sequences": 47,
+              "total_sequences": 116,
               "week": "2022-04-04"
             }
           ]
@@ -14095,7 +14584,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 597
               },
               "stand_total_cases": 597,
               "total_sequences": 134,
@@ -14124,7 +14614,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 344
               },
               "stand_total_cases": 344,
               "total_sequences": 67,
@@ -14153,7 +14644,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 183
               },
               "stand_total_cases": 183,
               "total_sequences": 15,
@@ -14182,7 +14674,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 113
               },
               "stand_total_cases": 113,
               "total_sequences": 38,
@@ -14211,7 +14704,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 123
               },
               "stand_total_cases": 126,
               "total_sequences": 39,
@@ -14240,7 +14734,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 130
               },
               "stand_total_cases": 145,
               "total_sequences": 39,
@@ -14269,7 +14764,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 342
               },
               "stand_total_cases": 528,
               "total_sequences": 146,
@@ -14298,7 +14794,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 424
               },
               "stand_total_cases": 728,
               "total_sequences": 129,
@@ -14327,7 +14824,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 193
               },
               "stand_total_cases": 577,
               "total_sequences": 54,
@@ -14356,7 +14854,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 308
               },
               "stand_total_cases": 723,
               "total_sequences": 87,
@@ -14385,7 +14884,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 695
               },
               "stand_total_cases": 1781,
               "total_sequences": 246,
@@ -14414,7 +14914,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 731
               },
               "stand_total_cases": 4133,
               "total_sequences": 130,
@@ -14443,7 +14944,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1830
               },
               "stand_total_cases": 13649,
               "total_sequences": 358,
@@ -14472,7 +14974,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2198
               },
               "stand_total_cases": 15453,
               "total_sequences": 218,
@@ -14501,7 +15004,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 411
               },
               "stand_total_cases": 4985,
               "total_sequences": 243,
@@ -14530,7 +15034,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 321
               },
               "stand_total_cases": 2834,
               "total_sequences": 150,
@@ -14559,7 +15064,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1413
               },
               "stand_total_cases": 2937,
               "total_sequences": 343,
@@ -14588,7 +15094,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 513
               },
               "stand_total_cases": 3295,
               "total_sequences": 527,
@@ -14617,7 +15124,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 215
               },
               "stand_total_cases": 2527,
               "total_sequences": 1324,
@@ -14646,7 +15154,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 2,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 261
               },
               "stand_total_cases": 2746,
               "total_sequences": 1758,
@@ -14675,7 +15184,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 274
               },
               "stand_total_cases": 2481,
               "total_sequences": 1752,
@@ -14704,7 +15214,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 294
               },
               "stand_total_cases": 2872,
               "total_sequences": 2188,
@@ -14733,14 +15244,15 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 327
               },
               "stand_total_cases": 4222,
               "total_sequences": 2875,
               "week": "2021-03-08"
             },
             {
-              "percent_total_cases": 0.05293014533520863,
+              "percent_total_cases": 0.05294577277699641,
               "stand_estimated_cases": {
                 "20A.EU2": 39,
                 "20A/S:126A": 8,
@@ -14762,10 +15274,11 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 314
               },
               "stand_total_cases": 5501,
-              "total_sequences": 3387,
+              "total_sequences": 3388,
               "week": "2021-03-22"
             },
             {
@@ -14791,7 +15304,8 @@
                 "21I (Delta)": 4,
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 183
               },
               "stand_total_cases": 4212,
               "total_sequences": 2887,
@@ -14820,7 +15334,8 @@
                 "21I (Delta)": 41,
                 "21J (Delta)": 56,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 192
               },
               "stand_total_cases": 3917,
               "total_sequences": 3272,
@@ -14849,7 +15364,8 @@
                 "21I (Delta)": 30,
                 "21J (Delta)": 18,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 95
               },
               "stand_total_cases": 3125,
               "total_sequences": 3048,
@@ -14878,7 +15394,8 @@
                 "21I (Delta)": 51,
                 "21J (Delta)": 98,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 64
               },
               "stand_total_cases": 2516,
               "total_sequences": 2922,
@@ -14907,7 +15424,8 @@
                 "21I (Delta)": 90,
                 "21J (Delta)": 58,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 17
               },
               "stand_total_cases": 1301,
               "total_sequences": 1959,
@@ -14936,7 +15454,8 @@
                 "21I (Delta)": 73,
                 "21J (Delta)": 107,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 6
               },
               "stand_total_cases": 527,
               "total_sequences": 1148,
@@ -14965,7 +15484,8 @@
                 "21I (Delta)": 172,
                 "21J (Delta)": 521,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 10
               },
               "stand_total_cases": 964,
               "total_sequences": 2538,
@@ -14994,7 +15514,8 @@
                 "21I (Delta)": 374,
                 "21J (Delta)": 1133,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 1699,
               "total_sequences": 3788,
@@ -15023,7 +15544,8 @@
                 "21I (Delta)": 343,
                 "21J (Delta)": 1566,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 1999,
               "total_sequences": 3929,
@@ -15052,7 +15574,8 @@
                 "21I (Delta)": 308,
                 "21J (Delta)": 1958,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2321,
               "total_sequences": 4496,
@@ -15081,7 +15604,8 @@
                 "21I (Delta)": 294,
                 "21J (Delta)": 2090,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 2431,
               "total_sequences": 4432,
@@ -15110,7 +15634,8 @@
                 "21I (Delta)": 180,
                 "21J (Delta)": 2189,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 2390,
               "total_sequences": 3070,
@@ -15139,7 +15664,8 @@
                 "21I (Delta)": 223,
                 "21J (Delta)": 2127,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2354,
               "total_sequences": 2883,
@@ -15168,7 +15694,8 @@
                 "21I (Delta)": 173,
                 "21J (Delta)": 2631,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2808,
               "total_sequences": 3307,
@@ -15197,7 +15724,8 @@
                 "21I (Delta)": 338,
                 "21J (Delta)": 6600,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 6944,
               "total_sequences": 3799,
@@ -15226,7 +15754,8 @@
                 "21I (Delta)": 397,
                 "21J (Delta)": 10261,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 10665,
               "total_sequences": 3036,
@@ -15255,7 +15784,8 @@
                 "21I (Delta)": 553,
                 "21J (Delta)": 18040,
                 "21K (Omicron)": 35,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 10
               },
               "stand_total_cases": 18648,
               "total_sequences": 3775,
@@ -15284,7 +15814,8 @@
                 "21I (Delta)": 612,
                 "21J (Delta)": 17477,
                 "21K (Omicron)": 1508,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 19612,
               "total_sequences": 4006,
@@ -15313,7 +15844,8 @@
                 "21I (Delta)": 200,
                 "21J (Delta)": 5601,
                 "21K (Omicron)": 3478,
-                "21L (Omicron)": 3
+                "21L (Omicron)": 3,
+                "Unknown": 31
               },
               "stand_total_cases": 9313,
               "total_sequences": 3211,
@@ -15342,7 +15874,8 @@
                 "21I (Delta)": 70,
                 "21J (Delta)": 2630,
                 "21K (Omicron)": 13851,
-                "21L (Omicron)": 70
+                "21L (Omicron)": 70,
+                "Unknown": 15
               },
               "stand_total_cases": 16641,
               "total_sequences": 3543,
@@ -15371,7 +15904,8 @@
                 "21I (Delta)": 10,
                 "21J (Delta)": 830,
                 "21K (Omicron)": 37626,
-                "21L (Omicron)": 1537
+                "21L (Omicron)": 1537,
+                "Unknown": 19
               },
               "stand_total_cases": 40022,
               "total_sequences": 4193,
@@ -15400,7 +15934,8 @@
                 "21I (Delta)": 13,
                 "21J (Delta)": 285,
                 "21K (Omicron)": 46104,
-                "21L (Omicron)": 5062
+                "21L (Omicron)": 5062,
+                "Unknown": 13
               },
               "stand_total_cases": 51477,
               "total_sequences": 3976,
@@ -15429,7 +15964,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 27,
                 "21K (Omicron)": 12238,
-                "21L (Omicron)": 4724
+                "21L (Omicron)": 4724,
+                "Unknown": 48
               },
               "stand_total_cases": 17037,
               "total_sequences": 3181,
@@ -15458,14 +15994,15 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 13,
                 "21K (Omicron)": 3601,
-                "21L (Omicron)": 4256
+                "21L (Omicron)": 4256,
+                "Unknown": 44
               },
               "stand_total_cases": 7914,
               "total_sequences": 2477,
               "week": "2022-02-21"
             },
             {
-              "percent_total_cases": 0.023682886805366583,
+              "percent_total_cases": 0.023757101979895934,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -15485,12 +16022,13 @@
                 "21G (Lambda)": 0,
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 15,
-                "21K (Omicron)": 1601,
-                "21L (Omicron)": 8744
+                "21J (Delta)": 14,
+                "21K (Omicron)": 1603,
+                "21L (Omicron)": 8742,
+                "Unknown": 66
               },
               "stand_total_cases": 10425,
-              "total_sequences": 2872,
+              "total_sequences": 2881,
               "week": "2022-03-07"
             },
             {
@@ -15516,14 +16054,15 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 781,
-                "21L (Omicron)": 11504
+                "21L (Omicron)": 11504,
+                "Unknown": 50
               },
               "stand_total_cases": 12335,
               "total_sequences": 2686,
               "week": "2022-03-21"
             },
             {
-              "percent_total_cases": 0.008817618832793339,
+              "percent_total_cases": 0.009482016158799164,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -15544,11 +16083,12 @@
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 244,
-                "21L (Omicron)": 10168
+                "21K (Omicron)": 236,
+                "21L (Omicron)": 10181,
+                "Unknown": 63
               },
               "stand_total_cases": 10480,
-              "total_sequences": 1075,
+              "total_sequences": 1156,
               "week": "2022-04-04"
             }
           ]
@@ -15578,7 +16118,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 9
               },
               "stand_total_cases": 9,
               "total_sequences": 113,
@@ -15606,7 +16147,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 6
               },
               "stand_total_cases": 6,
               "total_sequences": 81,
@@ -15634,7 +16176,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 5
               },
               "stand_total_cases": 5,
               "total_sequences": 88,
@@ -15662,7 +16205,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 8
               },
               "stand_total_cases": 8,
               "total_sequences": 159,
@@ -15690,7 +16234,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 43
               },
               "stand_total_cases": 43,
               "total_sequences": 807,
@@ -15718,7 +16263,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 135
               },
               "stand_total_cases": 135,
               "total_sequences": 2651,
@@ -15746,7 +16292,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 242
               },
               "stand_total_cases": 242,
               "total_sequences": 3899,
@@ -15774,7 +16321,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 203
               },
               "stand_total_cases": 203,
               "total_sequences": 2392,
@@ -15802,7 +16350,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 84
               },
               "stand_total_cases": 84,
               "total_sequences": 1563,
@@ -15830,7 +16379,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 36
               },
               "stand_total_cases": 36,
               "total_sequences": 643,
@@ -15858,7 +16408,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 13
               },
               "stand_total_cases": 13,
               "total_sequences": 267,
@@ -15886,7 +16437,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 9
               },
               "stand_total_cases": 9,
               "total_sequences": 156,
@@ -15914,7 +16466,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 9
               },
               "stand_total_cases": 9,
               "total_sequences": 108,
@@ -15942,7 +16495,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 5,
               "total_sequences": 58,
@@ -15970,7 +16524,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 6
               },
               "stand_total_cases": 6,
               "total_sequences": 61,
@@ -15998,7 +16553,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 5,
               "total_sequences": 44,
@@ -16026,7 +16582,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 8
               },
               "stand_total_cases": 8,
               "total_sequences": 135,
@@ -16054,7 +16611,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 11
               },
               "stand_total_cases": 16,
               "total_sequences": 247,
@@ -16082,7 +16640,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 6,
               "total_sequences": 89,
@@ -16110,7 +16669,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 3,
               "total_sequences": 46,
@@ -16138,7 +16698,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2,
               "total_sequences": 73,
@@ -16166,7 +16727,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 4,
               "total_sequences": 71,
@@ -16194,7 +16756,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 6,
               "total_sequences": 114,
@@ -16222,7 +16785,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 5,
               "total_sequences": 119,
@@ -16250,7 +16814,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 6,
               "total_sequences": 144,
@@ -16278,7 +16843,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 11,
               "total_sequences": 189,
@@ -16306,7 +16872,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 5,
               "total_sequences": 94,
@@ -16334,7 +16901,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 4,
               "total_sequences": 88,
@@ -16362,7 +16930,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 6,
               "total_sequences": 123,
@@ -16390,7 +16959,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 10,
               "total_sequences": 243,
@@ -16418,7 +16988,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 26,
               "total_sequences": 750,
@@ -16446,7 +17017,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 72,
               "total_sequences": 1691,
@@ -16474,7 +17046,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 137,
               "total_sequences": 2706,
@@ -16502,7 +17075,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 321,
               "total_sequences": 3117,
@@ -16530,7 +17104,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 707,
               "total_sequences": 3506,
@@ -16558,7 +17133,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 929,
               "total_sequences": 3659,
@@ -16586,7 +17162,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1019,
               "total_sequences": 2282,
@@ -16614,7 +17191,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1235,
               "total_sequences": 2414,
@@ -16642,7 +17220,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1037,
               "total_sequences": 1838,
@@ -16670,7 +17249,8 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 720,
               "total_sequences": 2079,
@@ -16698,7 +17278,8 @@
                 "21K (Omicron)": 3,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 718,
               "total_sequences": 1975,
@@ -16726,7 +17307,8 @@
                 "21K (Omicron)": 96,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 838,
               "total_sequences": 3532,
@@ -16754,7 +17336,8 @@
                 "21K (Omicron)": 1629,
                 "21L (Omicron)": 1,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 3090,
               "total_sequences": 4436,
@@ -16782,7 +17365,8 @@
                 "21K (Omicron)": 25721,
                 "21L (Omicron)": 98,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 28494,
               "total_sequences": 4079,
@@ -16810,14 +17394,15 @@
                 "21K (Omicron)": 43184,
                 "21L (Omicron)": 1353,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 45905,
               "total_sequences": 3222,
               "week": "2022-01-10"
             },
             {
-              "percent_total_cases": 0.0048958763055215815,
+              "percent_total_cases": 0.004899510957567255,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:439K": 0,
@@ -16835,13 +17420,14 @@
                 "21G (Lambda)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 87,
-                "21K (Omicron)": 19666,
-                "21L (Omicron)": 1584,
+                "21K (Omicron)": 19659,
+                "21L (Omicron)": 1591,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 21337,
-              "total_sequences": 2694,
+              "total_sequences": 2696,
               "week": "2022-01-24"
             },
             {
@@ -16866,14 +17452,15 @@
                 "21K (Omicron)": 9473,
                 "21L (Omicron)": 2111,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 11591,
               "total_sequences": 3278,
               "week": "2022-02-07"
             },
             {
-              "percent_total_cases": 0.01055880248091603,
+              "percent_total_cases": 0.010573711832061069,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:439K": 0,
@@ -16891,17 +17478,18 @@
                 "21G (Lambda)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 8487,
-                "21L (Omicron)": 4506,
+                "21K (Omicron)": 8482,
+                "21L (Omicron)": 4511,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 11
               },
               "stand_total_cases": 13004,
-              "total_sequences": 3541,
+              "total_sequences": 3546,
               "week": "2022-02-21"
             },
             {
-              "percent_total_cases": 0.008294718242478329,
+              "percent_total_cases": 0.00874182465917078,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:439K": 0,
@@ -16918,18 +17506,19 @@
                 "21F (Iota)": 0,
                 "21G (Lambda)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 5,
-                "21K (Omicron)": 6035,
-                "21L (Omicron)": 15633,
+                "21J (Delta)": 4,
+                "21K (Omicron)": 5891,
+                "21L (Omicron)": 15778,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 9
               },
               "stand_total_cases": 21682,
-              "total_sequences": 4638,
+              "total_sequences": 4888,
               "week": "2022-03-07"
             },
             {
-              "percent_total_cases": 0.0038293372221403434,
+              "percent_total_cases": 0.006881688735129321,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:439K": 0,
@@ -16947,17 +17536,18 @@
                 "21G (Lambda)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 3332,
-                "21L (Omicron)": 26632,
+                "21K (Omicron)": 2806,
+                "21L (Omicron)": 27165,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 23
               },
               "stand_total_cases": 29994,
-              "total_sequences": 2962,
+              "total_sequences": 5323,
               "week": "2022-03-21"
             },
             {
-              "percent_total_cases": 0.0005156332576309437,
+              "percent_total_cases": 0.0007341703446601248,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:439K": 0,
@@ -16975,13 +17565,14 @@
                 "21G (Lambda)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 2106,
-                "21L (Omicron)": 24967,
+                "21K (Omicron)": 1796,
+                "21L (Omicron)": 25299,
                 "S:677H.Robin1": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 53
               },
               "stand_total_cases": 27148,
-              "total_sequences": 361,
+              "total_sequences": 514,
               "week": "2022-04-04"
             }
           ]
@@ -17011,7 +17602,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 749
               },
               "stand_total_cases": 749,
               "total_sequences": 111,
@@ -17039,7 +17631,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 329
               },
               "stand_total_cases": 329,
               "total_sequences": 43,
@@ -17067,7 +17660,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 112
               },
               "stand_total_cases": 112,
               "total_sequences": 8,
@@ -17095,7 +17689,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 35
               },
               "stand_total_cases": 35,
               "total_sequences": 5,
@@ -17123,7 +17718,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 29
               },
               "stand_total_cases": 29,
               "total_sequences": 9,
@@ -17151,7 +17747,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 45
               },
               "stand_total_cases": 46,
               "total_sequences": 31,
@@ -17179,7 +17776,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 17
               },
               "stand_total_cases": 80,
               "total_sequences": 58,
@@ -17207,7 +17805,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 59
               },
               "stand_total_cases": 219,
               "total_sequences": 85,
@@ -17235,7 +17834,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 172
               },
               "stand_total_cases": 301,
               "total_sequences": 21,
@@ -17263,7 +17863,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 96
               },
               "stand_total_cases": 446,
               "total_sequences": 79,
@@ -17291,7 +17892,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 175
               },
               "stand_total_cases": 803,
               "total_sequences": 101,
@@ -17319,7 +17921,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 177
               },
               "stand_total_cases": 1512,
               "total_sequences": 85,
@@ -17347,7 +17950,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 329
               },
               "stand_total_cases": 2930,
               "total_sequences": 98,
@@ -17375,7 +17979,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 80
               },
               "stand_total_cases": 1658,
               "total_sequences": 62,
@@ -17403,7 +18008,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 54
               },
               "stand_total_cases": 1016,
               "total_sequences": 94,
@@ -17431,7 +18037,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 59
               },
               "stand_total_cases": 759,
               "total_sequences": 89,
@@ -17459,7 +18066,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 122
               },
               "stand_total_cases": 1062,
               "total_sequences": 96,
@@ -17487,7 +18095,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 569
               },
               "stand_total_cases": 13660,
               "total_sequences": 336,
@@ -17515,7 +18124,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 480
               },
               "stand_total_cases": 8015,
               "total_sequences": 484,
@@ -17543,7 +18153,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 88
               },
               "stand_total_cases": 3213,
               "total_sequences": 1132,
@@ -17571,7 +18182,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 88
               },
               "stand_total_cases": 2305,
               "total_sequences": 1450,
@@ -17599,7 +18211,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 32
               },
               "stand_total_cases": 1638,
               "total_sequences": 1609,
@@ -17627,7 +18240,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 26
               },
               "stand_total_cases": 1481,
               "total_sequences": 1705,
@@ -17655,7 +18269,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 7,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 41
               },
               "stand_total_cases": 1514,
               "total_sequences": 1360,
@@ -17683,7 +18298,8 @@
                 "21I (Delta)": 2,
                 "21J (Delta)": 3,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 53
               },
               "stand_total_cases": 1075,
               "total_sequences": 1431,
@@ -17711,7 +18327,8 @@
                 "21I (Delta)": 3,
                 "21J (Delta)": 11,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 43
               },
               "stand_total_cases": 1270,
               "total_sequences": 1903,
@@ -17739,7 +18356,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 13,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 31
               },
               "stand_total_cases": 1177,
               "total_sequences": 1405,
@@ -17767,7 +18385,8 @@
                 "21I (Delta)": 2,
                 "21J (Delta)": 10,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 13
               },
               "stand_total_cases": 1197,
               "total_sequences": 2357,
@@ -17795,7 +18414,8 @@
                 "21I (Delta)": 4,
                 "21J (Delta)": 63,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 30
               },
               "stand_total_cases": 1029,
               "total_sequences": 1205,
@@ -17823,7 +18443,8 @@
                 "21I (Delta)": 5,
                 "21J (Delta)": 212,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 894,
               "total_sequences": 1557,
@@ -17851,7 +18472,8 @@
                 "21I (Delta)": 62,
                 "21J (Delta)": 834,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 1335,
               "total_sequences": 1760,
@@ -17879,7 +18501,8 @@
                 "21I (Delta)": 149,
                 "21J (Delta)": 2490,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 8
               },
               "stand_total_cases": 3031,
               "total_sequences": 2644,
@@ -17907,7 +18530,8 @@
                 "21I (Delta)": 240,
                 "21J (Delta)": 3464,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 3907,
               "total_sequences": 2878,
@@ -17935,7 +18559,8 @@
                 "21I (Delta)": 322,
                 "21J (Delta)": 4490,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 4947,
               "total_sequences": 2904,
@@ -17963,7 +18588,8 @@
                 "21I (Delta)": 145,
                 "21J (Delta)": 4114,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 4296,
               "total_sequences": 2200,
@@ -17991,7 +18617,8 @@
                 "21I (Delta)": 144,
                 "21J (Delta)": 3777,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 3958,
               "total_sequences": 2426,
@@ -18019,7 +18646,8 @@
                 "21I (Delta)": 116,
                 "21J (Delta)": 3500,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 3664,
               "total_sequences": 1673,
@@ -18047,7 +18675,8 @@
                 "21I (Delta)": 142,
                 "21J (Delta)": 4164,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 4312,
               "total_sequences": 2672,
@@ -18075,7 +18704,8 @@
                 "21I (Delta)": 173,
                 "21J (Delta)": 5919,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 6116,
               "total_sequences": 2789,
@@ -18103,7 +18733,8 @@
                 "21I (Delta)": 230,
                 "21J (Delta)": 10344,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 10607,
               "total_sequences": 967,
@@ -18131,7 +18762,8 @@
                 "21I (Delta)": 235,
                 "21J (Delta)": 11941,
                 "21K (Omicron)": 164,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 12363,
               "total_sequences": 527,
@@ -18159,7 +18791,8 @@
                 "21I (Delta)": 251,
                 "21J (Delta)": 11192,
                 "21K (Omicron)": 1314,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 12757,
               "total_sequences": 2389,
@@ -18187,14 +18820,15 @@
                 "21I (Delta)": 160,
                 "21J (Delta)": 6965,
                 "21K (Omicron)": 11351,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 7
               },
               "stand_total_cases": 18483,
               "total_sequences": 2996,
               "week": "2021-12-13"
             },
             {
-              "percent_total_cases": 0.011083246308760644,
+              "percent_total_cases": 0.011090868899069281,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -18213,16 +18847,17 @@
                 "21G (Lambda)": 0,
                 "21H (Mu)": 0,
                 "21I (Delta)": 54,
-                "21J (Delta)": 2209,
-                "21K (Omicron)": 50337,
-                "21L (Omicron)": 36
+                "21J (Delta)": 2208,
+                "21K (Omicron)": 50339,
+                "21L (Omicron)": 36,
+                "Unknown": 0
               },
               "stand_total_cases": 52655,
-              "total_sequences": 2908,
+              "total_sequences": 2910,
               "week": "2021-12-27"
             },
             {
-              "percent_total_cases": 0.023245007863508554,
+              "percent_total_cases": 0.023274793880760616,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -18242,15 +18877,16 @@
                 "21H (Mu)": 0,
                 "21I (Delta)": 17,
                 "21J (Delta)": 388,
-                "21K (Omicron)": 32686,
-                "21L (Omicron)": 587
+                "21K (Omicron)": 32678,
+                "21L (Omicron)": 595,
+                "Unknown": 9
               },
               "stand_total_cases": 33687,
-              "total_sequences": 3902,
+              "total_sequences": 3907,
               "week": "2022-01-10"
             },
             {
-              "percent_total_cases": 0.024054982817869417,
+              "percent_total_cases": 0.024155072898942382,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -18270,11 +18906,12 @@
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 42,
-                "21K (Omicron)": 10503,
-                "21L (Omicron)": 1477
+                "21K (Omicron)": 10501,
+                "21L (Omicron)": 1479,
+                "Unknown": 8
               },
               "stand_total_cases": 12030,
-              "total_sequences": 1442,
+              "total_sequences": 1448,
               "week": "2022-01-24"
             },
             {
@@ -18299,14 +18936,15 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 18,
                 "21K (Omicron)": 4355,
-                "21L (Omicron)": 8601
+                "21L (Omicron)": 8601,
+                "Unknown": 18
               },
               "stand_total_cases": 12992,
               "total_sequences": 719,
               "week": "2022-02-07"
             },
             {
-              "percent_total_cases": 0.005702737313910677,
+              "percent_total_cases": 0.00572274691852089,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -18326,15 +18964,16 @@
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 3237,
-                "21L (Omicron)": 6686
+                "21K (Omicron)": 3226,
+                "21L (Omicron)": 6698,
+                "Unknown": 105
               },
               "stand_total_cases": 10029,
-              "total_sequences": 285,
+              "total_sequences": 286,
               "week": "2022-02-21"
             },
             {
-              "percent_total_cases": 0.030714555165088253,
+              "percent_total_cases": 0.034268469434351856,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -18353,16 +18992,17 @@
                 "21G (Lambda)": 0,
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 7,
-                "21K (Omicron)": 856,
-                "21L (Omicron)": 9225
+                "21J (Delta)": 6,
+                "21K (Omicron)": 832,
+                "21L (Omicron)": 9252,
+                "Unknown": 17
               },
               "stand_total_cases": 10107,
-              "total_sequences": 1547,
+              "total_sequences": 1726,
               "week": "2022-03-07"
             },
             {
-              "percent_total_cases": 0.006169557497266334,
+              "percent_total_cases": 0.010102023414223088,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -18382,12 +19022,42 @@
                 "21H (Mu)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 911,
-                "21L (Omicron)": 19029
+                "21K (Omicron)": 914,
+                "21L (Omicron)": 19032,
+                "Unknown": 59
               },
               "stand_total_cases": 20005,
-              "total_sequences": 615,
+              "total_sequences": 1007,
               "week": "2022-03-21"
+            },
+            {
+              "percent_total_cases": 0.0011578197363733523,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20C/S:80Y": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21G (Lambda)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 520,
+                "21L (Omicron)": 6239,
+                "Unknown": 0
+              },
+              "stand_total_cases": 6759,
+              "total_sequences": 39,
+              "week": "2022-04-04"
             }
           ]
         },
@@ -18413,7 +19083,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 29
               },
               "stand_total_cases": 29,
               "total_sequences": 4,
@@ -18438,7 +19109,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 8
               },
               "stand_total_cases": 8,
               "total_sequences": 4,
@@ -18463,7 +19135,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 16
               },
               "stand_total_cases": 16,
               "total_sequences": 11,
@@ -18488,7 +19161,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 86
               },
               "stand_total_cases": 86,
               "total_sequences": 49,
@@ -18513,7 +19187,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 118
               },
               "stand_total_cases": 118,
               "total_sequences": 56,
@@ -18538,7 +19213,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 110
               },
               "stand_total_cases": 112,
               "total_sequences": 65,
@@ -18563,7 +19239,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 70
               },
               "stand_total_cases": 113,
               "total_sequences": 74,
@@ -18588,7 +19265,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 106
               },
               "stand_total_cases": 215,
               "total_sequences": 94,
@@ -18613,7 +19291,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 138
               },
               "stand_total_cases": 402,
               "total_sequences": 166,
@@ -18638,7 +19317,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 228
               },
               "stand_total_cases": 792,
               "total_sequences": 163,
@@ -18663,7 +19343,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 607
               },
               "stand_total_cases": 1593,
               "total_sequences": 336,
@@ -18688,7 +19369,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 58,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2901
               },
               "stand_total_cases": 6872,
               "total_sequences": 353,
@@ -18713,7 +19395,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 84,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2948
               },
               "stand_total_cases": 10684,
               "total_sequences": 888,
@@ -18738,7 +19421,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2998
               },
               "stand_total_cases": 9692,
               "total_sequences": 139,
@@ -18763,7 +19447,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2131
               },
               "stand_total_cases": 9860,
               "total_sequences": 953,
@@ -18788,7 +19473,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1607
               },
               "stand_total_cases": 9666,
               "total_sequences": 866,
@@ -18813,7 +19499,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 15,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1276
               },
               "stand_total_cases": 16058,
               "total_sequences": 1083,
@@ -18838,7 +19525,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 144,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1516
               },
               "stand_total_cases": 8923,
               "total_sequences": 371,
@@ -18863,7 +19551,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 30,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1666
               },
               "stand_total_cases": 7635,
               "total_sequences": 1539,
@@ -18888,7 +19577,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 8,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 456
               },
               "stand_total_cases": 5322,
               "total_sequences": 1274,
@@ -18913,7 +19603,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 11,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 339
               },
               "stand_total_cases": 5147,
               "total_sequences": 1430,
@@ -18938,7 +19629,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 8,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 147
               },
               "stand_total_cases": 5079,
               "total_sequences": 1248,
@@ -18963,7 +19655,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 17,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 110
               },
               "stand_total_cases": 6790,
               "total_sequences": 1604,
@@ -18988,7 +19681,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 37
               },
               "stand_total_cases": 5739,
               "total_sequences": 2005,
@@ -19013,7 +19707,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 2,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 32
               },
               "stand_total_cases": 4618,
               "total_sequences": 1923,
@@ -19038,7 +19733,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 20
               },
               "stand_total_cases": 3674,
               "total_sequences": 1143,
@@ -19063,7 +19759,8 @@
                 "21I (Delta)": 9,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 16
               },
               "stand_total_cases": 2078,
               "total_sequences": 680,
@@ -19088,7 +19785,8 @@
                 "21I (Delta)": 8,
                 "21J (Delta)": 11,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 9
               },
               "stand_total_cases": 1352,
               "total_sequences": 640,
@@ -19113,7 +19811,8 @@
                 "21I (Delta)": 3,
                 "21J (Delta)": 39,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 11
               },
               "stand_total_cases": 383,
               "total_sequences": 286,
@@ -19138,7 +19837,8 @@
                 "21I (Delta)": 4,
                 "21J (Delta)": 195,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 11
               },
               "stand_total_cases": 299,
               "total_sequences": 235,
@@ -19163,7 +19863,8 @@
                 "21I (Delta)": 22,
                 "21J (Delta)": 346,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 379,
               "total_sequences": 617,
@@ -19188,7 +19889,8 @@
                 "21I (Delta)": 42,
                 "21J (Delta)": 646,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 701,
               "total_sequences": 1256,
@@ -19213,7 +19915,8 @@
                 "21I (Delta)": 87,
                 "21J (Delta)": 1555,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1653,
               "total_sequences": 1891,
@@ -19238,7 +19941,8 @@
                 "21I (Delta)": 296,
                 "21J (Delta)": 2947,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 3251,
               "total_sequences": 2371,
@@ -19263,7 +19967,8 @@
                 "21I (Delta)": 342,
                 "21J (Delta)": 5973,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 6336,
               "total_sequences": 2184,
@@ -19288,7 +19993,8 @@
                 "21I (Delta)": 296,
                 "21J (Delta)": 5651,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 5955,
               "total_sequences": 2192,
@@ -19313,7 +20019,8 @@
                 "21I (Delta)": 399,
                 "21J (Delta)": 5504,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 5906,
               "total_sequences": 2470,
@@ -19338,7 +20045,8 @@
                 "21I (Delta)": 671,
                 "21J (Delta)": 12661,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 13332,
               "total_sequences": 2643,
@@ -19363,7 +20071,8 @@
                 "21I (Delta)": 1039,
                 "21J (Delta)": 19306,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 20345,
               "total_sequences": 2272,
@@ -19388,7 +20097,8 @@
                 "21I (Delta)": 985,
                 "21J (Delta)": 17882,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 18874,
               "total_sequences": 2722,
@@ -19413,7 +20123,8 @@
                 "21I (Delta)": 368,
                 "21J (Delta)": 10418,
                 "21K (Omicron)": 28,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 17
               },
               "stand_total_cases": 10860,
               "total_sequences": 2332,
@@ -19438,7 +20149,8 @@
                 "21I (Delta)": 171,
                 "21J (Delta)": 6338,
                 "21K (Omicron)": 1090,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 17
               },
               "stand_total_cases": 7747,
               "total_sequences": 1947,
@@ -19463,7 +20175,8 @@
                 "21I (Delta)": 71,
                 "21J (Delta)": 3680,
                 "21K (Omicron)": 12950,
-                "21L (Omicron)": 4
+                "21L (Omicron)": 4,
+                "Unknown": 0
               },
               "stand_total_cases": 16705,
               "total_sequences": 4213,
@@ -19488,7 +20201,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 2707,
                 "21K (Omicron)": 51033,
-                "21L (Omicron)": 407
+                "21L (Omicron)": 407,
+                "Unknown": 0
               },
               "stand_total_cases": 54147,
               "total_sequences": 2660,
@@ -19513,7 +20227,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 768,
                 "21K (Omicron)": 87868,
-                "21L (Omicron)": 3296
+                "21L (Omicron)": 3296,
+                "Unknown": 0
               },
               "stand_total_cases": 91932,
               "total_sequences": 2036,
@@ -19538,7 +20253,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 47,
                 "21K (Omicron)": 35941,
-                "21L (Omicron)": 4225
+                "21L (Omicron)": 4225,
+                "Unknown": 0
               },
               "stand_total_cases": 40213,
               "total_sequences": 2570,
@@ -19563,7 +20279,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 35,
                 "21K (Omicron)": 9081,
-                "21L (Omicron)": 3223
+                "21L (Omicron)": 3223,
+                "Unknown": 0
               },
               "stand_total_cases": 12339,
               "total_sequences": 1409,
@@ -19588,7 +20305,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 12,
                 "21K (Omicron)": 8311,
-                "21L (Omicron)": 7606
+                "21L (Omicron)": 7606,
+                "Unknown": 23
               },
               "stand_total_cases": 15952,
               "total_sequences": 1380,
@@ -19613,7 +20331,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 4453,
-                "21L (Omicron)": 13340
+                "21L (Omicron)": 13340,
+                "Unknown": 20
               },
               "stand_total_cases": 17813,
               "total_sequences": 904,
@@ -19647,7 +20366,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 105
               },
               "stand_total_cases": 105,
               "total_sequences": 27,
@@ -19676,7 +20396,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 45
               },
               "stand_total_cases": 45,
               "total_sequences": 17,
@@ -19705,7 +20426,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 35
               },
               "stand_total_cases": 35,
               "total_sequences": 8,
@@ -19734,7 +20456,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 36
               },
               "stand_total_cases": 36,
               "total_sequences": 30,
@@ -19763,7 +20486,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 31
               },
               "stand_total_cases": 33,
               "total_sequences": 59,
@@ -19792,7 +20516,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 17
               },
               "stand_total_cases": 17,
               "total_sequences": 32,
@@ -19821,7 +20546,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 35
               },
               "stand_total_cases": 43,
               "total_sequences": 84,
@@ -19850,7 +20576,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 39
               },
               "stand_total_cases": 134,
               "total_sequences": 164,
@@ -19879,7 +20606,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 95
               },
               "stand_total_cases": 116,
               "total_sequences": 47,
@@ -19908,7 +20636,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 209
               },
               "stand_total_cases": 276,
               "total_sequences": 108,
@@ -19937,7 +20666,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 79
               },
               "stand_total_cases": 282,
               "total_sequences": 117,
@@ -19966,7 +20696,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 73
               },
               "stand_total_cases": 334,
               "total_sequences": 156,
@@ -19995,7 +20726,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 109
               },
               "stand_total_cases": 436,
               "total_sequences": 200,
@@ -20024,7 +20756,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 580
               },
               "stand_total_cases": 1248,
               "total_sequences": 260,
@@ -20053,7 +20786,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 758
               },
               "stand_total_cases": 1469,
               "total_sequences": 163,
@@ -20082,7 +20816,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 670
               },
               "stand_total_cases": 1016,
               "total_sequences": 188,
@@ -20111,7 +20846,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 777
               },
               "stand_total_cases": 1021,
               "total_sequences": 268,
@@ -20140,7 +20876,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 1122
               },
               "stand_total_cases": 2116,
               "total_sequences": 538,
@@ -20169,7 +20906,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 542
               },
               "stand_total_cases": 1026,
               "total_sequences": 738,
@@ -20198,7 +20936,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 334
               },
               "stand_total_cases": 675,
               "total_sequences": 1410,
@@ -20227,7 +20966,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 228
               },
               "stand_total_cases": 687,
               "total_sequences": 1472,
@@ -20256,7 +20996,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 126
               },
               "stand_total_cases": 1172,
               "total_sequences": 1602,
@@ -20285,7 +21026,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 64
               },
               "stand_total_cases": 2194,
               "total_sequences": 1814,
@@ -20314,7 +21056,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 34
               },
               "stand_total_cases": 2147,
               "total_sequences": 1428,
@@ -20343,7 +21086,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 16
               },
               "stand_total_cases": 1616,
               "total_sequences": 1933,
@@ -20372,7 +21116,8 @@
                 "21J (Delta)": 2,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 7
               },
               "stand_total_cases": 1090,
               "total_sequences": 1711,
@@ -20401,7 +21146,8 @@
                 "21J (Delta)": 23,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 7
               },
               "stand_total_cases": 1066,
               "total_sequences": 1839,
@@ -20430,7 +21176,8 @@
                 "21J (Delta)": 31,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 7
               },
               "stand_total_cases": 1010,
               "total_sequences": 1416,
@@ -20459,7 +21206,8 @@
                 "21J (Delta)": 14,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 589,
               "total_sequences": 1130,
@@ -20488,7 +21236,8 @@
                 "21J (Delta)": 49,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 465,
               "total_sequences": 820,
@@ -20517,7 +21266,8 @@
                 "21J (Delta)": 68,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 477,
               "total_sequences": 862,
@@ -20546,7 +21296,8 @@
                 "21J (Delta)": 137,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 470,
               "total_sequences": 888,
@@ -20575,7 +21326,8 @@
                 "21J (Delta)": 494,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 927,
               "total_sequences": 1314,
@@ -20604,7 +21356,8 @@
                 "21J (Delta)": 1055,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 1421,
               "total_sequences": 1761,
@@ -20633,7 +21386,8 @@
                 "21J (Delta)": 2607,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 3413,
               "total_sequences": 1965,
@@ -20662,7 +21416,8 @@
                 "21J (Delta)": 2346,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 2739,
               "total_sequences": 2280,
@@ -20691,7 +21446,8 @@
                 "21J (Delta)": 1292,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1517,
               "total_sequences": 1806,
@@ -20720,7 +21476,8 @@
                 "21J (Delta)": 1000,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1064,
               "total_sequences": 1499,
@@ -20749,7 +21506,8 @@
                 "21J (Delta)": 1923,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1999,
               "total_sequences": 2151,
@@ -20778,7 +21536,8 @@
                 "21J (Delta)": 3814,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 3887,
               "total_sequences": 2090,
@@ -20807,7 +21566,8 @@
                 "21J (Delta)": 5840,
                 "21K (Omicron)": 18,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 5927,
               "total_sequences": 2244,
@@ -20836,7 +21596,8 @@
                 "21J (Delta)": 7514,
                 "21K (Omicron)": 2762,
                 "21L (Omicron)": 4,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 10421,
               "total_sequences": 2445,
@@ -20865,7 +21626,8 @@
                 "21J (Delta)": 5083,
                 "21K (Omicron)": 5159,
                 "21L (Omicron)": 17,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 10329,
               "total_sequences": 1780,
@@ -20894,7 +21656,8 @@
                 "21J (Delta)": 2009,
                 "21K (Omicron)": 9773,
                 "21L (Omicron)": 999,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 10
               },
               "stand_total_cases": 12812,
               "total_sequences": 2487,
@@ -20923,7 +21686,8 @@
                 "21J (Delta)": 940,
                 "21K (Omicron)": 26982,
                 "21L (Omicron)": 4686,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 32608,
               "total_sequences": 2498,
@@ -20952,7 +21716,8 @@
                 "21J (Delta)": 218,
                 "21K (Omicron)": 32223,
                 "21L (Omicron)": 17069,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 65
               },
               "stand_total_cases": 49575,
               "total_sequences": 2277,
@@ -20981,7 +21746,8 @@
                 "21J (Delta)": 72,
                 "21K (Omicron)": 17852,
                 "21L (Omicron)": 26472,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 36
               },
               "stand_total_cases": 44432,
               "total_sequences": 2469,
@@ -21010,7 +21776,8 @@
                 "21J (Delta)": 14,
                 "21K (Omicron)": 6142,
                 "21L (Omicron)": 25232,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 69
               },
               "stand_total_cases": 31457,
               "total_sequences": 2269,
@@ -21039,7 +21806,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 935,
                 "21L (Omicron)": 12061,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 17
               },
               "stand_total_cases": 13013,
               "total_sequences": 1476,
@@ -21068,7 +21836,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 236,
                 "21L (Omicron)": 5074,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 39
               },
               "stand_total_cases": 5349,
               "total_sequences": 136,
@@ -21100,7 +21869,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 107
               },
               "stand_total_cases": 107,
               "total_sequences": 1,
@@ -21127,7 +21897,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 29
               },
               "stand_total_cases": 29,
               "total_sequences": 1,
@@ -21154,7 +21925,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 131
               },
               "stand_total_cases": 131,
               "total_sequences": 18,
@@ -21181,7 +21953,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 319
               },
               "stand_total_cases": 319,
               "total_sequences": 6,
@@ -21208,7 +21981,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1000
               },
               "stand_total_cases": 1000,
               "total_sequences": 16,
@@ -21235,7 +22009,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2195
               },
               "stand_total_cases": 2195,
               "total_sequences": 5,
@@ -21262,7 +22037,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2423
               },
               "stand_total_cases": 2423,
               "total_sequences": 42,
@@ -21289,7 +22065,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2189
               },
               "stand_total_cases": 2189,
               "total_sequences": 7,
@@ -21316,7 +22093,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2294
               },
               "stand_total_cases": 2294,
               "total_sequences": 1,
@@ -21343,7 +22121,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 4465
               },
               "stand_total_cases": 4465,
               "total_sequences": 3,
@@ -21370,7 +22149,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 8175
               },
               "stand_total_cases": 8175,
               "total_sequences": 1,
@@ -21397,7 +22177,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2010
               },
               "stand_total_cases": 2010,
               "total_sequences": 1,
@@ -21424,7 +22205,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1437
               },
               "stand_total_cases": 1677,
               "total_sequences": 7,
@@ -21451,7 +22233,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2457
               },
               "stand_total_cases": 3213,
               "total_sequences": 51,
@@ -21478,7 +22261,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 20,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 7336
               },
               "stand_total_cases": 12545,
               "total_sequences": 1840,
@@ -21505,7 +22289,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 48,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 4398
               },
               "stand_total_cases": 11417,
               "total_sequences": 955,
@@ -21532,7 +22317,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 24,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2276
               },
               "stand_total_cases": 10192,
               "total_sequences": 2099,
@@ -21559,7 +22345,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 396
               },
               "stand_total_cases": 6236,
               "total_sequences": 708,
@@ -21586,7 +22373,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 249
               },
               "stand_total_cases": 5546,
               "total_sequences": 1741,
@@ -21613,7 +22401,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 20
               },
               "stand_total_cases": 2819,
               "total_sequences": 846,
@@ -21640,7 +22429,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 696,
               "total_sequences": 763,
@@ -21667,7 +22457,8 @@
                 "21I (Delta)": 5,
                 "21J (Delta)": 14,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 307,
               "total_sequences": 402,
@@ -21694,7 +22485,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 162,
               "total_sequences": 309,
@@ -21721,7 +22513,8 @@
                 "21I (Delta)": 3,
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 60,
               "total_sequences": 160,
@@ -21748,7 +22541,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 36,
               "total_sequences": 129,
@@ -21775,7 +22569,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 13,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 22,
               "total_sequences": 75,
@@ -21802,7 +22597,8 @@
                 "21I (Delta)": 3,
                 "21J (Delta)": 125,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 131,
               "total_sequences": 751,
@@ -21829,7 +22625,8 @@
                 "21I (Delta)": 20,
                 "21J (Delta)": 512,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 6
               },
               "stand_total_cases": 564,
               "total_sequences": 1309,
@@ -21856,7 +22653,8 @@
                 "21I (Delta)": 197,
                 "21J (Delta)": 1343,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 10
               },
               "stand_total_cases": 1562,
               "total_sequences": 364,
@@ -21883,7 +22681,8 @@
                 "21I (Delta)": 461,
                 "21J (Delta)": 3775,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 4286,
               "total_sequences": 1182,
@@ -21910,7 +22709,8 @@
                 "21I (Delta)": 690,
                 "21J (Delta)": 8848,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 10
               },
               "stand_total_cases": 9691,
               "total_sequences": 1081,
@@ -21937,7 +22737,8 @@
                 "21I (Delta)": 529,
                 "21J (Delta)": 13038,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 13676,
               "total_sequences": 1630,
@@ -21964,7 +22765,8 @@
                 "21I (Delta)": 135,
                 "21J (Delta)": 11748,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 11896,
               "total_sequences": 1852,
@@ -21991,7 +22793,8 @@
                 "21I (Delta)": 25,
                 "21J (Delta)": 6622,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 6673,
               "total_sequences": 526,
@@ -22018,7 +22821,8 @@
                 "21I (Delta)": 90,
                 "21J (Delta)": 2717,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 2818,
               "total_sequences": 1093,
@@ -22045,7 +22849,8 @@
                 "21I (Delta)": 37,
                 "21J (Delta)": 1156,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1199,
               "total_sequences": 818,
@@ -22072,7 +22877,8 @@
                 "21I (Delta)": 25,
                 "21J (Delta)": 1021,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1047,
               "total_sequences": 1148,
@@ -22099,7 +22905,8 @@
                 "21I (Delta)": 10,
                 "21J (Delta)": 649,
                 "21K (Omicron)": 2,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 663,
               "total_sequences": 1850,
@@ -22126,7 +22933,8 @@
                 "21I (Delta)": 11,
                 "21J (Delta)": 803,
                 "21K (Omicron)": 44,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 861,
               "total_sequences": 1869,
@@ -22153,7 +22961,8 @@
                 "21I (Delta)": 13,
                 "21J (Delta)": 751,
                 "21K (Omicron)": 821,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 1586,
               "total_sequences": 1898,
@@ -22180,7 +22989,8 @@
                 "21I (Delta)": 13,
                 "21J (Delta)": 1374,
                 "21K (Omicron)": 13372,
-                "21L (Omicron)": 108
+                "21L (Omicron)": 108,
+                "Unknown": -1
               },
               "stand_total_cases": 14866,
               "total_sequences": 2348,
@@ -22207,7 +23017,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 666,
                 "21K (Omicron)": 70912,
-                "21L (Omicron)": 4755
+                "21L (Omicron)": 4755,
+                "Unknown": -1
               },
               "stand_total_cases": 76364,
               "total_sequences": 2409,
@@ -22234,7 +23045,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 182,
                 "21K (Omicron)": 94872,
-                "21L (Omicron)": 10849
+                "21L (Omicron)": 10849,
+                "Unknown": 0
               },
               "stand_total_cases": 105903,
               "total_sequences": 3485,
@@ -22261,7 +23073,8 @@
                 "21I (Delta)": 11,
                 "21J (Delta)": 11,
                 "21K (Omicron)": 28874,
-                "21L (Omicron)": 9423
+                "21L (Omicron)": 9423,
+                "Unknown": 31
               },
               "stand_total_cases": 38350,
               "total_sequences": 3614,
@@ -22288,7 +23101,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 6796,
-                "21L (Omicron)": 6130
+                "21L (Omicron)": 6130,
+                "Unknown": 16
               },
               "stand_total_cases": 12942,
               "total_sequences": 3961,
@@ -22315,7 +23129,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 8,
                 "21K (Omicron)": 1830,
-                "21L (Omicron)": 8840
+                "21L (Omicron)": 8840,
+                "Unknown": 47
               },
               "stand_total_cases": 10725,
               "total_sequences": 4279,
@@ -22342,7 +23157,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 14,
                 "21K (Omicron)": 970,
-                "21L (Omicron)": 17638
+                "21L (Omicron)": 17638,
+                "Unknown": 55
               },
               "stand_total_cases": 18677,
               "total_sequences": 4007,
@@ -22372,7 +23188,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 54
               },
               "stand_total_cases": 54,
               "total_sequences": 13,
@@ -22397,7 +23214,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 33
               },
               "stand_total_cases": 33,
               "total_sequences": 2,
@@ -22422,7 +23240,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 65
               },
               "stand_total_cases": 65,
               "total_sequences": 9,
@@ -22447,7 +23266,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 113
               },
               "stand_total_cases": 113,
               "total_sequences": 16,
@@ -22472,7 +23292,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 134
               },
               "stand_total_cases": 170,
               "total_sequences": 14,
@@ -22497,7 +23318,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 102
               },
               "stand_total_cases": 171,
               "total_sequences": 30,
@@ -22522,7 +23344,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 292
               },
               "stand_total_cases": 390,
               "total_sequences": 4,
@@ -22547,7 +23370,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 482
               },
               "stand_total_cases": 643,
               "total_sequences": 4,
@@ -22572,7 +23396,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 757
               },
               "stand_total_cases": 1513,
               "total_sequences": 2,
@@ -22597,7 +23422,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 5373,
               "total_sequences": 3,
@@ -22622,7 +23448,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2447
               },
               "stand_total_cases": 8317,
               "total_sequences": 17,
@@ -22647,7 +23474,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 4621
               },
               "stand_total_cases": 10287,
               "total_sequences": 187,
@@ -22672,7 +23500,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 5195
               },
               "stand_total_cases": 14213,
               "total_sequences": 197,
@@ -22697,7 +23526,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 3595
               },
               "stand_total_cases": 18152,
               "total_sequences": 202,
@@ -22722,7 +23552,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 957
               },
               "stand_total_cases": 5561,
               "total_sequences": 151,
@@ -22747,7 +23578,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 621
               },
               "stand_total_cases": 3742,
               "total_sequences": 181,
@@ -22772,7 +23604,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 375
               },
               "stand_total_cases": 2706,
               "total_sequences": 950,
@@ -22797,7 +23630,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 415
               },
               "stand_total_cases": 3034,
               "total_sequences": 1281,
@@ -22822,7 +23656,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 123
               },
               "stand_total_cases": 2526,
               "total_sequences": 1334,
@@ -22847,7 +23682,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 90
               },
               "stand_total_cases": 3939,
               "total_sequences": 1593,
@@ -22872,7 +23708,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 95
               },
               "stand_total_cases": 5213,
               "total_sequences": 1720,
@@ -22897,7 +23734,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 81
               },
               "stand_total_cases": 5966,
               "total_sequences": 1680,
@@ -22922,7 +23760,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 50
               },
               "stand_total_cases": 5894,
               "total_sequences": 1426,
@@ -22947,7 +23786,8 @@
                 "21I (Delta)": 2,
                 "21J (Delta)": 2,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 22
               },
               "stand_total_cases": 3220,
               "total_sequences": 1477,
@@ -22972,7 +23812,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 15,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 8
               },
               "stand_total_cases": 1318,
               "total_sequences": 1200,
@@ -22997,7 +23838,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 31,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 345,
               "total_sequences": 307,
@@ -23022,7 +23864,8 @@
                 "21I (Delta)": 3,
                 "21J (Delta)": 124,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 192,
               "total_sequences": 230,
@@ -23047,7 +23890,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 643,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 659,
               "total_sequences": 983,
@@ -23072,7 +23916,8 @@
                 "21I (Delta)": 14,
                 "21J (Delta)": 1884,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1909,
               "total_sequences": 1499,
@@ -23097,7 +23942,8 @@
                 "21I (Delta)": 18,
                 "21J (Delta)": 2831,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2849,
               "total_sequences": 1459,
@@ -23122,7 +23968,8 @@
                 "21I (Delta)": 35,
                 "21J (Delta)": 3257,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 3292,
               "total_sequences": 1310,
@@ -23147,7 +23994,8 @@
                 "21I (Delta)": 37,
                 "21J (Delta)": 4916,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 4953,
               "total_sequences": 929,
@@ -23172,7 +24020,8 @@
                 "21I (Delta)": 61,
                 "21J (Delta)": 7919,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 7980,
               "total_sequences": 784,
@@ -23197,7 +24046,8 @@
                 "21I (Delta)": 76,
                 "21J (Delta)": 11532,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 11608,
               "total_sequences": 917,
@@ -23222,7 +24072,8 @@
                 "21I (Delta)": 46,
                 "21J (Delta)": 14836,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 14898,
               "total_sequences": 963,
@@ -23247,7 +24098,8 @@
                 "21I (Delta)": 90,
                 "21J (Delta)": 12718,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 12830,
               "total_sequences": 1144,
@@ -23272,7 +24124,8 @@
                 "21I (Delta)": 40,
                 "21J (Delta)": 9109,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 9172,
               "total_sequences": 1158,
@@ -23297,7 +24150,8 @@
                 "21I (Delta)": 43,
                 "21J (Delta)": 8556,
                 "21K (Omicron)": 34,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 8633,
               "total_sequences": 1799,
@@ -23322,7 +24176,8 @@
                 "21I (Delta)": 33,
                 "21J (Delta)": 6015,
                 "21K (Omicron)": 1557,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 7605,
               "total_sequences": 1617,
@@ -23347,7 +24202,8 @@
                 "21I (Delta)": 15,
                 "21J (Delta)": 5707,
                 "21K (Omicron)": 5662,
-                "21L (Omicron)": 38
+                "21L (Omicron)": 38,
+                "Unknown": 0
               },
               "stand_total_cases": 11422,
               "total_sequences": 1517,
@@ -23372,7 +24228,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 3260,
                 "21K (Omicron)": 20767,
-                "21L (Omicron)": 604
+                "21L (Omicron)": 604,
+                "Unknown": 0
               },
               "stand_total_cases": 24631,
               "total_sequences": 816,
@@ -23397,7 +24254,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 814,
                 "21K (Omicron)": 43009,
-                "21L (Omicron)": 8615
+                "21L (Omicron)": 8615,
+                "Unknown": 1
               },
               "stand_total_cases": 52439,
               "total_sequences": 773,
@@ -23422,7 +24280,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 150,
                 "21K (Omicron)": 23834,
-                "21L (Omicron)": 17815
+                "21L (Omicron)": 17815,
+                "Unknown": 0
               },
               "stand_total_cases": 41799,
               "total_sequences": 1389,
@@ -23447,7 +24306,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 8798,
-                "21L (Omicron)": 17141
+                "21L (Omicron)": 17141,
+                "Unknown": 0
               },
               "stand_total_cases": 25939,
               "total_sequences": 743,
@@ -23472,7 +24332,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 150,
                 "21K (Omicron)": 2194,
-                "21L (Omicron)": 20064
+                "21L (Omicron)": 20064,
+                "Unknown": 0
               },
               "stand_total_cases": 22408,
               "total_sequences": 1195,
@@ -23497,11 +24358,38 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 741,
                 "21K (Omicron)": 794,
-                "21L (Omicron)": 12908
+                "21L (Omicron)": 12908,
+                "Unknown": -1
               },
               "stand_total_cases": 14442,
               "total_sequences": 546,
               "week": "2022-03-21"
+            },
+            {
+              "percent_total_cases": 0.002549636541173918,
+              "stand_estimated_cases": {
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:626S": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 146,
+                "21L (Omicron)": 6707,
+                "Unknown": 0
+              },
+              "stand_total_cases": 6853,
+              "total_sequences": 47,
+              "week": "2022-04-04"
             }
           ]
         },
@@ -23525,7 +24413,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 580
               },
               "stand_total_cases": 870,
               "total_sequences": 3,
@@ -23548,7 +24437,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 649
               },
               "stand_total_cases": 835,
               "total_sequences": 9,
@@ -23571,7 +24461,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 652
               },
               "stand_total_cases": 652,
               "total_sequences": 1,
@@ -23594,7 +24485,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 945
               },
               "stand_total_cases": 1039,
               "total_sequences": 11,
@@ -23617,7 +24509,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 4314
               },
               "stand_total_cases": 8935,
               "total_sequences": 29,
@@ -23640,7 +24533,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 10929
               },
               "stand_total_cases": 10929,
               "total_sequences": 1,
@@ -23663,7 +24557,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 3873
               },
               "stand_total_cases": 6132,
               "total_sequences": 19,
@@ -23686,7 +24581,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 448
               },
               "stand_total_cases": 2187,
               "total_sequences": 44,
@@ -23709,7 +24605,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 220
               },
               "stand_total_cases": 1588,
               "total_sequences": 151,
@@ -23732,7 +24629,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 96
               },
               "stand_total_cases": 1113,
               "total_sequences": 384,
@@ -23755,7 +24653,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 48
               },
               "stand_total_cases": 1609,
               "total_sequences": 575,
@@ -23778,7 +24677,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 13
               },
               "stand_total_cases": 2725,
               "total_sequences": 616,
@@ -23801,7 +24701,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 37
               },
               "stand_total_cases": 5484,
               "total_sequences": 740,
@@ -23824,7 +24725,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 56
               },
               "stand_total_cases": 6802,
               "total_sequences": 363,
@@ -23847,7 +24749,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 86
               },
               "stand_total_cases": 6708,
               "total_sequences": 708,
@@ -23870,7 +24773,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 11
               },
               "stand_total_cases": 3728,
               "total_sequences": 637,
@@ -23893,7 +24797,8 @@
                 "21J (Delta)": 16,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 19
               },
               "stand_total_cases": 1408,
               "total_sequences": 359,
@@ -23916,7 +24821,8 @@
                 "21J (Delta)": 54,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 593,
               "total_sequences": 254,
@@ -23939,7 +24845,8 @@
                 "21J (Delta)": 92,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 266,
               "total_sequences": 104,
@@ -23962,7 +24869,8 @@
                 "21J (Delta)": 201,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 287,
               "total_sequences": 204,
@@ -23985,7 +24893,8 @@
                 "21J (Delta)": 348,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 439,
               "total_sequences": 242,
@@ -24008,7 +24917,8 @@
                 "21J (Delta)": 503,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 593,
               "total_sequences": 329,
@@ -24031,7 +24941,8 @@
                 "21J (Delta)": 1015,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1156,
               "total_sequences": 572,
@@ -24054,7 +24965,8 @@
                 "21J (Delta)": 1859,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1977,
               "total_sequences": 755,
@@ -24077,7 +24989,8 @@
                 "21J (Delta)": 3335,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 3465,
               "total_sequences": 611,
@@ -24100,7 +25013,8 @@
                 "21J (Delta)": 3902,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 4095,
               "total_sequences": 593,
@@ -24123,7 +25037,8 @@
                 "21J (Delta)": 4410,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 4707,
               "total_sequences": 554,
@@ -24146,7 +25061,8 @@
                 "21J (Delta)": 9596,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 10396,
               "total_sequences": 598,
@@ -24169,7 +25085,8 @@
                 "21J (Delta)": 15103,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 16758,
               "total_sequences": 658,
@@ -24192,7 +25109,8 @@
                 "21J (Delta)": 14589,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 15818,
               "total_sequences": 695,
@@ -24215,7 +25133,8 @@
                 "21J (Delta)": 11917,
                 "21K (Omicron)": 58,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 12466,
               "total_sequences": 1294,
@@ -24238,7 +25157,8 @@
                 "21J (Delta)": 8981,
                 "21K (Omicron)": 294,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 9567,
               "total_sequences": 2892,
@@ -24261,7 +25181,8 @@
                 "21J (Delta)": 9995,
                 "21K (Omicron)": 7410,
                 "21L (Omicron)": 13,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 17726,
               "total_sequences": 2818,
@@ -24284,7 +25205,8 @@
                 "21J (Delta)": 2579,
                 "21K (Omicron)": 24456,
                 "21L (Omicron)": 206,
-                "S:677H.Robin1": 9
+                "S:677H.Robin1": 9,
+                "Unknown": 0
               },
               "stand_total_cases": 27306,
               "total_sequences": 2922,
@@ -24307,7 +25229,8 @@
                 "21J (Delta)": 247,
                 "21K (Omicron)": 24627,
                 "21L (Omicron)": 1247,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 26146,
               "total_sequences": 2117,
@@ -24330,7 +25253,8 @@
                 "21J (Delta)": 15,
                 "21K (Omicron)": 12076,
                 "21L (Omicron)": 1979,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 14070,
               "total_sequences": 1856,
@@ -24353,7 +25277,8 @@
                 "21J (Delta)": 5,
                 "21K (Omicron)": 3491,
                 "21L (Omicron)": 2039,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 5
               },
               "stand_total_cases": 5540,
               "total_sequences": 1076,
@@ -24376,7 +25301,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 1748,
                 "21L (Omicron)": 3197,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 4945,
               "total_sequences": 925,
@@ -24399,10 +25325,1416 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 716,
                 "21L (Omicron)": 3869,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 4585,
               "total_sequences": 692,
+              "week": "2022-03-21"
+            }
+          ]
+        },
+        {
+          "country": "South Korea",
+          "distribution": [
+            {
+              "percent_total_cases": 0.27485380116959063,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 3
+              },
+              "stand_total_cases": 3,
+              "total_sequences": 47,
+              "week": "2020-04-27"
+            },
+            {
+              "percent_total_cases": 0.21548821548821548,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 5
+              },
+              "stand_total_cases": 5,
+              "total_sequences": 64,
+              "week": "2020-05-11"
+            },
+            {
+              "percent_total_cases": 0.2713815789473684,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 11
+              },
+              "stand_total_cases": 11,
+              "total_sequences": 165,
+              "week": "2020-05-25"
+            },
+            {
+              "percent_total_cases": 0.17307692307692307,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 12
+              },
+              "stand_total_cases": 12,
+              "total_sequences": 108,
+              "week": "2020-06-08"
+            },
+            {
+              "percent_total_cases": 0.22603719599427755,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 13
+              },
+              "stand_total_cases": 13,
+              "total_sequences": 158,
+              "week": "2020-06-22"
+            },
+            {
+              "percent_total_cases": 0.17350157728706625,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 12
+              },
+              "stand_total_cases": 12,
+              "total_sequences": 110,
+              "week": "2020-07-06"
+            },
+            {
+              "percent_total_cases": 0.15857605177993528,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 12
+              },
+              "stand_total_cases": 12,
+              "total_sequences": 98,
+              "week": "2020-07-20"
+            },
+            {
+              "percent_total_cases": 0.10923623445825932,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 21
+              },
+              "stand_total_cases": 21,
+              "total_sequences": 123,
+              "week": "2020-08-03"
+            },
+            {
+              "percent_total_cases": 0.039485559566787,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 86
+              },
+              "stand_total_cases": 86,
+              "total_sequences": 175,
+              "week": "2020-08-17"
+            },
+            {
+              "percent_total_cases": 0.026090675791274595,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 45
+              },
+              "stand_total_cases": 45,
+              "total_sequences": 61,
+              "week": "2020-08-31"
+            },
+            {
+              "percent_total_cases": 0.04505813953488372,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 26
+              },
+              "stand_total_cases": 26,
+              "total_sequences": 62,
+              "week": "2020-09-14"
+            },
+            {
+              "percent_total_cases": 0.05470249520153551,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 3,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 17
+              },
+              "stand_total_cases": 20,
+              "total_sequences": 57,
+              "week": "2020-09-28"
+            },
+            {
+              "percent_total_cases": 0.0670926517571885,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 1,
+                "20A/S:98F": 3,
+                "20B/S:732A": 0,
+                "20E (EU1)": 1,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 19
+              },
+              "stand_total_cases": 24,
+              "total_sequences": 84,
+              "week": "2020-10-12"
+            },
+            {
+              "percent_total_cases": 0.04818523153942428,
+              "stand_estimated_cases": {
+                "20A.EU2": 1,
+                "20A/S:126A": 0,
+                "20A/S:439K": 1,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 29
+              },
+              "stand_total_cases": 31,
+              "total_sequences": 77,
+              "week": "2020-10-26"
+            },
+            {
+              "percent_total_cases": 0.04926108374384237,
+              "stand_estimated_cases": {
+                "20A.EU2": 1,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 1,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 65
+              },
+              "stand_total_cases": 67,
+              "total_sequences": 170,
+              "week": "2020-11-09"
+            },
+            {
+              "percent_total_cases": 0.02207628894788319,
+              "stand_estimated_cases": {
+                "20A.EU2": 3,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 6,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 130
+              },
+              "stand_total_cases": 139,
+              "total_sequences": 158,
+              "week": "2020-11-23"
+            },
+            {
+              "percent_total_cases": 0.013837489943684634,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 1,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 3,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 10,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 228
+              },
+              "stand_total_cases": 242,
+              "total_sequences": 172,
+              "week": "2020-12-07"
+            },
+            {
+              "percent_total_cases": 0.013334772984937645,
+              "stand_estimated_cases": {
+                "20A.EU2": 3,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 1,
+                "20I (Alpha, V1)": 16,
+                "20J (Gamma, V3)": 1,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 16,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 324
+              },
+              "stand_total_cases": 361,
+              "total_sequences": 247,
+              "week": "2020-12-21"
+            },
+            {
+              "percent_total_cases": 0.022163258935539255,
+              "stand_estimated_cases": {
+                "20A.EU2": 1,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 3,
+                "20I (Alpha, V1)": 16,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 5,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 99
+              },
+              "stand_total_cases": 124,
+              "total_sequences": 142,
+              "week": "2021-01-11"
+            },
+            {
+              "percent_total_cases": 0.03372175141242938,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 21,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 5,
+                "21D (Eta)": 1,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 83
+              },
+              "stand_total_cases": 110,
+              "total_sequences": 191,
+              "week": "2021-01-25"
+            },
+            {
+              "percent_total_cases": 0.03844274311777163,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 1,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 22,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 8,
+                "21D (Eta)": 0,
+                "21F (Iota)": 1,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 87
+              },
+              "stand_total_cases": 119,
+              "total_sequences": 236,
+              "week": "2021-02-08"
+            },
+            {
+              "percent_total_cases": 0.04624066994356454,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 2,
+                "20I (Alpha, V1)": 13,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 3,
+                "21D (Eta)": 0,
+                "21F (Iota)": 1,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 88
+              },
+              "stand_total_cases": 107,
+              "total_sequences": 254,
+              "week": "2021-02-22"
+            },
+            {
+              "percent_total_cases": 0.04234579737935443,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 11,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 110
+              },
+              "stand_total_cases": 121,
+              "total_sequences": 265,
+              "week": "2021-03-08"
+            },
+            {
+              "percent_total_cases": 0.047326643702261494,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 2,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 2,
+                "20I (Alpha, V1)": 26,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 1,
+                "21C (Epsilon)": 5,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 94
+              },
+              "stand_total_cases": 130,
+              "total_sequences": 316,
+              "week": "2021-03-22"
+            },
+            {
+              "percent_total_cases": 0.04429952777153137,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 4,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 3,
+                "20I (Alpha, V1)": 33,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 3,
+                "21C (Epsilon)": 8,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 122
+              },
+              "stand_total_cases": 173,
+              "total_sequences": 394,
+              "week": "2021-04-05"
+            },
+            {
+              "percent_total_cases": 0.057586434706011894,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 16,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 3,
+                "20I (Alpha, V1)": 57,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 2,
+                "21B (Kappa)": 1,
+                "21C (Epsilon)": 7,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 1,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 90
+              },
+              "stand_total_cases": 177,
+              "total_sequences": 523,
+              "week": "2021-04-19"
+            },
+            {
+              "percent_total_cases": 0.025344545666900257,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 37,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 1,
+                "20I (Alpha, V1)": 55,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 5,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 2,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 1,
+                "21J (Delta)": 7,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 58
+              },
+              "stand_total_cases": 166,
+              "total_sequences": 217,
+              "week": "2021-05-03"
+            },
+            {
+              "percent_total_cases": 0.025590062111801242,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 63,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 10,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 1,
+                "21J (Delta)": 7,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 75
+              },
+              "stand_total_cases": 156,
+              "total_sequences": 206,
+              "week": "2021-05-17"
+            },
+            {
+              "percent_total_cases": 0.058741963948065044,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 23,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 11,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 1,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 3,
+                "21J (Delta)": 4,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 112
+              },
+              "stand_total_cases": 154,
+              "total_sequences": 466,
+              "week": "2021-05-31"
+            },
+            {
+              "percent_total_cases": 0.07562679819153309,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 11,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 22,
+                "20J (Gamma, V3)": 1,
+                "21A (Delta)": 2,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 18,
+                "21J (Delta)": 18,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 70
+              },
+              "stand_total_cases": 142,
+              "total_sequences": 552,
+              "week": "2021-06-14"
+            },
+            {
+              "percent_total_cases": 0.04972742006777663,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 8,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 1,
+                "20I (Alpha, V1)": 20,
+                "20J (Gamma, V3)": 1,
+                "21A (Delta)": 8,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 92,
+                "21J (Delta)": 39,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 95
+              },
+              "stand_total_cases": 264,
+              "total_sequences": 675,
+              "week": "2021-06-28"
+            },
+            {
+              "percent_total_cases": 0.04938154138915319,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 14,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 17,
+                "20J (Gamma, V3)": 1,
+                "21A (Delta)": 5,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 207,
+                "21J (Delta)": 63,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 102
+              },
+              "stand_total_cases": 409,
+              "total_sequences": 1038,
+              "week": "2021-07-12"
+            },
+            {
+              "percent_total_cases": 0.042007001166861145,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 9,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 8,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 11,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 318,
+                "21J (Delta)": 42,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 46
+              },
+              "stand_total_cases": 434,
+              "total_sequences": 936,
+              "week": "2021-07-26"
+            },
+            {
+              "percent_total_cases": 0.03536749032920186,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 3,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 1,
+                "20J (Gamma, V3)": 1,
+                "21A (Delta)": 9,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 392,
+                "21J (Delta)": 76,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 11
+              },
+              "stand_total_cases": 493,
+              "total_sequences": 896,
+              "week": "2021-08-09"
+            },
+            {
+              "percent_total_cases": 0.05371728621436906,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 1,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 14,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 402,
+                "21J (Delta)": 46,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 4
+              },
+              "stand_total_cases": 467,
+              "total_sequences": 1289,
+              "week": "2021-08-23"
+            },
+            {
+              "percent_total_cases": 0.0466262908610917,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 11,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 424,
+                "21J (Delta)": 64,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 3
+              },
+              "stand_total_cases": 502,
+              "total_sequences": 1201,
+              "week": "2021-09-06"
+            },
+            {
+              "percent_total_cases": 0.028597127880648863,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 1,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 6,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 488,
+                "21J (Delta)": 132,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 1
+              },
+              "stand_total_cases": 628,
+              "total_sequences": 922,
+              "week": "2021-09-20"
+            },
+            {
+              "percent_total_cases": 0.046856515125908396,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 3,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 362,
+                "21J (Delta)": 96,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 0
+              },
+              "stand_total_cases": 461,
+              "total_sequences": 1109,
+              "week": "2021-10-04"
+            },
+            {
+              "percent_total_cases": 0.06686718102959767,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 6,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 324,
+                "21J (Delta)": 116,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 1
+              },
+              "stand_total_cases": 447,
+              "total_sequences": 1534,
+              "week": "2021-10-18"
+            },
+            {
+              "percent_total_cases": 0.04864864864864865,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 6,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 386,
+                "21J (Delta)": 213,
+                "21K (Omicron)": 0,
+                "21L (Omicron)": 0,
+                "Unknown": 0
+              },
+              "stand_total_cases": 605,
+              "total_sequences": 1512,
+              "week": "2021-11-01"
+            },
+            {
+              "percent_total_cases": 0.02815937005178243,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 3,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 517,
+                "21J (Delta)": 389,
+                "21K (Omicron)": 1,
+                "21L (Omicron)": 0,
+                "Unknown": 0
+              },
+              "stand_total_cases": 910,
+              "total_sequences": 1316,
+              "week": "2021-11-15"
+            },
+            {
+              "percent_total_cases": 0.02110587161545482,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 2,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 739,
+                "21J (Delta)": 725,
+                "21K (Omicron)": 71,
+                "21L (Omicron)": 0,
+                "Unknown": 0
+              },
+              "stand_total_cases": 1537,
+              "total_sequences": 1665,
+              "week": "2021-11-29"
+            },
+            {
+              "percent_total_cases": 0.019721839651396445,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 792,
+                "21J (Delta)": 833,
+                "21K (Omicron)": 101,
+                "21L (Omicron)": 0,
+                "Unknown": 0
+              },
+              "stand_total_cases": 1726,
+              "total_sequences": 1747,
+              "week": "2021-12-13"
+            },
+            {
+              "percent_total_cases": 0.03271715721464465,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 291,
+                "21J (Delta)": 360,
+                "21K (Omicron)": 426,
+                "21L (Omicron)": 8,
+                "Unknown": 1
+              },
+              "stand_total_cases": 1086,
+              "total_sequences": 1823,
+              "week": "2021-12-27"
+            },
+            {
+              "percent_total_cases": 0.020277481323372464,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 1,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 120,
+                "21J (Delta)": 146,
+                "21K (Omicron)": 1136,
+                "21L (Omicron)": 39,
+                "Unknown": 0
+              },
+              "stand_total_cases": 1442,
+              "total_sequences": 1501,
+              "week": "2022-01-10"
+            },
+            {
+              "percent_total_cases": 0.004137703837917971,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 47,
+                "21J (Delta)": 127,
+                "21K (Omicron)": 5101,
+                "21L (Omicron)": 641,
+                "Unknown": 0
+              },
+              "stand_total_cases": 5916,
+              "total_sequences": 1256,
+              "week": "2022-01-24"
+            },
+            {
+              "percent_total_cases": 0.0015860310830509829,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 15373,
+                "21L (Omicron)": 4375,
+                "Unknown": 0
+              },
+              "stand_total_cases": 19748,
+              "total_sequences": 1607,
+              "week": "2022-02-07"
+            },
+            {
+              "percent_total_cases": 0.0006443592879925697,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 30,
+                "21K (Omicron)": 28766,
+                "21L (Omicron)": 22051,
+                "Unknown": 1
+              },
+              "stand_total_cases": 50848,
+              "total_sequences": 1681,
+              "week": "2022-02-21"
+            },
+            {
+              "percent_total_cases": 0.00021339189778019535,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 31055,
+                "21L (Omicron)": 64760,
+                "Unknown": 0
+              },
+              "stand_total_cases": 95815,
+              "total_sequences": 1049,
+              "week": "2022-03-07"
+            },
+            {
+              "percent_total_cases": 2.489481375397723e-06,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20A/S:98F": 0,
+                "20B/S:732A": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "20J (Gamma, V3)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21C (Epsilon)": 0,
+                "21D (Eta)": 0,
+                "21F (Iota)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 31317,
+                "21L (Omicron)": 54806,
+                "Unknown": 0
+              },
+              "stand_total_cases": 86123,
+              "total_sequences": 11,
               "week": "2022-03-21"
             }
           ]
@@ -24432,7 +26764,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 231
               },
               "stand_total_cases": 231,
               "total_sequences": 102,
@@ -24460,7 +26793,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 112
               },
               "stand_total_cases": 112,
               "total_sequences": 51,
@@ -24488,7 +26822,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 50
               },
               "stand_total_cases": 50,
               "total_sequences": 36,
@@ -24516,7 +26851,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 17
               },
               "stand_total_cases": 17,
               "total_sequences": 4,
@@ -24544,7 +26880,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 56
               },
               "stand_total_cases": 56,
               "total_sequences": 10,
@@ -24572,7 +26909,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 67
               },
               "stand_total_cases": 67,
               "total_sequences": 14,
@@ -24600,7 +26938,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 66
               },
               "stand_total_cases": 101,
               "total_sequences": 23,
@@ -24628,7 +26967,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 175
               },
               "stand_total_cases": 209,
               "total_sequences": 96,
@@ -24656,7 +26996,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 429
               },
               "stand_total_cases": 485,
               "total_sequences": 283,
@@ -24684,7 +27025,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 385
               },
               "stand_total_cases": 455,
               "total_sequences": 98,
@@ -24712,7 +27054,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 435
               },
               "stand_total_cases": 516,
               "total_sequences": 51,
@@ -24740,7 +27083,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 646
               },
               "stand_total_cases": 742,
               "total_sequences": 54,
@@ -24768,7 +27112,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 893
               },
               "stand_total_cases": 1105,
               "total_sequences": 156,
@@ -24796,7 +27141,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 766
               },
               "stand_total_cases": 950,
               "total_sequences": 108,
@@ -24824,7 +27170,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 296
               },
               "stand_total_cases": 954,
               "total_sequences": 257,
@@ -24852,7 +27199,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 243
               },
               "stand_total_cases": 729,
               "total_sequences": 722,
@@ -24880,7 +27228,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 233
               },
               "stand_total_cases": 954,
               "total_sequences": 1165,
@@ -24908,7 +27257,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 146
               },
               "stand_total_cases": 1082,
               "total_sequences": 1507,
@@ -24936,7 +27286,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 197
               },
               "stand_total_cases": 1515,
               "total_sequences": 1528,
@@ -24964,7 +27315,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 127
               },
               "stand_total_cases": 1735,
               "total_sequences": 1529,
@@ -24992,7 +27344,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 71
               },
               "stand_total_cases": 1361,
               "total_sequences": 862,
@@ -25020,7 +27373,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 21
               },
               "stand_total_cases": 838,
               "total_sequences": 547,
@@ -25048,7 +27402,8 @@
                 "21I (Delta)": 2,
                 "21J (Delta)": 14,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 13
               },
               "stand_total_cases": 543,
               "total_sequences": 501,
@@ -25076,7 +27431,8 @@
                 "21I (Delta)": 2,
                 "21J (Delta)": 30,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 7
               },
               "stand_total_cases": 529,
               "total_sequences": 501,
@@ -25104,7 +27460,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 76,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 5
               },
               "stand_total_cases": 407,
               "total_sequences": 467,
@@ -25132,7 +27489,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 39,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 237,
               "total_sequences": 202,
@@ -25160,7 +27518,8 @@
                 "21I (Delta)": 7,
                 "21J (Delta)": 209,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 260,
               "total_sequences": 603,
@@ -25188,7 +27547,8 @@
                 "21I (Delta)": 19,
                 "21J (Delta)": 474,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 531,
               "total_sequences": 643,
@@ -25216,7 +27576,8 @@
                 "21I (Delta)": 40,
                 "21J (Delta)": 840,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 898,
               "total_sequences": 1416,
@@ -25244,7 +27605,8 @@
                 "21I (Delta)": 71,
                 "21J (Delta)": 1616,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 1725,
               "total_sequences": 1580,
@@ -25272,7 +27634,8 @@
                 "21I (Delta)": 40,
                 "21J (Delta)": 1694,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 1741,
               "total_sequences": 956,
@@ -25300,7 +27663,8 @@
                 "21I (Delta)": 35,
                 "21J (Delta)": 1437,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 1479,
               "total_sequences": 917,
@@ -25328,7 +27692,8 @@
                 "21I (Delta)": 14,
                 "21J (Delta)": 1066,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 1086,
               "total_sequences": 701,
@@ -25356,7 +27721,8 @@
                 "21I (Delta)": 40,
                 "21J (Delta)": 1185,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1226,
               "total_sequences": 950,
@@ -25384,7 +27750,8 @@
                 "21I (Delta)": 15,
                 "21J (Delta)": 1433,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1448,
               "total_sequences": 842,
@@ -25412,7 +27779,8 @@
                 "21I (Delta)": 9,
                 "21J (Delta)": 1392,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1401,
               "total_sequences": 633,
@@ -25440,7 +27808,8 @@
                 "21I (Delta)": 5,
                 "21J (Delta)": 1982,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1987,
               "total_sequences": 429,
@@ -25468,7 +27837,8 @@
                 "21I (Delta)": 30,
                 "21J (Delta)": 2749,
                 "21K (Omicron)": 5,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2784,
               "total_sequences": 562,
@@ -25496,7 +27866,8 @@
                 "21I (Delta)": 31,
                 "21J (Delta)": 3269,
                 "21K (Omicron)": 251,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 3551,
               "total_sequences": 1047,
@@ -25524,7 +27895,8 @@
                 "21I (Delta)": 18,
                 "21J (Delta)": 3535,
                 "21K (Omicron)": 2518,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 6071,
               "total_sequences": 1039,
@@ -25552,7 +27924,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 3457,
                 "21K (Omicron)": 14303,
-                "21L (Omicron)": 43
+                "21L (Omicron)": 43,
+                "Unknown": 0
               },
               "stand_total_cases": 17803,
               "total_sequences": 824,
@@ -25580,7 +27953,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 613,
                 "21K (Omicron)": 18765,
-                "21L (Omicron)": 454
+                "21L (Omicron)": 454,
+                "Unknown": 204
               },
               "stand_total_cases": 20036,
               "total_sequences": 883,
@@ -25608,7 +27982,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 121,
                 "21K (Omicron)": 10962,
-                "21L (Omicron)": 702
+                "21L (Omicron)": 702,
+                "Unknown": 48
               },
               "stand_total_cases": 11833,
               "total_sequences": 489,
@@ -25636,7 +28011,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 26,
                 "21K (Omicron)": 12366,
-                "21L (Omicron)": 2648
+                "21L (Omicron)": 2648,
+                "Unknown": 1208
               },
               "stand_total_cases": 16248,
               "total_sequences": 632,
@@ -25664,7 +28040,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 7663,
-                "21L (Omicron)": 4145
+                "21L (Omicron)": 4145,
+                "Unknown": 218
               },
               "stand_total_cases": 12026,
               "total_sequences": 441,
@@ -25692,1338 +28069,11 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 9948,
-                "21L (Omicron)": 10529
+                "21L (Omicron)": 10529,
+                "Unknown": 166
               },
               "stand_total_cases": 20643,
               "total_sequences": 249,
-              "week": "2022-03-07"
-            }
-          ]
-        },
-        {
-          "country": "South Korea",
-          "distribution": [
-            {
-              "percent_total_cases": 0.27485380116959063,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 3,
-              "total_sequences": 47,
-              "week": "2020-04-27"
-            },
-            {
-              "percent_total_cases": 0.21548821548821548,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 5,
-              "total_sequences": 64,
-              "week": "2020-05-11"
-            },
-            {
-              "percent_total_cases": 0.2713815789473684,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 11,
-              "total_sequences": 165,
-              "week": "2020-05-25"
-            },
-            {
-              "percent_total_cases": 0.17307692307692307,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 12,
-              "total_sequences": 108,
-              "week": "2020-06-08"
-            },
-            {
-              "percent_total_cases": 0.22603719599427755,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 13,
-              "total_sequences": 158,
-              "week": "2020-06-22"
-            },
-            {
-              "percent_total_cases": 0.17350157728706625,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 12,
-              "total_sequences": 110,
-              "week": "2020-07-06"
-            },
-            {
-              "percent_total_cases": 0.15857605177993528,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 12,
-              "total_sequences": 98,
-              "week": "2020-07-20"
-            },
-            {
-              "percent_total_cases": 0.10923623445825932,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 21,
-              "total_sequences": 123,
-              "week": "2020-08-03"
-            },
-            {
-              "percent_total_cases": 0.039485559566787,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 86,
-              "total_sequences": 175,
-              "week": "2020-08-17"
-            },
-            {
-              "percent_total_cases": 0.026090675791274595,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 45,
-              "total_sequences": 61,
-              "week": "2020-08-31"
-            },
-            {
-              "percent_total_cases": 0.04505813953488372,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 26,
-              "total_sequences": 62,
-              "week": "2020-09-14"
-            },
-            {
-              "percent_total_cases": 0.05470249520153551,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 3,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 20,
-              "total_sequences": 57,
-              "week": "2020-09-28"
-            },
-            {
-              "percent_total_cases": 0.0670926517571885,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 1,
-                "20A/S:98F": 3,
-                "20B/S:732A": 0,
-                "20E (EU1)": 1,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 24,
-              "total_sequences": 84,
-              "week": "2020-10-12"
-            },
-            {
-              "percent_total_cases": 0.04818523153942428,
-              "stand_estimated_cases": {
-                "20A.EU2": 1,
-                "20A/S:126A": 0,
-                "20A/S:439K": 1,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 31,
-              "total_sequences": 77,
-              "week": "2020-10-26"
-            },
-            {
-              "percent_total_cases": 0.04926108374384237,
-              "stand_estimated_cases": {
-                "20A.EU2": 1,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 1,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 67,
-              "total_sequences": 170,
-              "week": "2020-11-09"
-            },
-            {
-              "percent_total_cases": 0.02207628894788319,
-              "stand_estimated_cases": {
-                "20A.EU2": 3,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 6,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 139,
-              "total_sequences": 158,
-              "week": "2020-11-23"
-            },
-            {
-              "percent_total_cases": 0.013837489943684634,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 1,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 3,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 10,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 242,
-              "total_sequences": 172,
-              "week": "2020-12-07"
-            },
-            {
-              "percent_total_cases": 0.013334772984937645,
-              "stand_estimated_cases": {
-                "20A.EU2": 3,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 1,
-                "20I (Alpha, V1)": 16,
-                "20J (Gamma, V3)": 1,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 16,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 361,
-              "total_sequences": 247,
-              "week": "2020-12-21"
-            },
-            {
-              "percent_total_cases": 0.022163258935539255,
-              "stand_estimated_cases": {
-                "20A.EU2": 1,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 3,
-                "20I (Alpha, V1)": 16,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 5,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 124,
-              "total_sequences": 142,
-              "week": "2021-01-11"
-            },
-            {
-              "percent_total_cases": 0.03372175141242938,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 21,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 5,
-                "21D (Eta)": 1,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 110,
-              "total_sequences": 191,
-              "week": "2021-01-25"
-            },
-            {
-              "percent_total_cases": 0.03844274311777163,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 1,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 22,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 8,
-                "21D (Eta)": 0,
-                "21F (Iota)": 1,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 119,
-              "total_sequences": 236,
-              "week": "2021-02-08"
-            },
-            {
-              "percent_total_cases": 0.04624066994356454,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 2,
-                "20I (Alpha, V1)": 13,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 3,
-                "21D (Eta)": 0,
-                "21F (Iota)": 1,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 107,
-              "total_sequences": 254,
-              "week": "2021-02-22"
-            },
-            {
-              "percent_total_cases": 0.04234579737935443,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 11,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 121,
-              "total_sequences": 265,
-              "week": "2021-03-08"
-            },
-            {
-              "percent_total_cases": 0.047326643702261494,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 2,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 2,
-                "20I (Alpha, V1)": 26,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 1,
-                "21C (Epsilon)": 5,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 130,
-              "total_sequences": 316,
-              "week": "2021-03-22"
-            },
-            {
-              "percent_total_cases": 0.04429952777153137,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 4,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 3,
-                "20I (Alpha, V1)": 33,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 3,
-                "21C (Epsilon)": 8,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 173,
-              "total_sequences": 394,
-              "week": "2021-04-05"
-            },
-            {
-              "percent_total_cases": 0.057586434706011894,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 16,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 3,
-                "20I (Alpha, V1)": 57,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 2,
-                "21B (Kappa)": 1,
-                "21C (Epsilon)": 7,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 1,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 177,
-              "total_sequences": 523,
-              "week": "2021-04-19"
-            },
-            {
-              "percent_total_cases": 0.025344545666900257,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 37,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 1,
-                "20I (Alpha, V1)": 55,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 5,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 2,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 1,
-                "21J (Delta)": 7,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 166,
-              "total_sequences": 217,
-              "week": "2021-05-03"
-            },
-            {
-              "percent_total_cases": 0.025590062111801242,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 63,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 10,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 1,
-                "21J (Delta)": 7,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 156,
-              "total_sequences": 206,
-              "week": "2021-05-17"
-            },
-            {
-              "percent_total_cases": 0.058741963948065044,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 23,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 11,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 1,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 3,
-                "21J (Delta)": 4,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 154,
-              "total_sequences": 466,
-              "week": "2021-05-31"
-            },
-            {
-              "percent_total_cases": 0.07562679819153309,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 11,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 22,
-                "20J (Gamma, V3)": 1,
-                "21A (Delta)": 2,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 18,
-                "21J (Delta)": 18,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 142,
-              "total_sequences": 552,
-              "week": "2021-06-14"
-            },
-            {
-              "percent_total_cases": 0.04972742006777663,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 8,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 1,
-                "20I (Alpha, V1)": 20,
-                "20J (Gamma, V3)": 1,
-                "21A (Delta)": 8,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 92,
-                "21J (Delta)": 39,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 264,
-              "total_sequences": 675,
-              "week": "2021-06-28"
-            },
-            {
-              "percent_total_cases": 0.04938154138915319,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 14,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 17,
-                "20J (Gamma, V3)": 1,
-                "21A (Delta)": 5,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 207,
-                "21J (Delta)": 63,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 409,
-              "total_sequences": 1038,
-              "week": "2021-07-12"
-            },
-            {
-              "percent_total_cases": 0.042007001166861145,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 9,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 8,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 11,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 318,
-                "21J (Delta)": 42,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 434,
-              "total_sequences": 936,
-              "week": "2021-07-26"
-            },
-            {
-              "percent_total_cases": 0.03536749032920186,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 3,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 1,
-                "20J (Gamma, V3)": 1,
-                "21A (Delta)": 9,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 392,
-                "21J (Delta)": 76,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 493,
-              "total_sequences": 896,
-              "week": "2021-08-09"
-            },
-            {
-              "percent_total_cases": 0.05371728621436906,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 1,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 14,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 402,
-                "21J (Delta)": 46,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 467,
-              "total_sequences": 1289,
-              "week": "2021-08-23"
-            },
-            {
-              "percent_total_cases": 0.0466262908610917,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 11,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 424,
-                "21J (Delta)": 64,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 502,
-              "total_sequences": 1201,
-              "week": "2021-09-06"
-            },
-            {
-              "percent_total_cases": 0.028597127880648863,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 1,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 6,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 488,
-                "21J (Delta)": 132,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 628,
-              "total_sequences": 922,
-              "week": "2021-09-20"
-            },
-            {
-              "percent_total_cases": 0.046856515125908396,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 3,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 362,
-                "21J (Delta)": 96,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 461,
-              "total_sequences": 1109,
-              "week": "2021-10-04"
-            },
-            {
-              "percent_total_cases": 0.06686718102959767,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 6,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 324,
-                "21J (Delta)": 116,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 447,
-              "total_sequences": 1534,
-              "week": "2021-10-18"
-            },
-            {
-              "percent_total_cases": 0.04864864864864865,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 6,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 386,
-                "21J (Delta)": 213,
-                "21K (Omicron)": 0,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 605,
-              "total_sequences": 1512,
-              "week": "2021-11-01"
-            },
-            {
-              "percent_total_cases": 0.02815937005178243,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 3,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 517,
-                "21J (Delta)": 389,
-                "21K (Omicron)": 1,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 910,
-              "total_sequences": 1316,
-              "week": "2021-11-15"
-            },
-            {
-              "percent_total_cases": 0.02110587161545482,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 2,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 739,
-                "21J (Delta)": 725,
-                "21K (Omicron)": 71,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 1537,
-              "total_sequences": 1665,
-              "week": "2021-11-29"
-            },
-            {
-              "percent_total_cases": 0.019721839651396445,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 792,
-                "21J (Delta)": 833,
-                "21K (Omicron)": 101,
-                "21L (Omicron)": 0
-              },
-              "stand_total_cases": 1726,
-              "total_sequences": 1747,
-              "week": "2021-12-13"
-            },
-            {
-              "percent_total_cases": 0.03271715721464465,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 291,
-                "21J (Delta)": 360,
-                "21K (Omicron)": 426,
-                "21L (Omicron)": 8
-              },
-              "stand_total_cases": 1086,
-              "total_sequences": 1823,
-              "week": "2021-12-27"
-            },
-            {
-              "percent_total_cases": 0.020277481323372464,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 1,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 120,
-                "21J (Delta)": 146,
-                "21K (Omicron)": 1136,
-                "21L (Omicron)": 39
-              },
-              "stand_total_cases": 1442,
-              "total_sequences": 1501,
-              "week": "2022-01-10"
-            },
-            {
-              "percent_total_cases": 0.004137703837917971,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 47,
-                "21J (Delta)": 127,
-                "21K (Omicron)": 5101,
-                "21L (Omicron)": 641
-              },
-              "stand_total_cases": 5916,
-              "total_sequences": 1256,
-              "week": "2022-01-24"
-            },
-            {
-              "percent_total_cases": 0.00158504413153695,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 15370,
-                "21L (Omicron)": 4378
-              },
-              "stand_total_cases": 19748,
-              "total_sequences": 1606,
-              "week": "2022-02-07"
-            },
-            {
-              "percent_total_cases": 0.000588394709737415,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 33,
-                "21K (Omicron)": 27329,
-                "21L (Omicron)": 23486
-              },
-              "stand_total_cases": 50848,
-              "total_sequences": 1535,
-              "week": "2022-02-21"
-            },
-            {
-              "percent_total_cases": 2.766567978847147e-05,
-              "stand_estimated_cases": {
-                "20A.EU2": 0,
-                "20A/S:126A": 0,
-                "20A/S:439K": 0,
-                "20A/S:98F": 0,
-                "20B/S:732A": 0,
-                "20E (EU1)": 0,
-                "20H (Beta, V2)": 0,
-                "20I (Alpha, V1)": 0,
-                "20J (Gamma, V3)": 0,
-                "21A (Delta)": 0,
-                "21B (Kappa)": 0,
-                "21C (Epsilon)": 0,
-                "21D (Eta)": 0,
-                "21F (Iota)": 0,
-                "21H (Mu)": 0,
-                "21I (Delta)": 0,
-                "21J (Delta)": 0,
-                "21K (Omicron)": 34522,
-                "21L (Omicron)": 61293
-              },
-              "stand_total_cases": 95815,
-              "total_sequences": 136,
               "week": "2022-03-07"
             }
           ]
@@ -27051,7 +28101,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 256
               },
               "stand_total_cases": 256,
               "total_sequences": 6,
@@ -27077,7 +28128,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 166
               },
               "stand_total_cases": 166,
               "total_sequences": 12,
@@ -27103,7 +28155,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 127
               },
               "stand_total_cases": 127,
               "total_sequences": 4,
@@ -27129,7 +28182,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 633
               },
               "stand_total_cases": 633,
               "total_sequences": 20,
@@ -27155,7 +28209,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1706
               },
               "stand_total_cases": 1706,
               "total_sequences": 24,
@@ -27181,7 +28236,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1969
               },
               "stand_total_cases": 1969,
               "total_sequences": 20,
@@ -27207,7 +28263,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 893
               },
               "stand_total_cases": 949,
               "total_sequences": 17,
@@ -27233,7 +28290,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 811
               },
               "stand_total_cases": 811,
               "total_sequences": 4,
@@ -27259,7 +28317,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 481
               },
               "stand_total_cases": 841,
               "total_sequences": 7,
@@ -27285,7 +28344,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 751
               },
               "stand_total_cases": 1691,
               "total_sequences": 18,
@@ -27311,7 +28371,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 620
               },
               "stand_total_cases": 2345,
               "total_sequences": 34,
@@ -27337,7 +28398,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 738
               },
               "stand_total_cases": 4929,
               "total_sequences": 394,
@@ -27363,7 +28425,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2003
               },
               "stand_total_cases": 14106,
               "total_sequences": 535,
@@ -27389,7 +28452,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1528
               },
               "stand_total_cases": 12532,
               "total_sequences": 443,
@@ -27415,7 +28479,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1399
               },
               "stand_total_cases": 11428,
               "total_sequences": 768,
@@ -27441,7 +28506,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1231
               },
               "stand_total_cases": 10571,
               "total_sequences": 670,
@@ -27467,7 +28533,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 903
               },
               "stand_total_cases": 6326,
               "total_sequences": 378,
@@ -27493,7 +28560,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 388
               },
               "stand_total_cases": 2668,
               "total_sequences": 254,
@@ -27519,7 +28587,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 348
               },
               "stand_total_cases": 3267,
               "total_sequences": 579,
@@ -27545,7 +28614,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 343
               },
               "stand_total_cases": 3575,
               "total_sequences": 353,
@@ -27571,7 +28641,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 607
               },
               "stand_total_cases": 3960,
               "total_sequences": 744,
@@ -27597,7 +28668,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 331
               },
               "stand_total_cases": 4188,
               "total_sequences": 673,
@@ -27623,7 +28695,8 @@
                 "21I (Delta)": 5,
                 "21J (Delta)": 42,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 126
               },
               "stand_total_cases": 4962,
               "total_sequences": 940,
@@ -27649,7 +28722,8 @@
                 "21I (Delta)": 4,
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 44
               },
               "stand_total_cases": 4160,
               "total_sequences": 1037,
@@ -27675,7 +28749,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 68
               },
               "stand_total_cases": 3873,
               "total_sequences": 1063,
@@ -27701,7 +28776,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 125
               },
               "stand_total_cases": 2704,
               "total_sequences": 731,
@@ -27727,7 +28803,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 100
               },
               "stand_total_cases": 1430,
               "total_sequences": 388,
@@ -27753,7 +28830,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 84,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 18
               },
               "stand_total_cases": 907,
               "total_sequences": 238,
@@ -27779,7 +28857,8 @@
                 "21I (Delta)": 9,
                 "21J (Delta)": 124,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 305,
               "total_sequences": 130,
@@ -27805,7 +28884,8 @@
                 "21I (Delta)": 33,
                 "21J (Delta)": 614,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 2221,
               "total_sequences": 937,
@@ -27831,7 +28911,8 @@
                 "21I (Delta)": 235,
                 "21J (Delta)": 1152,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 2208,
               "total_sequences": 696,
@@ -27857,7 +28938,8 @@
                 "21I (Delta)": 172,
                 "21J (Delta)": 995,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 1338,
               "total_sequences": 460,
@@ -27883,7 +28965,8 @@
                 "21I (Delta)": 94,
                 "21J (Delta)": 1027,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1138,
               "total_sequences": 410,
@@ -27909,7 +28992,8 @@
                 "21I (Delta)": 123,
                 "21J (Delta)": 1617,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1759,
               "total_sequences": 545,
@@ -27935,7 +29019,8 @@
                 "21I (Delta)": 136,
                 "21J (Delta)": 1576,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1712,
               "total_sequences": 591,
@@ -27961,7 +29046,8 @@
                 "21I (Delta)": 41,
                 "21J (Delta)": 1750,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1791,
               "total_sequences": 701,
@@ -27987,7 +29073,8 @@
                 "21I (Delta)": 12,
                 "21J (Delta)": 2183,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2195,
               "total_sequences": 742,
@@ -28013,7 +29100,8 @@
                 "21I (Delta)": 20,
                 "21J (Delta)": 3072,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 3092,
               "total_sequences": 787,
@@ -28039,7 +29127,8 @@
                 "21I (Delta)": 100,
                 "21J (Delta)": 3940,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 4040,
               "total_sequences": 767,
@@ -28065,7 +29154,8 @@
                 "21I (Delta)": 53,
                 "21J (Delta)": 6027,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 6080,
               "total_sequences": 1039,
@@ -28091,7 +29181,8 @@
                 "21I (Delta)": 66,
                 "21J (Delta)": 8286,
                 "21K (Omicron)": 29,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 8381,
               "total_sequences": 1144,
@@ -28117,7 +29208,8 @@
                 "21I (Delta)": 111,
                 "21J (Delta)": 6761,
                 "21K (Omicron)": 1871,
-                "21L (Omicron)": 7
+                "21L (Omicron)": 7,
+                "Unknown": -1
               },
               "stand_total_cases": 8749,
               "total_sequences": 1342,
@@ -28143,7 +29235,8 @@
                 "21I (Delta)": 18,
                 "21J (Delta)": 3377,
                 "21K (Omicron)": 17411,
-                "21L (Omicron)": 18
+                "21L (Omicron)": 18,
+                "Unknown": 0
               },
               "stand_total_cases": 20824,
               "total_sequences": 1147,
@@ -28169,7 +29262,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 844,
                 "21K (Omicron)": 38543,
-                "21L (Omicron)": 572
+                "21L (Omicron)": 572,
+                "Unknown": 0
               },
               "stand_total_cases": 39959,
               "total_sequences": 1467,
@@ -28195,7 +29289,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 181,
                 "21K (Omicron)": 41718,
-                "21L (Omicron)": 2819
+                "21L (Omicron)": 2819,
+                "Unknown": 0
               },
               "stand_total_cases": 44718,
               "total_sequences": 1729,
@@ -28224,7 +29319,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1780
               },
               "stand_total_cases": 1780,
               "total_sequences": 110,
@@ -28248,7 +29344,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1518
               },
               "stand_total_cases": 1518,
               "total_sequences": 70,
@@ -28272,7 +29369,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1154
               },
               "stand_total_cases": 1154,
               "total_sequences": 59,
@@ -28296,7 +29394,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 767
               },
               "stand_total_cases": 767,
               "total_sequences": 48,
@@ -28320,7 +29419,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 496
               },
               "stand_total_cases": 496,
               "total_sequences": 70,
@@ -28344,7 +29444,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 570
               },
               "stand_total_cases": 570,
               "total_sequences": 73,
@@ -28368,7 +29469,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 900
               },
               "stand_total_cases": 900,
               "total_sequences": 21,
@@ -28392,7 +29494,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 535
               },
               "stand_total_cases": 535,
               "total_sequences": 18,
@@ -28416,7 +29519,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 187
               },
               "stand_total_cases": 187,
               "total_sequences": 28,
@@ -28440,7 +29544,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 116
               },
               "stand_total_cases": 116,
               "total_sequences": 24,
@@ -28464,7 +29569,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 53
               },
               "stand_total_cases": 53,
               "total_sequences": 11,
@@ -28488,7 +29594,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 30
               },
               "stand_total_cases": 32,
               "total_sequences": 27,
@@ -28512,7 +29619,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 16
               },
               "stand_total_cases": 17,
               "total_sequences": 23,
@@ -28536,7 +29644,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 11
               },
               "stand_total_cases": 15,
               "total_sequences": 23,
@@ -28560,7 +29669,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 18
               },
               "stand_total_cases": 19,
               "total_sequences": 26,
@@ -28584,7 +29694,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 18
               },
               "stand_total_cases": 18,
               "total_sequences": 24,
@@ -28608,7 +29719,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 26
               },
               "stand_total_cases": 29,
               "total_sequences": 35,
@@ -28632,7 +29744,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 77
               },
               "stand_total_cases": 88,
               "total_sequences": 98,
@@ -28656,7 +29769,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 48
               },
               "stand_total_cases": 73,
               "total_sequences": 64,
@@ -28680,7 +29794,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 46
               },
               "stand_total_cases": 71,
               "total_sequences": 72,
@@ -28704,7 +29819,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 23
               },
               "stand_total_cases": 31,
               "total_sequences": 42,
@@ -28728,7 +29844,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 16
               },
               "stand_total_cases": 30,
               "total_sequences": 30,
@@ -28752,7 +29869,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 10
               },
               "stand_total_cases": 29,
               "total_sequences": 45,
@@ -28776,7 +29894,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 8
               },
               "stand_total_cases": 51,
               "total_sequences": 159,
@@ -28800,7 +29919,8 @@
                 "21I (Delta)": 3,
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 12
               },
               "stand_total_cases": 64,
               "total_sequences": 178,
@@ -28824,7 +29944,8 @@
                 "21I (Delta)": 3,
                 "21J (Delta)": 15,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 70,
               "total_sequences": 190,
@@ -28848,7 +29969,8 @@
                 "21I (Delta)": 8,
                 "21J (Delta)": 41,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 67,
               "total_sequences": 216,
@@ -28872,7 +29994,8 @@
                 "21I (Delta)": 23,
                 "21J (Delta)": 47,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 5
               },
               "stand_total_cases": 81,
               "total_sequences": 327,
@@ -28896,7 +30019,8 @@
                 "21I (Delta)": 4,
                 "21J (Delta)": 38,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 45,
               "total_sequences": 178,
@@ -28920,7 +30044,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 46,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 49,
               "total_sequences": 215,
@@ -28944,7 +30069,8 @@
                 "21I (Delta)": 6,
                 "21J (Delta)": 15,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 27,
               "total_sequences": 75,
@@ -28968,7 +30094,8 @@
                 "21I (Delta)": 2,
                 "21J (Delta)": 267,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 272,
               "total_sequences": 836,
@@ -28992,7 +30119,8 @@
                 "21I (Delta)": 2,
                 "21J (Delta)": 288,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 290,
               "total_sequences": 861,
@@ -29016,7 +30144,8 @@
                 "21I (Delta)": 12,
                 "21J (Delta)": 118,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 130,
               "total_sequences": 640,
@@ -29040,7 +30169,8 @@
                 "21I (Delta)": 7,
                 "21J (Delta)": 392,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 400,
               "total_sequences": 1008,
@@ -29064,7 +30194,8 @@
                 "21I (Delta)": 7,
                 "21J (Delta)": 1669,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1676,
               "total_sequences": 700,
@@ -29088,7 +30219,8 @@
                 "21I (Delta)": 16,
                 "21J (Delta)": 4758,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 4774,
               "total_sequences": 610,
@@ -29112,7 +30244,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 8129,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 8129,
               "total_sequences": 571,
@@ -29136,7 +30269,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 9187,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 9204,
               "total_sequences": 537,
@@ -29160,7 +30294,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 7119,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 7119,
               "total_sequences": 540,
@@ -29184,7 +30319,8 @@
                 "21I (Delta)": 30,
                 "21J (Delta)": 4587,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 4617,
               "total_sequences": 463,
@@ -29208,7 +30344,8 @@
                 "21I (Delta)": 34,
                 "21J (Delta)": 1842,
                 "21K (Omicron)": 137,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2013,
               "total_sequences": 411,
@@ -29232,7 +30369,8 @@
                 "21I (Delta)": 9,
                 "21J (Delta)": 367,
                 "21K (Omicron)": 427,
-                "21L (Omicron)": 4
+                "21L (Omicron)": 4,
+                "Unknown": 0
               },
               "stand_total_cases": 807,
               "total_sequences": 682,
@@ -29256,7 +30394,8 @@
                 "21I (Delta)": 8,
                 "21J (Delta)": 305,
                 "21K (Omicron)": 962,
-                "21L (Omicron)": 170
+                "21L (Omicron)": 170,
+                "Unknown": 0
               },
               "stand_total_cases": 1445,
               "total_sequences": 568,
@@ -29280,7 +30419,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 287,
                 "21K (Omicron)": 2745,
-                "21L (Omicron)": 2125
+                "21L (Omicron)": 2125,
+                "Unknown": 0
               },
               "stand_total_cases": 5157,
               "total_sequences": 682,
@@ -29304,7 +30444,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 36,
                 "21K (Omicron)": 6125,
-                "21L (Omicron)": 7829
+                "21L (Omicron)": 7829,
+                "Unknown": 0
               },
               "stand_total_cases": 13990,
               "total_sequences": 386,
@@ -29328,7 +30469,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 80,
                 "21K (Omicron)": 17337,
-                "21L (Omicron)": 17894
+                "21L (Omicron)": 17894,
+                "Unknown": -1
               },
               "stand_total_cases": 35310,
               "total_sequences": 444,
@@ -29352,7 +30494,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 12065,
-                "21L (Omicron)": 33809
+                "21L (Omicron)": 33809,
+                "Unknown": 0
               },
               "stand_total_cases": 45874,
               "total_sequences": 635,
@@ -29376,14 +30519,15 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 2784,
-                "21L (Omicron)": 30624
+                "21L (Omicron)": 30624,
+                "Unknown": 0
               },
               "stand_total_cases": 33408,
               "total_sequences": 456,
               "week": "2022-03-07"
             },
             {
-              "percent_total_cases": 0.005668922271369304,
+              "percent_total_cases": 0.005890611969132349,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:439K": 0,
@@ -29399,15 +30543,16 @@
                 "21F (Iota)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 906,
-                "21L (Omicron)": 16431
+                "21K (Omicron)": 872,
+                "21L (Omicron)": 16466,
+                "Unknown": 31
               },
               "stand_total_cases": 17369,
-              "total_sequences": 537,
+              "total_sequences": 558,
               "week": "2022-03-21"
             },
             {
-              "percent_total_cases": 0.0022351451855368303,
+              "percent_total_cases": 0.006646095418941372,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:439K": 0,
@@ -29423,11 +30568,12 @@
                 "21F (Iota)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 328,
-                "21L (Omicron)": 8942
+                "21K (Omicron)": 221,
+                "21L (Omicron)": 9049,
+                "Unknown": 0
               },
               "stand_total_cases": 9270,
-              "total_sequences": 113,
+              "total_sequences": 336,
               "week": "2022-04-04"
             }
           ]
@@ -29452,7 +30598,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 68
               },
               "stand_total_cases": 68,
               "total_sequences": 19,
@@ -29475,7 +30622,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 21
               },
               "stand_total_cases": 21,
               "total_sequences": 3,
@@ -29498,7 +30646,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 12
               },
               "stand_total_cases": 12,
               "total_sequences": 5,
@@ -29521,7 +30670,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 6
               },
               "stand_total_cases": 6,
               "total_sequences": 3,
@@ -29544,7 +30694,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 36
               },
               "stand_total_cases": 36,
               "total_sequences": 29,
@@ -29567,7 +30718,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 27
               },
               "stand_total_cases": 27,
               "total_sequences": 11,
@@ -29590,7 +30742,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 42
               },
               "stand_total_cases": 42,
               "total_sequences": 18,
@@ -29613,7 +30766,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 16
               },
               "stand_total_cases": 38,
               "total_sequences": 21,
@@ -29636,7 +30790,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 33
               },
               "stand_total_cases": 43,
               "total_sequences": 23,
@@ -29659,7 +30814,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 87
               },
               "stand_total_cases": 108,
               "total_sequences": 46,
@@ -29682,7 +30838,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 427
               },
               "stand_total_cases": 532,
               "total_sequences": 296,
@@ -29705,7 +30862,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 806
               },
               "stand_total_cases": 1075,
               "total_sequences": 12,
@@ -29728,7 +30886,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1830
               },
               "stand_total_cases": 1830,
               "total_sequences": 1,
@@ -29751,7 +30910,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2691
               },
               "stand_total_cases": 2691,
               "total_sequences": 1,
@@ -29774,7 +30934,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 5156,
               "total_sequences": 7,
@@ -29797,7 +30958,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 4989
               },
               "stand_total_cases": 9977,
               "total_sequences": 4,
@@ -29820,7 +30982,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1967
               },
               "stand_total_cases": 6127,
               "total_sequences": 81,
@@ -29843,7 +31006,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2308
               },
               "stand_total_cases": 5780,
               "total_sequences": 248,
@@ -29866,7 +31030,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1584
               },
               "stand_total_cases": 5205,
               "total_sequences": 427,
@@ -29889,7 +31054,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1203
               },
               "stand_total_cases": 4720,
               "total_sequences": 467,
@@ -29912,7 +31078,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 726
               },
               "stand_total_cases": 3791,
               "total_sequences": 1214,
@@ -29935,7 +31102,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 33,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 361
               },
               "stand_total_cases": 3586,
               "total_sequences": 966,
@@ -29958,7 +31126,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 210
               },
               "stand_total_cases": 3872,
               "total_sequences": 739,
@@ -29981,7 +31150,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 205
               },
               "stand_total_cases": 4507,
               "total_sequences": 789,
@@ -30004,7 +31174,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 42,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 135
               },
               "stand_total_cases": 4407,
               "total_sequences": 525,
@@ -30027,7 +31198,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 89,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 69
               },
               "stand_total_cases": 2742,
               "total_sequences": 555,
@@ -30050,7 +31222,8 @@
                 "21I (Delta)": 5,
                 "21J (Delta)": 230,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 51
               },
               "stand_total_cases": 1570,
               "total_sequences": 307,
@@ -30073,7 +31246,8 @@
                 "21I (Delta)": 5,
                 "21J (Delta)": 250,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 5
               },
               "stand_total_cases": 632,
               "total_sequences": 129,
@@ -30096,7 +31270,8 @@
                 "21I (Delta)": 4,
                 "21J (Delta)": 273,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 11
               },
               "stand_total_cases": 369,
               "total_sequences": 250,
@@ -30119,7 +31294,8 @@
                 "21I (Delta)": 22,
                 "21J (Delta)": 271,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 311,
               "total_sequences": 139,
@@ -30142,7 +31318,8 @@
                 "21I (Delta)": 10,
                 "21J (Delta)": 486,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 503,
               "total_sequences": 146,
@@ -30165,7 +31342,8 @@
                 "21I (Delta)": 12,
                 "21J (Delta)": 760,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 869,
               "total_sequences": 143,
@@ -30188,7 +31366,8 @@
                 "21I (Delta)": 176,
                 "21J (Delta)": 1680,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 1860,
               "total_sequences": 413,
@@ -30211,7 +31390,8 @@
                 "21I (Delta)": 222,
                 "21J (Delta)": 2982,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 3236,
               "total_sequences": 102,
@@ -30234,7 +31414,8 @@
                 "21I (Delta)": 198,
                 "21J (Delta)": 5638,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 5935,
               "total_sequences": 240,
@@ -30257,7 +31438,8 @@
                 "21I (Delta)": 402,
                 "21J (Delta)": 12404,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 12840,
               "total_sequences": 383,
@@ -30280,7 +31462,8 @@
                 "21I (Delta)": 585,
                 "21J (Delta)": 17314,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 17957,
               "total_sequences": 614,
@@ -30303,7 +31486,8 @@
                 "21I (Delta)": 238,
                 "21J (Delta)": 11118,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 11356,
               "total_sequences": 620,
@@ -30326,7 +31510,8 @@
                 "21I (Delta)": 75,
                 "21J (Delta)": 6391,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 6466,
               "total_sequences": 429,
@@ -30349,7 +31534,8 @@
                 "21I (Delta)": 113,
                 "21J (Delta)": 4950,
                 "21K (Omicron)": 21,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 5105,
               "total_sequences": 724,
@@ -30372,7 +31558,8 @@
                 "21I (Delta)": 95,
                 "21J (Delta)": 4416,
                 "21K (Omicron)": 560,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 5081,
               "total_sequences": 481,
@@ -30395,7 +31582,8 @@
                 "21I (Delta)": 17,
                 "21J (Delta)": 5086,
                 "21K (Omicron)": 3675,
-                "21L (Omicron)": 17
+                "21L (Omicron)": 17,
+                "Unknown": 0
               },
               "stand_total_cases": 8795,
               "total_sequences": 517,
@@ -30418,7 +31606,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 4660,
                 "21K (Omicron)": 20884,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 25544,
               "total_sequences": 148,
@@ -30443,7 +31632,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 136
               },
               "stand_total_cases": 228,
               "total_sequences": 5,
@@ -30463,7 +31653,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 344
               },
               "stand_total_cases": 395,
               "total_sequences": 117,
@@ -30483,7 +31674,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 464
               },
               "stand_total_cases": 501,
               "total_sequences": 53,
@@ -30503,7 +31695,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 325
               },
               "stand_total_cases": 412,
               "total_sequences": 19,
@@ -30523,7 +31716,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 794
               },
               "stand_total_cases": 1293,
               "total_sequences": 44,
@@ -30543,7 +31737,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 799
               },
               "stand_total_cases": 2715,
               "total_sequences": 17,
@@ -30563,7 +31758,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 5143,
               "total_sequences": 2,
@@ -30583,7 +31779,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2211
               },
               "stand_total_cases": 8845,
               "total_sequences": 48,
@@ -30603,7 +31800,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2173
               },
               "stand_total_cases": 5433,
               "total_sequences": 10,
@@ -30623,7 +31821,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1505
               },
               "stand_total_cases": 5442,
               "total_sequences": 47,
@@ -30643,7 +31842,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2550
               },
               "stand_total_cases": 7310,
               "total_sequences": 559,
@@ -30663,7 +31863,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2285
               },
               "stand_total_cases": 13120,
               "total_sequences": 155,
@@ -30683,7 +31884,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1905
               },
               "stand_total_cases": 15392,
               "total_sequences": 978,
@@ -30703,7 +31905,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 645
               },
               "stand_total_cases": 10563,
               "total_sequences": 1079,
@@ -30723,7 +31926,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 16
               },
               "stand_total_cases": 6153,
               "total_sequences": 366,
@@ -30743,7 +31947,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 34
               },
               "stand_total_cases": 3871,
               "total_sequences": 349,
@@ -30763,7 +31968,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 51
               },
               "stand_total_cases": 3296,
               "total_sequences": 326,
@@ -30783,7 +31989,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 11,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 772,
               "total_sequences": 137,
@@ -30803,7 +32010,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 15,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 345,
               "total_sequences": 45,
@@ -30823,7 +32031,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 357,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 391,
               "total_sequences": 138,
@@ -30843,7 +32052,8 @@
                 "21I (Delta)": 6,
                 "21J (Delta)": 700,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 732,
               "total_sequences": 251,
@@ -30863,7 +32073,8 @@
                 "21I (Delta)": 72,
                 "21J (Delta)": 1887,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 1975,
               "total_sequences": 359,
@@ -30883,7 +32094,8 @@
                 "21I (Delta)": 228,
                 "21J (Delta)": 2557,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2815,
               "total_sequences": 371,
@@ -30903,7 +32115,8 @@
                 "21I (Delta)": 244,
                 "21J (Delta)": 3493,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 3758,
               "total_sequences": 369,
@@ -30923,7 +32136,8 @@
                 "21I (Delta)": 340,
                 "21J (Delta)": 4178,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 4518,
               "total_sequences": 345,
@@ -30943,7 +32157,8 @@
                 "21I (Delta)": 633,
                 "21J (Delta)": 5842,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 6475,
               "total_sequences": 348,
@@ -30963,7 +32178,8 @@
                 "21I (Delta)": 1075,
                 "21J (Delta)": 9608,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 10683,
               "total_sequences": 318,
@@ -30983,7 +32199,8 @@
                 "21I (Delta)": 824,
                 "21J (Delta)": 15366,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 16190,
               "total_sequences": 334,
@@ -31003,7 +32220,8 @@
                 "21I (Delta)": 793,
                 "21J (Delta)": 12885,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 13678,
               "total_sequences": 276,
@@ -31023,7 +32241,8 @@
                 "21I (Delta)": 281,
                 "21J (Delta)": 6852,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 7133,
               "total_sequences": 330,
@@ -31043,7 +32262,8 @@
                 "21I (Delta)": 117,
                 "21J (Delta)": 4961,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 5078,
               "total_sequences": 347,
@@ -31063,7 +32283,8 @@
                 "21I (Delta)": 159,
                 "21J (Delta)": 6093,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 6252,
               "total_sequences": 275,
@@ -31083,7 +32304,8 @@
                 "21I (Delta)": 122,
                 "21J (Delta)": 11794,
                 "21K (Omicron)": 122,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 12037,
               "total_sequences": 99,
@@ -31103,7 +32325,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 24957,
                 "21K (Omicron)": 4404,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 29361,
               "total_sequences": 20,
@@ -31123,7 +32346,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 2252,
                 "21K (Omicron)": 41282,
-                "21L (Omicron)": 24018
+                "21L (Omicron)": 24018,
+                "Unknown": 0
               },
               "stand_total_cases": 67552,
               "total_sequences": 90,
@@ -31143,7 +32367,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 22802,
-                "21L (Omicron)": 36662
+                "21L (Omicron)": 36662,
+                "Unknown": 0
               },
               "stand_total_cases": 59464,
               "total_sequences": 266,
@@ -31163,7 +32388,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 10414,
-                "21L (Omicron)": 31814
+                "21L (Omicron)": 31814,
+                "Unknown": 0
               },
               "stand_total_cases": 42228,
               "total_sequences": 369,
@@ -31183,7 +32409,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 1599,
-                "21L (Omicron)": 18476
+                "21L (Omicron)": 18476,
+                "Unknown": 56
               },
               "stand_total_cases": 20131,
               "total_sequences": 365,
@@ -31203,7 +32430,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 425,
-                "21L (Omicron)": 11890
+                "21L (Omicron)": 11890,
+                "Unknown": 0
               },
               "stand_total_cases": 12315,
               "total_sequences": 58,
@@ -31232,7 +32460,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 5
               },
               "stand_total_cases": 5,
               "total_sequences": 8,
@@ -31256,7 +32485,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 1,
               "total_sequences": 1,
@@ -31280,7 +32510,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 1,
               "total_sequences": 5,
@@ -31304,7 +32535,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 4,
               "total_sequences": 3,
@@ -31328,7 +32560,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 3,
               "total_sequences": 3,
@@ -31352,7 +32585,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 2,
               "total_sequences": 2,
@@ -31376,7 +32610,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 12
               },
               "stand_total_cases": 12,
               "total_sequences": 37,
@@ -31400,7 +32635,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 20
               },
               "stand_total_cases": 20,
               "total_sequences": 74,
@@ -31424,7 +32660,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 11
               },
               "stand_total_cases": 11,
               "total_sequences": 33,
@@ -31448,7 +32685,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 6
               },
               "stand_total_cases": 6,
               "total_sequences": 16,
@@ -31472,7 +32710,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 7,
               "total_sequences": 14,
@@ -31496,7 +32735,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 10
               },
               "stand_total_cases": 13,
               "total_sequences": 36,
@@ -31520,7 +32760,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 6
               },
               "stand_total_cases": 8,
               "total_sequences": 32,
@@ -31544,7 +32785,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 5
               },
               "stand_total_cases": 8,
               "total_sequences": 20,
@@ -31568,7 +32810,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 8
               },
               "stand_total_cases": 9,
               "total_sequences": 28,
@@ -31592,7 +32835,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 8,
               "total_sequences": 20,
@@ -31616,7 +32860,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 10
               },
               "stand_total_cases": 19,
               "total_sequences": 39,
@@ -31640,7 +32885,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 12,
               "total_sequences": 22,
@@ -31664,7 +32910,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 6,
               "total_sequences": 17,
@@ -31688,7 +32935,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 7,
               "total_sequences": 19,
@@ -31712,7 +32960,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 9,
               "total_sequences": 26,
@@ -31736,7 +32985,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 11,
               "total_sequences": 28,
@@ -31760,7 +33010,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 8,
               "total_sequences": 29,
@@ -31784,7 +33035,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 17,
               "total_sequences": 26,
@@ -31808,7 +33060,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 5,
               "total_sequences": 19,
@@ -31832,7 +33085,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 5,
               "total_sequences": 7,
@@ -31856,7 +33110,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 2,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 4,
               "total_sequences": 8,
@@ -31880,7 +33135,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 3,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 7,
               "total_sequences": 14,
@@ -31904,7 +33160,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 5,
               "total_sequences": 13,
@@ -31928,7 +33185,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 2,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 5,
               "total_sequences": 12,
@@ -31952,7 +33210,8 @@
                 "21I (Delta)": 6,
                 "21J (Delta)": 12,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 18,
               "total_sequences": 49,
@@ -31976,7 +33235,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 5,
               "total_sequences": 31,
@@ -32000,7 +33260,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 30,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 31,
               "total_sequences": 173,
@@ -32024,7 +33285,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 143,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 143,
               "total_sequences": 613,
@@ -32048,7 +33310,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 56,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 56,
               "total_sequences": 238,
@@ -32072,7 +33335,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 57,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 58,
               "total_sequences": 276,
@@ -32096,7 +33360,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 131,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 131,
               "total_sequences": 583,
@@ -32120,7 +33385,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 300,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 300,
               "total_sequences": 605,
@@ -32144,7 +33410,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 442,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 443,
               "total_sequences": 567,
@@ -32168,7 +33435,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 502,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 502,
               "total_sequences": 462,
@@ -32192,7 +33460,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 297,
                 "21K (Omicron)": 3,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 300,
               "total_sequences": 353,
@@ -32216,7 +33485,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 154,
                 "21K (Omicron)": 24,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 178,
               "total_sequences": 440,
@@ -32240,7 +33510,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 93,
                 "21K (Omicron)": 63,
-                "21L (Omicron)": 5
+                "21L (Omicron)": 5,
+                "Unknown": 1
               },
               "stand_total_cases": 162,
               "total_sequences": 516,
@@ -32264,7 +33535,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 51,
                 "21K (Omicron)": 94,
-                "21L (Omicron)": 29
+                "21L (Omicron)": 29,
+                "Unknown": 0
               },
               "stand_total_cases": 174,
               "total_sequences": 534,
@@ -32288,7 +33560,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 38,
                 "21K (Omicron)": 291,
-                "21L (Omicron)": 130
+                "21L (Omicron)": 130,
+                "Unknown": 1
               },
               "stand_total_cases": 460,
               "total_sequences": 674,
@@ -32312,7 +33585,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 36,
                 "21K (Omicron)": 2094,
-                "21L (Omicron)": 859
+                "21L (Omicron)": 859,
+                "Unknown": 1
               },
               "stand_total_cases": 2990,
               "total_sequences": 821,
@@ -32336,7 +33610,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 67,
                 "21K (Omicron)": 15117,
-                "21L (Omicron)": 25128
+                "21L (Omicron)": 25128,
+                "Unknown": 68
               },
               "stand_total_cases": 40380,
               "total_sequences": 601,
@@ -32360,7 +33635,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 11530,
-                "21L (Omicron)": 38683
+                "21L (Omicron)": 38683,
+                "Unknown": 0
               },
               "stand_total_cases": 50213,
               "total_sequences": 675,
@@ -32384,7 +33660,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 5211,
-                "21L (Omicron)": 34811
+                "21L (Omicron)": 34811,
+                "Unknown": 111
               },
               "stand_total_cases": 40133,
               "total_sequences": 362,
@@ -32411,7 +33688,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 180
               },
               "stand_total_cases": 184,
               "total_sequences": 50,
@@ -32433,7 +33711,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 250
               },
               "stand_total_cases": 282,
               "total_sequences": 79,
@@ -32455,7 +33734,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 209
               },
               "stand_total_cases": 254,
               "total_sequences": 74,
@@ -32477,7 +33757,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 98
               },
               "stand_total_cases": 162,
               "total_sequences": 41,
@@ -32499,7 +33780,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 178
               },
               "stand_total_cases": 1241,
               "total_sequences": 453,
@@ -32521,7 +33803,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 97
               },
               "stand_total_cases": 2448,
               "total_sequences": 837,
@@ -32543,7 +33826,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 156
               },
               "stand_total_cases": 2500,
               "total_sequences": 775,
@@ -32565,7 +33849,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 143
               },
               "stand_total_cases": 1708,
               "total_sequences": 520,
@@ -32587,7 +33872,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 260
               },
               "stand_total_cases": 539,
               "total_sequences": 158,
@@ -32609,7 +33895,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 69
               },
               "stand_total_cases": 555,
               "total_sequences": 176,
@@ -32631,7 +33918,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 77
               },
               "stand_total_cases": 433,
               "total_sequences": 146,
@@ -32653,7 +33941,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 173
               },
               "stand_total_cases": 672,
               "total_sequences": 237,
@@ -32675,7 +33964,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 87
               },
               "stand_total_cases": 246,
               "total_sequences": 75,
@@ -32697,7 +33987,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 33
               },
               "stand_total_cases": 108,
               "total_sequences": 26,
@@ -32719,7 +34010,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 11
               },
               "stand_total_cases": 67,
               "total_sequences": 18,
@@ -32741,7 +34033,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 37,
               "total_sequences": 12,
@@ -32763,7 +34056,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 2,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 103,
               "total_sequences": 51,
@@ -32785,7 +34079,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 347,
               "total_sequences": 101,
@@ -32807,7 +34102,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 165,
               "total_sequences": 83,
@@ -32829,7 +34125,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 504,
               "total_sequences": 147,
@@ -32851,7 +34148,8 @@
                 "21A (Delta)": 3,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 0
+                "21J (Delta)": 0,
+                "Unknown": 6
               },
               "stand_total_cases": 176,
               "total_sequences": 59,
@@ -32873,7 +34171,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
-                "21J (Delta)": 5
+                "21J (Delta)": 5,
+                "Unknown": 0
               },
               "stand_total_cases": 105,
               "total_sequences": 39,
@@ -32895,7 +34194,8 @@
                 "21A (Delta)": 0,
                 "21D (Eta)": 0,
                 "21I (Delta)": 4,
-                "21J (Delta)": 11
+                "21J (Delta)": 11,
+                "Unknown": 4
               },
               "stand_total_cases": 108,
               "total_sequences": 29,
@@ -32917,7 +34217,8 @@
                 "21A (Delta)": 7,
                 "21D (Eta)": 0,
                 "21I (Delta)": 8,
-                "21J (Delta)": 14
+                "21J (Delta)": 14,
+                "Unknown": 3
               },
               "stand_total_cases": 56,
               "total_sequences": 33,
@@ -32939,7 +34240,8 @@
                 "21A (Delta)": 16,
                 "21D (Eta)": 0,
                 "21I (Delta)": 8,
-                "21J (Delta)": 54
+                "21J (Delta)": 54,
+                "Unknown": 0
               },
               "stand_total_cases": 103,
               "total_sequences": 38,
@@ -32961,7 +34263,8 @@
                 "21A (Delta)": 15,
                 "21D (Eta)": 0,
                 "21I (Delta)": 603,
-                "21J (Delta)": 885
+                "21J (Delta)": 885,
+                "Unknown": 1
               },
               "stand_total_cases": 1513,
               "total_sequences": 612,
@@ -32983,7 +34286,8 @@
                 "21A (Delta)": 78,
                 "21D (Eta)": 0,
                 "21I (Delta)": 2433,
-                "21J (Delta)": 1713
+                "21J (Delta)": 1713,
+                "Unknown": 0
               },
               "stand_total_cases": 4230,
               "total_sequences": 1415,
@@ -33005,7 +34309,8 @@
                 "21A (Delta)": 58,
                 "21D (Eta)": 0,
                 "21I (Delta)": 1907,
-                "21J (Delta)": 1619
+                "21J (Delta)": 1619,
+                "Unknown": 0
               },
               "stand_total_cases": 3584,
               "total_sequences": 1242,
@@ -33027,7 +34332,8 @@
                 "21A (Delta)": 13,
                 "21D (Eta)": 0,
                 "21I (Delta)": 921,
-                "21J (Delta)": 1552
+                "21J (Delta)": 1552,
+                "Unknown": 0
               },
               "stand_total_cases": 2486,
               "total_sequences": 394,
@@ -33056,7 +34362,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 9142
               },
               "stand_total_cases": 9142,
               "total_sequences": 4,
@@ -33080,7 +34387,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 8349
               },
               "stand_total_cases": 8349,
               "total_sequences": 1,
@@ -33104,7 +34412,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 4886
               },
               "stand_total_cases": 6352,
               "total_sequences": 26,
@@ -33128,7 +34437,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 4065
               },
               "stand_total_cases": 4664,
               "total_sequences": 109,
@@ -33152,7 +34462,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 56
+                "S:677H.Robin1": 56,
+                "Unknown": 2424
               },
               "stand_total_cases": 4207,
               "total_sequences": 151,
@@ -33176,7 +34487,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 467
               },
               "stand_total_cases": 4067,
               "total_sequences": 122,
@@ -33200,7 +34512,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 311
               },
               "stand_total_cases": 6166,
               "total_sequences": 99,
@@ -33224,7 +34537,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 89
               },
               "stand_total_cases": 8088,
               "total_sequences": 91,
@@ -33248,7 +34562,8 @@
                 "21J (Delta)": 590,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 274
               },
               "stand_total_cases": 6399,
               "total_sequences": 141,
@@ -33272,7 +34587,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 44
               },
               "stand_total_cases": 3041,
               "total_sequences": 135,
@@ -33296,7 +34612,8 @@
                 "21J (Delta)": 190,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 38
               },
               "stand_total_cases": 1903,
               "total_sequences": 100,
@@ -33320,7 +34637,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1156,
               "total_sequences": 104,
@@ -33344,7 +34662,8 @@
                 "21J (Delta)": 44,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 951,
               "total_sequences": 86,
@@ -33368,7 +34687,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 475,
               "total_sequences": 24,
@@ -33392,7 +34712,8 @@
                 "21J (Delta)": 159,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 354,
               "total_sequences": 29,
@@ -33416,7 +34737,8 @@
                 "21J (Delta)": 1086,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1987,
               "total_sequences": 97,
@@ -33440,7 +34762,8 @@
                 "21J (Delta)": 8007,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 10009,
               "total_sequences": 340,
@@ -33464,7 +34787,8 @@
                 "21J (Delta)": 11050,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 14440,
               "total_sequences": 524,
@@ -33488,7 +34812,8 @@
                 "21J (Delta)": 6414,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 7546,
               "total_sequences": 260,
@@ -33512,7 +34837,8 @@
                 "21J (Delta)": 3460,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 4076,
               "total_sequences": 139,
@@ -33536,7 +34862,8 @@
                 "21J (Delta)": 2479,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2677,
               "total_sequences": 176,
@@ -33560,7 +34887,8 @@
                 "21J (Delta)": 1670,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1716,
               "total_sequences": 37,
@@ -33584,7 +34912,8 @@
                 "21J (Delta)": 1473,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1473,
               "total_sequences": 73,
@@ -33608,7 +34937,8 @@
                 "21J (Delta)": 2248,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2248,
               "total_sequences": 43,
@@ -33632,7 +34962,8 @@
                 "21J (Delta)": 2434,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2509,
               "total_sequences": 100,
@@ -33656,7 +34987,8 @@
                 "21J (Delta)": 7485,
                 "21K (Omicron)": 2356,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 9841,
               "total_sequences": 71,
@@ -33680,7 +35012,8 @@
                 "21J (Delta)": 3246,
                 "21K (Omicron)": 87653,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 90899,
               "total_sequences": 28,
@@ -33704,7 +35037,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 2835,
                 "21L (Omicron)": 0,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2835,
               "total_sequences": 7,
@@ -33728,7 +35062,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 194,
                 "21L (Omicron)": 1746,
-                "S:677H.Robin1": 0
+                "S:677H.Robin1": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1940,
               "total_sequences": 10,
@@ -33749,7 +35084,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 2,
@@ -33765,7 +35101,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 3,
@@ -33781,7 +35118,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 2,
               "total_sequences": 14,
@@ -33797,7 +35135,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 1,
@@ -33813,7 +35152,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 1,
               "total_sequences": 5,
@@ -33829,7 +35169,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 3,
               "total_sequences": 2,
@@ -33845,7 +35186,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 3,
@@ -33861,7 +35203,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 5,
               "total_sequences": 12,
@@ -33877,7 +35220,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 26,
               "total_sequences": 14,
@@ -33893,7 +35237,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 43,
               "total_sequences": 13,
@@ -33909,7 +35254,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 37
               },
               "stand_total_cases": 55,
               "total_sequences": 3,
@@ -33925,7 +35271,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 11
               },
               "stand_total_cases": 218,
               "total_sequences": 38,
@@ -33941,7 +35288,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 479,
               "total_sequences": 56,
@@ -33957,7 +35305,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 452,
               "total_sequences": 52,
@@ -33973,7 +35322,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 24
               },
               "stand_total_cases": 426,
               "total_sequences": 69,
@@ -33989,7 +35339,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 36
               },
               "stand_total_cases": 532,
               "total_sequences": 75,
@@ -34005,7 +35356,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 6,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 544,
               "total_sequences": 94,
@@ -34021,7 +35373,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 785,
               "total_sequences": 77,
@@ -34037,7 +35390,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 49,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 705,
               "total_sequences": 114,
@@ -34053,7 +35407,8 @@
                 "21I (Delta)": 8,
                 "21J (Delta)": 61,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 529,
               "total_sequences": 69,
@@ -34069,7 +35424,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 34,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 433,
               "total_sequences": 103,
@@ -34085,7 +35441,8 @@
                 "21I (Delta)": 4,
                 "21J (Delta)": 28,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 358,
               "total_sequences": 89,
@@ -34101,7 +35458,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 100,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 518,
               "total_sequences": 114,
@@ -34117,7 +35475,8 @@
                 "21I (Delta)": 6,
                 "21J (Delta)": 51,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 540,
               "total_sequences": 84,
@@ -34133,7 +35492,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 29,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 201,
               "total_sequences": 123,
@@ -34149,7 +35509,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 31,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 109,
               "total_sequences": 128,
@@ -34165,7 +35526,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 15,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 59,
               "total_sequences": 142,
@@ -34181,7 +35543,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 12,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 32,
               "total_sequences": 148,
@@ -34197,7 +35560,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 7,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 15,
               "total_sequences": 124,
@@ -34213,7 +35577,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 2,
                 "21K (Omicron)": 1,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 5,
               "total_sequences": 93,
@@ -34229,7 +35594,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 3,
                 "21K (Omicron)": 6,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 10,
               "total_sequences": 107,
@@ -34245,7 +35611,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 5,
                 "21K (Omicron)": 14,
-                "21L (Omicron)": 3
+                "21L (Omicron)": 3,
+                "Unknown": 0
               },
               "stand_total_cases": 23,
               "total_sequences": 119,
@@ -34261,7 +35628,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 2,
                 "21K (Omicron)": 14,
-                "21L (Omicron)": 28
+                "21L (Omicron)": 28,
+                "Unknown": 0
               },
               "stand_total_cases": 44,
               "total_sequences": 176,
@@ -34277,7 +35645,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 31,
-                "21L (Omicron)": 247
+                "21L (Omicron)": 247,
+                "Unknown": 0
               },
               "stand_total_cases": 278,
               "total_sequences": 168,
@@ -34293,7 +35662,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 22,
-                "21L (Omicron)": 326
+                "21L (Omicron)": 326,
+                "Unknown": 0
               },
               "stand_total_cases": 348,
               "total_sequences": 189,
@@ -34309,7 +35679,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 3,
-                "21L (Omicron)": 149
+                "21L (Omicron)": 149,
+                "Unknown": 0
               },
               "stand_total_cases": 152,
               "total_sequences": 103,
@@ -34325,7 +35696,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 44
+                "21L (Omicron)": 44,
+                "Unknown": 0
               },
               "stand_total_cases": 44,
               "total_sequences": 54,
@@ -34341,7 +35713,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 18
+                "21L (Omicron)": 18,
+                "Unknown": 0
               },
               "stand_total_cases": 18,
               "total_sequences": 20,
@@ -34367,7 +35740,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 1,
               "total_sequences": 3,
@@ -34388,7 +35762,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 2,
               "total_sequences": 3,
@@ -34409,7 +35784,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 5
               },
               "stand_total_cases": 5,
               "total_sequences": 8,
@@ -34430,7 +35806,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 3,
               "total_sequences": 5,
@@ -34451,7 +35828,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 18
               },
               "stand_total_cases": 18,
               "total_sequences": 31,
@@ -34472,7 +35850,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 81
               },
               "stand_total_cases": 81,
               "total_sequences": 231,
@@ -34493,7 +35872,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 215
               },
               "stand_total_cases": 215,
               "total_sequences": 239,
@@ -34514,7 +35894,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 127
               },
               "stand_total_cases": 128,
               "total_sequences": 105,
@@ -34535,7 +35916,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 41
               },
               "stand_total_cases": 42,
               "total_sequences": 55,
@@ -34556,7 +35938,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 19
               },
               "stand_total_cases": 20,
               "total_sequences": 26,
@@ -34577,7 +35960,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 13
               },
               "stand_total_cases": 14,
               "total_sequences": 40,
@@ -34598,7 +35982,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 15
               },
               "stand_total_cases": 15,
               "total_sequences": 64,
@@ -34619,7 +36004,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 8
               },
               "stand_total_cases": 14,
               "total_sequences": 13,
@@ -34640,7 +36026,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 9
               },
               "stand_total_cases": 10,
               "total_sequences": 25,
@@ -34661,7 +36048,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 31
               },
               "stand_total_cases": 33,
               "total_sequences": 112,
@@ -34682,7 +36070,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 164
               },
               "stand_total_cases": 168,
               "total_sequences": 229,
@@ -34703,7 +36092,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 158
               },
               "stand_total_cases": 166,
               "total_sequences": 134,
@@ -34724,7 +36114,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 134
               },
               "stand_total_cases": 144,
               "total_sequences": 201,
@@ -34745,7 +36136,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 109
               },
               "stand_total_cases": 111,
               "total_sequences": 67,
@@ -34766,7 +36158,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 72
               },
               "stand_total_cases": 72,
               "total_sequences": 45,
@@ -34787,7 +36180,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 22
               },
               "stand_total_cases": 30,
               "total_sequences": 12,
@@ -34808,7 +36202,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 22
               },
               "stand_total_cases": 29,
               "total_sequences": 28,
@@ -34829,7 +36224,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 32
               },
               "stand_total_cases": 38,
               "total_sequences": 137,
@@ -34850,7 +36246,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 6
               },
               "stand_total_cases": 17,
               "total_sequences": 40,
@@ -34871,7 +36268,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 7
               },
               "stand_total_cases": 23,
               "total_sequences": 74,
@@ -34892,7 +36290,8 @@
                 "21I (Delta)": 5,
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 13,
               "total_sequences": 41,
@@ -34913,7 +36312,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 5,
               "total_sequences": 19,
@@ -34934,7 +36334,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 1,
               "total_sequences": 8,
@@ -34955,7 +36356,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 2,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 5,
               "total_sequences": 32,
@@ -34976,7 +36378,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 5,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 5,
               "total_sequences": 51,
@@ -34997,7 +36400,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 3,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 4,
               "total_sequences": 33,
@@ -35018,7 +36422,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 2,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 3,
               "total_sequences": 15,
@@ -35039,7 +36444,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 3,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 4,
               "total_sequences": 26,
@@ -35060,7 +36466,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 5,
               "total_sequences": 27,
@@ -35081,7 +36488,8 @@
                 "21I (Delta)": 4,
                 "21J (Delta)": 3,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 8,
               "total_sequences": 48,
@@ -35102,7 +36510,8 @@
                 "21I (Delta)": 2,
                 "21J (Delta)": 3,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 5,
               "total_sequences": 31,
@@ -35123,7 +36532,8 @@
                 "21I (Delta)": 2,
                 "21J (Delta)": 6,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 8,
               "total_sequences": 24,
@@ -35144,7 +36554,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 11,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 12,
               "total_sequences": 30,
@@ -35165,7 +36576,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 5,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 6,
               "total_sequences": 25,
@@ -35186,7 +36598,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 3,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 4,
               "total_sequences": 51,
@@ -35207,7 +36620,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 5,
                 "21K (Omicron)": 1,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 6,
               "total_sequences": 77,
@@ -35228,7 +36642,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 6,
                 "21K (Omicron)": 1,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 8,
               "total_sequences": 99,
@@ -35249,7 +36664,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 2,
                 "21K (Omicron)": 11,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 13,
               "total_sequences": 163,
@@ -35270,7 +36686,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 31,
-                "21L (Omicron)": 14
+                "21L (Omicron)": 14,
+                "Unknown": 0
               },
               "stand_total_cases": 45,
               "total_sequences": 156,
@@ -35291,7 +36708,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 5,
                 "21K (Omicron)": 14,
-                "21L (Omicron)": 28
+                "21L (Omicron)": 28,
+                "Unknown": -1
               },
               "stand_total_cases": 46,
               "total_sequences": 224,
@@ -35312,7 +36730,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 31,
                 "21K (Omicron)": 10,
-                "21L (Omicron)": 238
+                "21L (Omicron)": 238,
+                "Unknown": 1
               },
               "stand_total_cases": 280,
               "total_sequences": 161,
@@ -35333,7 +36752,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 90,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 4864
+                "21L (Omicron)": 4864,
+                "Unknown": 0
               },
               "stand_total_cases": 4954,
               "total_sequences": 219,
@@ -35354,7 +36774,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 81025
+                "21L (Omicron)": 81025,
+                "Unknown": 0
               },
               "stand_total_cases": 81025,
               "total_sequences": 150,
@@ -35375,14 +36796,15 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 50695
+                "21L (Omicron)": 50695,
+                "Unknown": 0
               },
               "stand_total_cases": 50695,
               "total_sequences": 52,
               "week": "2022-03-07"
             },
             {
-              "percent_total_cases": 0.0023276112889147513,
+              "percent_total_cases": 0.0023518572398409467,
               "stand_estimated_cases": {
                 "20A.EU2": 0,
                 "20A/S:126A": 0,
@@ -35396,11 +36818,34 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 16382
+                "21L (Omicron)": 16382,
+                "Unknown": 0
               },
               "stand_total_cases": 16382,
-              "total_sequences": 288,
+              "total_sequences": 291,
               "week": "2022-03-21"
+            },
+            {
+              "percent_total_cases": 0.0012119834867249935,
+              "stand_estimated_cases": {
+                "20A.EU2": 0,
+                "20A/S:126A": 0,
+                "20A/S:439K": 0,
+                "20E (EU1)": 0,
+                "20H (Beta, V2)": 0,
+                "20I (Alpha, V1)": 0,
+                "21A (Delta)": 0,
+                "21B (Kappa)": 0,
+                "21H (Mu)": 0,
+                "21I (Delta)": 0,
+                "21J (Delta)": 0,
+                "21K (Omicron)": 109,
+                "21L (Omicron)": 3386,
+                "Unknown": 0
+              },
+              "stand_total_cases": 3495,
+              "total_sequences": 32,
+              "week": "2022-04-04"
             }
           ]
         },
@@ -35415,7 +36860,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 4,
@@ -35429,7 +36875,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 10
               },
               "stand_total_cases": 10,
               "total_sequences": 29,
@@ -35443,7 +36890,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 25
               },
               "stand_total_cases": 25,
               "total_sequences": 45,
@@ -35457,7 +36905,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 14
               },
               "stand_total_cases": 14,
               "total_sequences": 4,
@@ -35471,7 +36920,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 5
               },
               "stand_total_cases": 5,
               "total_sequences": 2,
@@ -35485,7 +36935,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 2,
               "total_sequences": 2,
@@ -35499,7 +36950,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 2,
               "total_sequences": 6,
@@ -35513,7 +36965,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 7
               },
               "stand_total_cases": 7,
               "total_sequences": 22,
@@ -35527,7 +36980,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 9
               },
               "stand_total_cases": 9,
               "total_sequences": 7,
@@ -35541,7 +36995,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 5
               },
               "stand_total_cases": 5,
               "total_sequences": 13,
@@ -35555,7 +37010,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 2,
               "total_sequences": 3,
@@ -35569,7 +37025,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 6
               },
               "stand_total_cases": 6,
               "total_sequences": 10,
@@ -35583,7 +37040,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 8
               },
               "stand_total_cases": 8,
               "total_sequences": 47,
@@ -35597,7 +37055,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 67
               },
               "stand_total_cases": 67,
               "total_sequences": 174,
@@ -35611,7 +37070,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 164
               },
               "stand_total_cases": 164,
               "total_sequences": 316,
@@ -35625,7 +37085,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 432
               },
               "stand_total_cases": 433,
               "total_sequences": 486,
@@ -35639,7 +37100,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 296
               },
               "stand_total_cases": 296,
               "total_sequences": 89,
@@ -35653,7 +37115,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 160
               },
               "stand_total_cases": 160,
               "total_sequences": 100,
@@ -35667,7 +37130,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 274
               },
               "stand_total_cases": 274,
               "total_sequences": 136,
@@ -35681,7 +37145,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 234
               },
               "stand_total_cases": 234,
               "total_sequences": 14,
@@ -35695,7 +37160,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 91
               },
               "stand_total_cases": 91,
               "total_sequences": 13,
@@ -35709,7 +37175,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 45
               },
               "stand_total_cases": 45,
               "total_sequences": 2,
@@ -35723,7 +37190,8 @@
                 "21I (Delta)": 23,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 3
               },
               "stand_total_cases": 26,
               "total_sequences": 8,
@@ -35737,7 +37205,8 @@
                 "21I (Delta)": 11,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 19
               },
               "stand_total_cases": 32,
               "total_sequences": 14,
@@ -35751,7 +37220,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 12,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 15,
               "total_sequences": 17,
@@ -35765,7 +37235,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 5,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 6,
               "total_sequences": 94,
@@ -35779,7 +37250,8 @@
                 "21I (Delta)": 2,
                 "21J (Delta)": 8,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 10,
               "total_sequences": 313,
@@ -35793,7 +37265,8 @@
                 "21I (Delta)": 39,
                 "21J (Delta)": 28,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 67,
               "total_sequences": 187,
@@ -35807,7 +37280,8 @@
                 "21I (Delta)": 126,
                 "21J (Delta)": 105,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 233,
               "total_sequences": 341,
@@ -35821,7 +37295,8 @@
                 "21I (Delta)": 227,
                 "21J (Delta)": 142,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 369,
               "total_sequences": 307,
@@ -35835,7 +37310,8 @@
                 "21I (Delta)": 367,
                 "21J (Delta)": 251,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 622,
               "total_sequences": 193,
@@ -35849,7 +37325,8 @@
                 "21I (Delta)": 143,
                 "21J (Delta)": 206,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 355,
               "total_sequences": 62,
@@ -35863,7 +37340,8 @@
                 "21I (Delta)": 132,
                 "21J (Delta)": 95,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 227,
               "total_sequences": 50,
@@ -35877,7 +37355,8 @@
                 "21I (Delta)": 53,
                 "21J (Delta)": 45,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 98,
               "total_sequences": 13,
@@ -35891,7 +37370,8 @@
                 "21I (Delta)": 12,
                 "21J (Delta)": 6,
                 "21K (Omicron)": 2,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 20,
               "total_sequences": 10,
@@ -35905,7 +37385,8 @@
                 "21I (Delta)": 3,
                 "21J (Delta)": 4,
                 "21K (Omicron)": 4,
-                "21L (Omicron)": 17
+                "21L (Omicron)": 17,
+                "Unknown": -1
               },
               "stand_total_cases": 27,
               "total_sequences": 21,
@@ -35919,7 +37400,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 2,
-                "21L (Omicron)": 6
+                "21L (Omicron)": 6,
+                "Unknown": 1
               },
               "stand_total_cases": 9,
               "total_sequences": 24,
@@ -35933,7 +37415,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 1,
                 "21K (Omicron)": 1,
-                "21L (Omicron)": 101
+                "21L (Omicron)": 101,
+                "Unknown": 0
               },
               "stand_total_cases": 103,
               "total_sequences": 100,
@@ -35947,7 +37430,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 276
+                "21L (Omicron)": 276,
+                "Unknown": 0
               },
               "stand_total_cases": 276,
               "total_sequences": 86,
@@ -35975,7 +37459,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 30
               },
               "stand_total_cases": 30,
               "total_sequences": 3,
@@ -35998,7 +37483,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1353
               },
               "stand_total_cases": 1353,
               "total_sequences": 1,
@@ -36021,7 +37507,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1668
               },
               "stand_total_cases": 1668,
               "total_sequences": 3,
@@ -36044,7 +37531,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1269
               },
               "stand_total_cases": 1450,
               "total_sequences": 8,
@@ -36067,7 +37555,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 3956
               },
               "stand_total_cases": 3956,
               "total_sequences": 4,
@@ -36090,7 +37579,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 8416
               },
               "stand_total_cases": 8416,
               "total_sequences": 2,
@@ -36113,7 +37603,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 4921
               },
               "stand_total_cases": 4921,
               "total_sequences": 8,
@@ -36136,7 +37627,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 2480
               },
               "stand_total_cases": 3100,
               "total_sequences": 10,
@@ -36159,7 +37651,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 438
               },
               "stand_total_cases": 546,
               "total_sequences": 15,
@@ -36182,7 +37675,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 237
               },
               "stand_total_cases": 394,
               "total_sequences": 15,
@@ -36205,7 +37699,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 11
+                "S:677P.Pelican": 11,
+                "Unknown": 57
               },
               "stand_total_cases": 412,
               "total_sequences": 36,
@@ -36228,7 +37723,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 64
               },
               "stand_total_cases": 764,
               "total_sequences": 48,
@@ -36251,7 +37747,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 7221,
               "total_sequences": 53,
@@ -36274,7 +37771,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 23623,
               "total_sequences": 56,
@@ -36297,7 +37795,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 198
               },
               "stand_total_cases": 12087,
               "total_sequences": 61,
@@ -36320,7 +37819,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 45
               },
               "stand_total_cases": 1990,
               "total_sequences": 45,
@@ -36343,7 +37843,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 266,
               "total_sequences": 25,
@@ -36366,7 +37867,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 109,
               "total_sequences": 10,
@@ -36389,7 +37891,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 139,
               "total_sequences": 3,
@@ -36412,7 +37915,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 212,
               "total_sequences": 16,
@@ -36435,7 +37939,8 @@
                 "21J (Delta)": 169,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 358,
               "total_sequences": 36,
@@ -36458,7 +37963,8 @@
                 "21J (Delta)": 2032,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 5236,
               "total_sequences": 67,
@@ -36481,7 +37987,8 @@
                 "21J (Delta)": 1873,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 5279,
               "total_sequences": 62,
@@ -36504,7 +38011,8 @@
                 "21J (Delta)": 1917,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 4945,
               "total_sequences": 49,
@@ -36527,7 +38035,8 @@
                 "21J (Delta)": 1195,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 3234,
               "total_sequences": 46,
@@ -36550,7 +38059,8 @@
                 "21J (Delta)": 1655,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 3555,
               "total_sequences": 58,
@@ -36573,7 +38083,8 @@
                 "21J (Delta)": 1198,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 3355,
               "total_sequences": 56,
@@ -36596,7 +38107,8 @@
                 "21J (Delta)": 744,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1972,
               "total_sequences": 53,
@@ -36619,7 +38131,8 @@
                 "21J (Delta)": 310,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 910,
               "total_sequences": 47,
@@ -36642,7 +38155,8 @@
                 "21J (Delta)": 519,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 855,
               "total_sequences": 28,
@@ -36665,7 +38179,8 @@
                 "21J (Delta)": 834,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1043,
               "total_sequences": 20,
@@ -36688,7 +38203,8 @@
                 "21J (Delta)": 1053,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1165,
               "total_sequences": 52,
@@ -36711,7 +38227,8 @@
                 "21J (Delta)": 3844,
                 "21K (Omicron)": 4847,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 8859,
               "total_sequences": 53,
@@ -36734,7 +38251,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 57315,
                 "21L (Omicron)": 0,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 58338,
               "total_sequences": 57,
@@ -36757,7 +38275,8 @@
                 "21J (Delta)": 3743,
                 "21K (Omicron)": 39610,
                 "21L (Omicron)": 312,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 44600,
               "total_sequences": 143,
@@ -36780,7 +38299,8 @@
                 "21J (Delta)": 382,
                 "21K (Omicron)": 10324,
                 "21L (Omicron)": 191,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 10898,
               "total_sequences": 57,
@@ -36803,7 +38323,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 5136,
                 "21L (Omicron)": 373,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 5509,
               "total_sequences": 59,
@@ -36826,7 +38347,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 1285,
                 "21L (Omicron)": 1239,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2524,
               "total_sequences": 55,
@@ -36849,7 +38371,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 728,
                 "21L (Omicron)": 3641,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 4369,
               "total_sequences": 48,
@@ -36872,7 +38395,8 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 348,
                 "21L (Omicron)": 4615,
-                "S:677P.Pelican": 0
+                "S:677P.Pelican": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 4963,
               "total_sequences": 57,
@@ -36894,7 +38418,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 2,
@@ -36911,7 +38436,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 18,
@@ -36928,7 +38454,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 50,
@@ -36945,7 +38472,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 37,
@@ -36962,7 +38490,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 34,
@@ -36979,7 +38508,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 9,
@@ -36996,7 +38526,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1436,
               "total_sequences": 8,
@@ -37013,7 +38544,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 567,
               "total_sequences": 4,
@@ -37030,7 +38562,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 264,
               "total_sequences": 1,
@@ -37047,7 +38580,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 794,
               "total_sequences": 20,
@@ -37064,7 +38598,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 160,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 718,
               "total_sequences": 9,
@@ -37081,7 +38616,8 @@
                 "21I (Delta)": 857,
                 "21J (Delta)": 333,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 1285,
               "total_sequences": 27,
@@ -37098,7 +38634,8 @@
                 "21I (Delta)": 537,
                 "21J (Delta)": 537,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1172,
               "total_sequences": 24,
@@ -37115,7 +38652,8 @@
                 "21I (Delta)": 876,
                 "21J (Delta)": 1014,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1890,
               "total_sequences": 41,
@@ -37132,7 +38670,8 @@
                 "21I (Delta)": 664,
                 "21J (Delta)": 1718,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2382,
               "total_sequences": 61,
@@ -37149,7 +38688,8 @@
                 "21I (Delta)": 1469,
                 "21J (Delta)": 3557,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 5104,
               "total_sequences": 66,
@@ -37166,7 +38706,8 @@
                 "21I (Delta)": 2772,
                 "21J (Delta)": 3541,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 6390,
               "total_sequences": 83,
@@ -37183,7 +38724,8 @@
                 "21I (Delta)": 1856,
                 "21J (Delta)": 5479,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 7335,
               "total_sequences": 83,
@@ -37200,7 +38742,8 @@
                 "21I (Delta)": 780,
                 "21J (Delta)": 3001,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 3781,
               "total_sequences": 63,
@@ -37217,7 +38760,8 @@
                 "21I (Delta)": 2085,
                 "21J (Delta)": 5213,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 7298,
               "total_sequences": 63,
@@ -37234,7 +38778,8 @@
                 "21I (Delta)": 794,
                 "21J (Delta)": 9075,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 9869,
               "total_sequences": 87,
@@ -37251,7 +38796,8 @@
                 "21I (Delta)": 1412,
                 "21J (Delta)": 8003,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 9415,
               "total_sequences": 80,
@@ -37268,7 +38814,8 @@
                 "21I (Delta)": 350,
                 "21J (Delta)": 3574,
                 "21K (Omicron)": 1332,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 5256,
               "total_sequences": 75,
@@ -37285,7 +38832,8 @@
                 "21I (Delta)": 525,
                 "21J (Delta)": 4727,
                 "21K (Omicron)": 37024,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 42276,
               "total_sequences": 161,
@@ -37302,7 +38850,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 76536,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 76536,
               "total_sequences": 66,
@@ -37319,7 +38868,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 29873,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 29873,
               "total_sequences": 74,
@@ -37336,7 +38886,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 11533,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 11533,
               "total_sequences": 31,
@@ -37353,7 +38904,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 3857
+                "21L (Omicron)": 3857,
+                "Unknown": 0
               },
               "stand_total_cases": 3857,
               "total_sequences": 1,
@@ -37370,7 +38922,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 4179,
-                "21L (Omicron)": 27395
+                "21L (Omicron)": 27395,
+                "Unknown": 0
               },
               "stand_total_cases": 31574,
               "total_sequences": 68,
@@ -37390,7 +38943,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 6848,
               "total_sequences": 3,
@@ -37405,7 +38959,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 8704,
               "total_sequences": 1,
@@ -37420,7 +38975,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 7319,
               "total_sequences": 2,
@@ -37435,7 +38991,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 946
               },
               "stand_total_cases": 10404,
               "total_sequences": 11,
@@ -37450,7 +39007,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 15004,
               "total_sequences": 13,
@@ -37465,7 +39023,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2823,
               "total_sequences": 1,
@@ -37480,7 +39039,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2195,
               "total_sequences": 5,
@@ -37495,7 +39055,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1699
               },
               "stand_total_cases": 1699,
               "total_sequences": 1,
@@ -37510,7 +39071,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2407
               },
               "stand_total_cases": 3476,
               "total_sequences": 13,
@@ -37525,7 +39087,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 2395
               },
               "stand_total_cases": 3293,
               "total_sequences": 11,
@@ -37540,7 +39103,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1150
               },
               "stand_total_cases": 1150,
               "total_sequences": 5,
@@ -37555,7 +39119,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 313
               },
               "stand_total_cases": 627,
               "total_sequences": 2,
@@ -37570,7 +39135,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 444,
               "total_sequences": 2,
@@ -37585,7 +39151,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 182,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 182,
               "total_sequences": 2,
@@ -37600,7 +39167,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 679,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 679,
               "total_sequences": 1,
@@ -37615,7 +39183,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 679,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 679,
               "total_sequences": 3,
@@ -37630,7 +39199,8 @@
                 "21I (Delta)": 731,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 731,
               "total_sequences": 1,
@@ -37645,7 +39215,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 3555,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 3555,
               "total_sequences": 8,
@@ -37660,7 +39231,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 2666,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2666,
               "total_sequences": 2,
@@ -37675,7 +39247,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 2221,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2221,
               "total_sequences": 3,
@@ -37690,7 +39263,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 810,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 810,
               "total_sequences": 4,
@@ -37705,7 +39279,8 @@
                 "21I (Delta)": 163,
                 "21J (Delta)": 490,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 653,
               "total_sequences": 4,
@@ -37720,7 +39295,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 2039,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 2039,
               "total_sequences": 7,
@@ -37735,7 +39311,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 4809,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 4809,
               "total_sequences": 60,
@@ -37750,7 +39327,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 17279,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 17279,
               "total_sequences": 104,
@@ -37765,7 +39343,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 21279,
                 "21K (Omicron)": 156,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 21435,
               "total_sequences": 137,
@@ -37780,7 +39359,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 11825,
                 "21K (Omicron)": 4042,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 15867,
               "total_sequences": 106,
@@ -37795,7 +39375,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 4258,
                 "21K (Omicron)": 14668,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 18926,
               "total_sequences": 40,
@@ -37810,7 +39391,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 30846,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 30846,
               "total_sequences": 3,
@@ -37825,7 +39407,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 3578,
                 "21K (Omicron)": 25044,
-                "21L (Omicron)": 19320
+                "21L (Omicron)": 19320,
+                "Unknown": 0
               },
               "stand_total_cases": 47942,
               "total_sequences": 67,
@@ -37840,7 +39423,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 16747,
-                "21L (Omicron)": 24189
+                "21L (Omicron)": 24189,
+                "Unknown": 0
               },
               "stand_total_cases": 40936,
               "total_sequences": 66,
@@ -37855,7 +39439,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 28587,
-                "21L (Omicron)": 15134
+                "21L (Omicron)": 15134,
+                "Unknown": 561
               },
               "stand_total_cases": 44282,
               "total_sequences": 79,
@@ -37870,7 +39455,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 62215,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 62215,
               "total_sequences": 32,
@@ -37885,7 +39471,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 17407,
-                "21L (Omicron)": 11792
+                "21L (Omicron)": 11792,
+                "Unknown": 0
               },
               "stand_total_cases": 29199,
               "total_sequences": 52,
@@ -37907,7 +39494,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 31,
               "total_sequences": 1,
@@ -37924,7 +39512,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 15,
               "total_sequences": 1,
@@ -37941,7 +39530,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 31,
               "total_sequences": 3,
@@ -37958,7 +39548,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 7
               },
               "stand_total_cases": 7,
               "total_sequences": 1,
@@ -37975,7 +39566,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 7
               },
               "stand_total_cases": 14,
               "total_sequences": 2,
@@ -37992,7 +39584,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 7
               },
               "stand_total_cases": 11,
               "total_sequences": 8,
@@ -38009,7 +39602,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 7
               },
               "stand_total_cases": 13,
               "total_sequences": 4,
@@ -38026,7 +39620,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 21
               },
               "stand_total_cases": 21,
               "total_sequences": 1,
@@ -38043,7 +39638,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 14
               },
               "stand_total_cases": 14,
               "total_sequences": 1,
@@ -38060,7 +39656,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 28
               },
               "stand_total_cases": 28,
               "total_sequences": 4,
@@ -38077,7 +39674,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 135
               },
               "stand_total_cases": 135,
               "total_sequences": 69,
@@ -38094,7 +39692,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 235
               },
               "stand_total_cases": 235,
               "total_sequences": 10,
@@ -38111,7 +39710,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 71
               },
               "stand_total_cases": 71,
               "total_sequences": 3,
@@ -38128,7 +39728,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 29
               },
               "stand_total_cases": 29,
               "total_sequences": 8,
@@ -38145,7 +39746,8 @@
                 "21I (Delta)": 1,
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 34
               },
               "stand_total_cases": 36,
               "total_sequences": 39,
@@ -38162,7 +39764,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 82
               },
               "stand_total_cases": 82,
               "total_sequences": 8,
@@ -38179,7 +39782,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 38,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 210
               },
               "stand_total_cases": 248,
               "total_sequences": 13,
@@ -38196,7 +39800,8 @@
                 "21I (Delta)": 16,
                 "21J (Delta)": 71,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 39
               },
               "stand_total_cases": 134,
               "total_sequences": 17,
@@ -38213,7 +39818,8 @@
                 "21I (Delta)": 9,
                 "21J (Delta)": 9,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 179
               },
               "stand_total_cases": 197,
               "total_sequences": 22,
@@ -38230,7 +39836,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 119,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1135
               },
               "stand_total_cases": 1254,
               "total_sequences": 21,
@@ -38247,7 +39854,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1005
               },
               "stand_total_cases": 1005,
               "total_sequences": 10,
@@ -38264,7 +39872,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1101
               },
               "stand_total_cases": 2201,
               "total_sequences": 6,
@@ -38281,7 +39890,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 3315
               },
               "stand_total_cases": 3315,
               "total_sequences": 18,
@@ -38298,7 +39908,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 95,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1766
               },
               "stand_total_cases": 1861,
               "total_sequences": 39,
@@ -38315,7 +39926,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 211,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 853
               },
               "stand_total_cases": 1075,
               "total_sequences": 102,
@@ -38332,7 +39944,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 309,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 371
               },
               "stand_total_cases": 701,
               "total_sequences": 34,
@@ -38349,7 +39962,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 3793,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1062
               },
               "stand_total_cases": 4855,
               "total_sequences": 32,
@@ -38366,7 +39980,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 15082
               },
               "stand_total_cases": 15082,
               "total_sequences": 3,
@@ -38383,7 +39998,8 @@
                 "21I (Delta)": 186,
                 "21J (Delta)": 10241,
                 "21K (Omicron)": 186,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 10613,
               "total_sequences": 57,
@@ -38400,7 +40016,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 5743,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 5743,
               "total_sequences": 3,
@@ -38417,7 +40034,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 2932,
                 "21K (Omicron)": 382,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 3315,
               "total_sequences": 52,
@@ -38434,7 +40052,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 979,
                 "21K (Omicron)": 703,
-                "21L (Omicron)": 0
+                "21L (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 1682,
               "total_sequences": 79,
@@ -38451,7 +40070,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 225,
                 "21K (Omicron)": 577,
-                "21L (Omicron)": 68
+                "21L (Omicron)": 68,
+                "Unknown": 0
               },
               "stand_total_cases": 870,
               "total_sequences": 89,
@@ -38468,7 +40088,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 1573,
                 "21K (Omicron)": 25615,
-                "21L (Omicron)": 7640
+                "21L (Omicron)": 7640,
+                "Unknown": 0
               },
               "stand_total_cases": 34828,
               "total_sequences": 155,
@@ -38485,7 +40106,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 456,
                 "21K (Omicron)": 10263,
-                "21L (Omicron)": 16421
+                "21L (Omicron)": 16421,
+                "Unknown": 0
               },
               "stand_total_cases": 27140,
               "total_sequences": 119,
@@ -38502,7 +40124,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 4057,
-                "21L (Omicron)": 12170
+                "21L (Omicron)": 12170,
+                "Unknown": 0
               },
               "stand_total_cases": 16227,
               "total_sequences": 36,
@@ -38519,7 +40142,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 2681,
-                "21L (Omicron)": 15193
+                "21L (Omicron)": 15193,
+                "Unknown": 0
               },
               "stand_total_cases": 17874,
               "total_sequences": 20,
@@ -38536,7 +40160,8 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "21L (Omicron)": 13966
+                "21L (Omicron)": 13966,
+                "Unknown": 0
               },
               "stand_total_cases": 13966,
               "total_sequences": 10,
@@ -38555,7 +40180,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 4,
               "total_sequences": 13,
@@ -38569,7 +40195,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 2,
               "total_sequences": 12,
@@ -38583,7 +40210,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 8,
@@ -38597,7 +40225,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 4
               },
               "stand_total_cases": 4,
               "total_sequences": 1,
@@ -38611,7 +40240,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 8
               },
               "stand_total_cases": 8,
               "total_sequences": 17,
@@ -38625,7 +40255,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 14
               },
               "stand_total_cases": 14,
               "total_sequences": 3,
@@ -38639,7 +40270,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 162
               },
               "stand_total_cases": 162,
               "total_sequences": 220,
@@ -38653,7 +40285,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 552
               },
               "stand_total_cases": 552,
               "total_sequences": 25,
@@ -38667,7 +40300,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 478
               },
               "stand_total_cases": 478,
               "total_sequences": 26,
@@ -38681,7 +40315,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 177
               },
               "stand_total_cases": 177,
               "total_sequences": 20,
@@ -38695,7 +40330,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 65
               },
               "stand_total_cases": 65,
               "total_sequences": 3,
@@ -38709,7 +40345,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 25
               },
               "stand_total_cases": 25,
               "total_sequences": 4,
@@ -38723,7 +40360,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 11
               },
               "stand_total_cases": 11,
               "total_sequences": 1,
@@ -38737,7 +40375,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 14
               },
               "stand_total_cases": 28,
               "total_sequences": 2,
@@ -38751,7 +40390,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 31
               },
               "stand_total_cases": 46,
               "total_sequences": 6,
@@ -38765,7 +40405,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 106
               },
               "stand_total_cases": 106,
               "total_sequences": 9,
@@ -38779,7 +40420,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 127
               },
               "stand_total_cases": 127,
               "total_sequences": 6,
@@ -38793,7 +40435,8 @@
                 "21D (Eta)": 16,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 21
               },
               "stand_total_cases": 82,
               "total_sequences": 20,
@@ -38807,7 +40450,8 @@
                 "21D (Eta)": 27,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 45
               },
               "stand_total_cases": 199,
               "total_sequences": 44,
@@ -38821,7 +40465,8 @@
                 "21D (Eta)": 47,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 11
               },
               "stand_total_cases": 100,
               "total_sequences": 19,
@@ -38835,7 +40480,8 @@
                 "21D (Eta)": 25,
                 "21I (Delta)": 25,
                 "21J (Delta)": 25,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 11
               },
               "stand_total_cases": 86,
               "total_sequences": 7,
@@ -38849,7 +40495,8 @@
                 "21D (Eta)": 24,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 24
               },
               "stand_total_cases": 72,
               "total_sequences": 6,
@@ -38863,7 +40510,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 8,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": -1
               },
               "stand_total_cases": 15,
               "total_sequences": 2,
@@ -38877,7 +40525,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 13,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 7
               },
               "stand_total_cases": 20,
               "total_sequences": 6,
@@ -38891,7 +40540,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 7,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 7,
               "total_sequences": 2,
@@ -38905,7 +40555,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 24,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 24,
               "total_sequences": 4,
@@ -38919,7 +40570,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 66,
                 "21J (Delta)": 14,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 2
               },
               "stand_total_cases": 85,
               "total_sequences": 49,
@@ -38933,7 +40585,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 226,
                 "21J (Delta)": 196,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 422,
               "total_sequences": 43,
@@ -38947,7 +40600,8 @@
                 "21D (Eta)": 4,
                 "21I (Delta)": 137,
                 "21J (Delta)": 355,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 7
               },
               "stand_total_cases": 510,
               "total_sequences": 138,
@@ -38961,7 +40615,8 @@
                 "21D (Eta)": 6,
                 "21I (Delta)": 56,
                 "21J (Delta)": 269,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 5
               },
               "stand_total_cases": 336,
               "total_sequences": 60,
@@ -38975,7 +40630,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 7,
                 "21J (Delta)": 110,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 1
               },
               "stand_total_cases": 119,
               "total_sequences": 82,
@@ -38989,7 +40645,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 4,
                 "21J (Delta)": 57,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 61,
               "total_sequences": 15,
@@ -39003,7 +40660,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 18,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 18,
               "total_sequences": 11,
@@ -39017,7 +40675,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 4,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 4,
               "total_sequences": 2,
@@ -39031,7 +40690,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 7,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 7,
               "total_sequences": 2,
@@ -39045,7 +40705,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 18,
-                "21K (Omicron)": 0
+                "21K (Omicron)": 0,
+                "Unknown": 0
               },
               "stand_total_cases": 18,
               "total_sequences": 3,
@@ -39059,7 +40720,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 5,
-                "21K (Omicron)": 16
+                "21K (Omicron)": 16,
+                "Unknown": 0
               },
               "stand_total_cases": 21,
               "total_sequences": 4,
@@ -39073,7 +40735,8 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "21K (Omicron)": 283
+                "21K (Omicron)": 283,
+                "Unknown": 0
               },
               "stand_total_cases": 283,
               "total_sequences": 45,

--- a/web/data/perCountryDataCaseCounts.json
+++ b/web/data/perCountryDataCaseCounts.json
@@ -57,7 +57,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1086
+                "others": 1086
               },
               "stand_total_cases": 1086,
               "total_sequences": 5478,
@@ -88,7 +88,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 934
+                "others": 934
               },
               "stand_total_cases": 934,
               "total_sequences": 4477,
@@ -119,7 +119,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 884
+                "others": 884
               },
               "stand_total_cases": 884,
               "total_sequences": 3796,
@@ -150,7 +150,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1019
+                "others": 1019
               },
               "stand_total_cases": 1019,
               "total_sequences": 5810,
@@ -181,7 +181,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1871
+                "others": 1871
               },
               "stand_total_cases": 1871,
               "total_sequences": 8227,
@@ -212,7 +212,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2587
+                "others": 2587
               },
               "stand_total_cases": 2587,
               "total_sequences": 9237,
@@ -243,7 +243,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2663
+                "others": 2663
               },
               "stand_total_cases": 2663,
               "total_sequences": 6443,
@@ -274,7 +274,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2310
+                "others": 2310
               },
               "stand_total_cases": 2310,
               "total_sequences": 4861,
@@ -305,7 +305,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 6,
                 "S:677P.Pelican": 0,
-                "Unknown": 1770
+                "others": 1770
               },
               "stand_total_cases": 1777,
               "total_sequences": 4128,
@@ -336,7 +336,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 8,
                 "S:677P.Pelican": 0,
-                "Unknown": 1601
+                "others": 1601
               },
               "stand_total_cases": 1611,
               "total_sequences": 4193,
@@ -367,7 +367,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 21,
                 "S:677P.Pelican": 0,
-                "Unknown": 1704
+                "others": 1704
               },
               "stand_total_cases": 1729,
               "total_sequences": 5188,
@@ -398,7 +398,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 11,
                 "S:677P.Pelican": 0,
-                "Unknown": 1923
+                "others": 1923
               },
               "stand_total_cases": 1942,
               "total_sequences": 5878,
@@ -429,7 +429,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 21,
                 "S:677P.Pelican": 3,
-                "Unknown": 2609
+                "others": 2609
               },
               "stand_total_cases": 2650,
               "total_sequences": 7317,
@@ -460,7 +460,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 46,
                 "S:677P.Pelican": 13,
-                "Unknown": 4097
+                "others": 4097
               },
               "stand_total_cases": 4185,
               "total_sequences": 13054,
@@ -491,7 +491,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 88,
                 "S:677P.Pelican": 27,
-                "Unknown": 6551
+                "others": 6551
               },
               "stand_total_cases": 6768,
               "total_sequences": 13612,
@@ -522,7 +522,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 105,
                 "S:677P.Pelican": 54,
-                "Unknown": 7249
+                "others": 7249
               },
               "stand_total_cases": 7752,
               "total_sequences": 13808,
@@ -553,7 +553,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 131,
                 "S:677P.Pelican": 157,
-                "Unknown": 7750
+                "others": 7750
               },
               "stand_total_cases": 9259,
               "total_sequences": 22590,
@@ -584,7 +584,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 348,
                 "S:677P.Pelican": 244,
-                "Unknown": 11145
+                "others": 11145
               },
               "stand_total_cases": 13904,
               "total_sequences": 36239,
@@ -615,7 +615,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 173,
                 "S:677P.Pelican": 154,
-                "Unknown": 5779
+                "others": 5779
               },
               "stand_total_cases": 8163,
               "total_sequences": 34228,
@@ -646,7 +646,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 109,
                 "S:677P.Pelican": 96,
-                "Unknown": 3362
+                "others": 3362
               },
               "stand_total_cases": 5585,
               "total_sequences": 31102,
@@ -677,7 +677,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 68,
                 "S:677P.Pelican": 53,
-                "Unknown": 1755
+                "others": 1755
               },
               "stand_total_cases": 3304,
               "total_sequences": 34104,
@@ -708,7 +708,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 53,
                 "S:677P.Pelican": 52,
-                "Unknown": 1112
+                "others": 1112
               },
               "stand_total_cases": 2689,
               "total_sequences": 37026,
@@ -739,7 +739,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 30,
                 "S:677P.Pelican": 21,
-                "Unknown": 653
+                "others": 653
               },
               "stand_total_cases": 2284,
               "total_sequences": 48695,
@@ -770,7 +770,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 17,
                 "S:677P.Pelican": 10,
-                "Unknown": 440
+                "others": 440
               },
               "stand_total_cases": 2682,
               "total_sequences": 66348,
@@ -801,7 +801,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 8,
                 "S:677P.Pelican": 6,
-                "Unknown": 293
+                "others": 293
               },
               "stand_total_cases": 2895,
               "total_sequences": 77699,
@@ -832,7 +832,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 2,
                 "S:677P.Pelican": 2,
-                "Unknown": 158
+                "others": 158
               },
               "stand_total_cases": 2254,
               "total_sequences": 65936,
@@ -863,7 +863,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 1,
                 "S:677P.Pelican": 1,
-                "Unknown": 100
+                "others": 100
               },
               "stand_total_cases": 1562,
               "total_sequences": 49542,
@@ -894,7 +894,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 66
+                "others": 66
               },
               "stand_total_cases": 957,
               "total_sequences": 27901,
@@ -925,7 +925,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 38
+                "others": 38
               },
               "stand_total_cases": 606,
               "total_sequences": 19341,
@@ -956,7 +956,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 24
+                "others": 24
               },
               "stand_total_cases": 505,
               "total_sequences": 22718,
@@ -987,7 +987,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 18
+                "others": 18
               },
               "stand_total_cases": 699,
               "total_sequences": 38676,
@@ -1018,7 +1018,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 18
+                "others": 18
               },
               "stand_total_cases": 1808,
               "total_sequences": 86113,
@@ -1049,7 +1049,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 18
+                "others": 18
               },
               "stand_total_cases": 4020,
               "total_sequences": 146903,
@@ -1080,7 +1080,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 14
+                "others": 14
               },
               "stand_total_cases": 5905,
               "total_sequences": 128701,
@@ -1111,7 +1111,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 18
+                "others": 18
               },
               "stand_total_cases": 6784,
               "total_sequences": 134708,
@@ -1142,7 +1142,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 12
+                "others": 12
               },
               "stand_total_cases": 6141,
               "total_sequences": 131393,
@@ -1173,7 +1173,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 9
+                "others": 9
               },
               "stand_total_cases": 4781,
               "total_sequences": 109213,
@@ -1204,7 +1204,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 7
+                "others": 7
               },
               "stand_total_cases": 3738,
               "total_sequences": 106206,
@@ -1235,7 +1235,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 8
+                "others": 8
               },
               "stand_total_cases": 3053,
               "total_sequences": 104330,
@@ -1266,7 +1266,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 13
+                "others": 13
               },
               "stand_total_cases": 3240,
               "total_sequences": 118714,
@@ -1297,7 +1297,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 14
+                "others": 14
               },
               "stand_total_cases": 3502,
               "total_sequences": 102875,
@@ -1328,7 +1328,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 5
+                "others": 5
               },
               "stand_total_cases": 5082,
               "total_sequences": 122235,
@@ -1359,7 +1359,7 @@
                 "21L (Omicron)": 1,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 6
+                "others": 6
               },
               "stand_total_cases": 7190,
               "total_sequences": 143517,
@@ -1390,7 +1390,7 @@
                 "21L (Omicron)": 15,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 31
+                "others": 31
               },
               "stand_total_cases": 24181,
               "total_sequences": 181516,
@@ -1421,7 +1421,7 @@
                 "21L (Omicron)": 124,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 8
+                "others": 8
               },
               "stand_total_cases": 31848,
               "total_sequences": 171684,
@@ -1452,7 +1452,7 @@
                 "21L (Omicron)": 182,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 16619,
               "total_sequences": 140817,
@@ -1483,7 +1483,7 @@
                 "21L (Omicron)": 199,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 5819,
               "total_sequences": 102521,
@@ -1514,7 +1514,7 @@
                 "21L (Omicron)": 298,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 2375,
               "total_sequences": 48804,
@@ -1545,7 +1545,7 @@
                 "21L (Omicron)": 580,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 1387,
               "total_sequences": 30254,
@@ -1576,7 +1576,7 @@
                 "21L (Omicron)": 939,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 1247,
               "total_sequences": 27956,
@@ -1607,7 +1607,7 @@
                 "21L (Omicron)": 1279,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 1427,
               "total_sequences": 5436,
@@ -1645,7 +1645,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 776
+                "others": 776
               },
               "stand_total_cases": 776,
               "total_sequences": 4667,
@@ -1678,7 +1678,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 513
+                "others": 513
               },
               "stand_total_cases": 513,
               "total_sequences": 2715,
@@ -1711,7 +1711,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 272
+                "others": 272
               },
               "stand_total_cases": 272,
               "total_sequences": 1720,
@@ -1744,7 +1744,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 198
+                "others": 198
               },
               "stand_total_cases": 198,
               "total_sequences": 4681,
@@ -1777,7 +1777,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 111
+                "others": 111
               },
               "stand_total_cases": 111,
               "total_sequences": 2274,
@@ -1810,7 +1810,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 135
+                "others": 135
               },
               "stand_total_cases": 137,
               "total_sequences": 1076,
@@ -1843,7 +1843,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 141
+                "others": 141
               },
               "stand_total_cases": 145,
               "total_sequences": 1185,
@@ -1876,7 +1876,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 179
+                "others": 179
               },
               "stand_total_cases": 202,
               "total_sequences": 2342,
@@ -1909,7 +1909,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 143
+                "others": 143
               },
               "stand_total_cases": 234,
               "total_sequences": 4113,
@@ -1942,7 +1942,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 283
+                "others": 283
               },
               "stand_total_cases": 499,
               "total_sequences": 5636,
@@ -1975,7 +1975,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 444
+                "others": 444
               },
               "stand_total_cases": 974,
               "total_sequences": 9665,
@@ -2008,7 +2008,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 873
+                "others": 873
               },
               "stand_total_cases": 2474,
               "total_sequences": 11440,
@@ -2041,7 +2041,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1128
+                "others": 1128
               },
               "stand_total_cases": 3961,
               "total_sequences": 16068,
@@ -2074,7 +2074,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1067
+                "others": 1067
               },
               "stand_total_cases": 4667,
               "total_sequences": 17807,
@@ -2107,7 +2107,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 856
+                "others": 856
               },
               "stand_total_cases": 4694,
               "total_sequences": 17846,
@@ -2140,7 +2140,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 407
+                "others": 407
               },
               "stand_total_cases": 3102,
               "total_sequences": 8362,
@@ -2173,7 +2173,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 321
+                "others": 321
               },
               "stand_total_cases": 4660,
               "total_sequences": 21412,
@@ -2206,7 +2206,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 481
+                "others": 481
               },
               "stand_total_cases": 15143,
               "total_sequences": 31023,
@@ -2239,7 +2239,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 123
+                "others": 123
               },
               "stand_total_cases": 8434,
               "total_sequences": 30549,
@@ -2272,7 +2272,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 37
+                "others": 37
               },
               "stand_total_cases": 4378,
               "total_sequences": 33290,
@@ -2305,7 +2305,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 13
+                "others": 13
               },
               "stand_total_cases": 2491,
               "total_sequences": 32800,
@@ -2338,7 +2338,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 13
+                "others": 13
               },
               "stand_total_cases": 1510,
               "total_sequences": 30242,
@@ -2371,7 +2371,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 8
+                "others": 8
               },
               "stand_total_cases": 1144,
               "total_sequences": 35271,
@@ -2404,7 +2404,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 7
+                "others": 7
               },
               "stand_total_cases": 920,
               "total_sequences": 29811,
@@ -2437,7 +2437,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 6
+                "others": 6
               },
               "stand_total_cases": 488,
               "total_sequences": 16089,
@@ -2470,7 +2470,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 474,
               "total_sequences": 14619,
@@ -2503,7 +2503,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 448,
               "total_sequences": 14707,
@@ -2536,7 +2536,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 522,
               "total_sequences": 24167,
@@ -2569,7 +2569,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 1199,
               "total_sequences": 37723,
@@ -2602,7 +2602,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 6
+                "others": 6
               },
               "stand_total_cases": 2445,
               "total_sequences": 45042,
@@ -2635,7 +2635,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 5717,
               "total_sequences": 59643,
@@ -2668,7 +2668,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 8501,
               "total_sequences": 59720,
@@ -2701,7 +2701,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 5461,
               "total_sequences": 65226,
@@ -2734,7 +2734,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 6218,
               "total_sequences": 65943,
@@ -2767,7 +2767,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 7121,
               "total_sequences": 79686,
@@ -2800,7 +2800,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 6628,
               "total_sequences": 79891,
@@ -2833,7 +2833,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 6910,
               "total_sequences": 76801,
@@ -2866,7 +2866,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 8049,
               "total_sequences": 78497,
@@ -2899,7 +2899,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 8934,
               "total_sequences": 87482,
@@ -2932,7 +2932,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 7405,
               "total_sequences": 99147,
@@ -2965,7 +2965,7 @@
                 "21K (Omicron)": 15,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 8628,
               "total_sequences": 114007,
@@ -2998,7 +2998,7 @@
                 "21K (Omicron)": 920,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 9905,
               "total_sequences": 130510,
@@ -3031,7 +3031,7 @@
                 "21K (Omicron)": 13650,
                 "21L (Omicron)": 2,
                 "S:677P.Pelican": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 19295,
               "total_sequences": 120518,
@@ -3064,7 +3064,7 @@
                 "21K (Omicron)": 33248,
                 "21L (Omicron)": 91,
                 "S:677P.Pelican": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 34484,
               "total_sequences": 144769,
@@ -3097,7 +3097,7 @@
                 "21K (Omicron)": 19709,
                 "21L (Omicron)": 540,
                 "S:677P.Pelican": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 20374,
               "total_sequences": 135553,
@@ -3130,7 +3130,7 @@
                 "21K (Omicron)": 14200,
                 "21L (Omicron)": 1926,
                 "S:677P.Pelican": 0,
-                "Unknown": 9
+                "others": 9
               },
               "stand_total_cases": 16155,
               "total_sequences": 136316,
@@ -3163,7 +3163,7 @@
                 "21K (Omicron)": 7951,
                 "21L (Omicron)": 4011,
                 "S:677P.Pelican": 0,
-                "Unknown": 16
+                "others": 16
               },
               "stand_total_cases": 11981,
               "total_sequences": 143287,
@@ -3196,7 +3196,7 @@
                 "21K (Omicron)": 2472,
                 "21L (Omicron)": 4938,
                 "S:677P.Pelican": 0,
-                "Unknown": 27
+                "others": 27
               },
               "stand_total_cases": 7438,
               "total_sequences": 116963,
@@ -3229,7 +3229,7 @@
                 "21K (Omicron)": 1698,
                 "21L (Omicron)": 12620,
                 "S:677P.Pelican": 0,
-                "Unknown": 81
+                "others": 81
               },
               "stand_total_cases": 14400,
               "total_sequences": 146014,
@@ -3262,7 +3262,7 @@
                 "21K (Omicron)": 750,
                 "21L (Omicron)": 15732,
                 "S:677P.Pelican": 0,
-                "Unknown": 105
+                "others": 105
               },
               "stand_total_cases": 16588,
               "total_sequences": 82696,
@@ -3295,7 +3295,7 @@
                 "21K (Omicron)": 154,
                 "21L (Omicron)": 7614,
                 "S:677P.Pelican": 0,
-                "Unknown": 62
+                "others": 62
               },
               "stand_total_cases": 7830,
               "total_sequences": 11070,
@@ -3331,7 +3331,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 179
+                "others": 179
               },
               "stand_total_cases": 179,
               "total_sequences": 94,
@@ -3362,7 +3362,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 107
+                "others": 107
               },
               "stand_total_cases": 108,
               "total_sequences": 86,
@@ -3393,7 +3393,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 67
+                "others": 67
               },
               "stand_total_cases": 67,
               "total_sequences": 67,
@@ -3424,7 +3424,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 69
+                "others": 69
               },
               "stand_total_cases": 69,
               "total_sequences": 1365,
@@ -3455,7 +3455,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 77
+                "others": 77
               },
               "stand_total_cases": 77,
               "total_sequences": 323,
@@ -3486,7 +3486,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 62
+                "others": 62
               },
               "stand_total_cases": 62,
               "total_sequences": 75,
@@ -3517,7 +3517,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 99
+                "others": 99
               },
               "stand_total_cases": 99,
               "total_sequences": 49,
@@ -3548,7 +3548,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 136
+                "others": 136
               },
               "stand_total_cases": 161,
               "total_sequences": 142,
@@ -3579,7 +3579,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 139
+                "others": 139
               },
               "stand_total_cases": 218,
               "total_sequences": 172,
@@ -3610,7 +3610,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 160
+                "others": 160
               },
               "stand_total_cases": 210,
               "total_sequences": 111,
@@ -3641,7 +3641,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 200
+                "others": 200
               },
               "stand_total_cases": 294,
               "total_sequences": 313,
@@ -3672,7 +3672,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 317
+                "others": 317
               },
               "stand_total_cases": 461,
               "total_sequences": 314,
@@ -3703,7 +3703,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 620
+                "others": 620
               },
               "stand_total_cases": 1267,
               "total_sequences": 333,
@@ -3734,7 +3734,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1333
+                "others": 1333
               },
               "stand_total_cases": 2733,
               "total_sequences": 365,
@@ -3765,7 +3765,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1248
+                "others": 1248
               },
               "stand_total_cases": 3096,
               "total_sequences": 422,
@@ -3796,7 +3796,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1282
+                "others": 1282
               },
               "stand_total_cases": 3016,
               "total_sequences": 586,
@@ -3827,7 +3827,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1310
+                "others": 1310
               },
               "stand_total_cases": 3846,
               "total_sequences": 822,
@@ -3858,7 +3858,7 @@
                 "21J (Delta)": 5,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1322
+                "others": 1322
               },
               "stand_total_cases": 4940,
               "total_sequences": 1028,
@@ -3889,7 +3889,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 624
+                "others": 624
               },
               "stand_total_cases": 2698,
               "total_sequences": 3043,
@@ -3920,7 +3920,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 366
+                "others": 366
               },
               "stand_total_cases": 1776,
               "total_sequences": 6098,
@@ -3951,7 +3951,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 177
+                "others": 177
               },
               "stand_total_cases": 1222,
               "total_sequences": 8844,
@@ -3982,7 +3982,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 184
+                "others": 184
               },
               "stand_total_cases": 1354,
               "total_sequences": 11235,
@@ -4013,7 +4013,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 107
+                "others": 107
               },
               "stand_total_cases": 1899,
               "total_sequences": 14190,
@@ -4044,7 +4044,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 73
+                "others": 73
               },
               "stand_total_cases": 2692,
               "total_sequences": 16198,
@@ -4075,7 +4075,7 @@
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 53
+                "others": 53
               },
               "stand_total_cases": 3061,
               "total_sequences": 19153,
@@ -4106,7 +4106,7 @@
                 "21J (Delta)": 6,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 41
+                "others": 41
               },
               "stand_total_cases": 3272,
               "total_sequences": 19177,
@@ -4137,7 +4137,7 @@
                 "21J (Delta)": 14,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 34
+                "others": 34
               },
               "stand_total_cases": 2105,
               "total_sequences": 15505,
@@ -4168,7 +4168,7 @@
                 "21J (Delta)": 18,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 27
+                "others": 27
               },
               "stand_total_cases": 1021,
               "total_sequences": 9710,
@@ -4199,7 +4199,7 @@
                 "21J (Delta)": 40,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 18
+                "others": 18
               },
               "stand_total_cases": 426,
               "total_sequences": 5328,
@@ -4230,7 +4230,7 @@
                 "21J (Delta)": 54,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 5
+                "others": 5
               },
               "stand_total_cases": 139,
               "total_sequences": 2582,
@@ -4261,7 +4261,7 @@
                 "21J (Delta)": 75,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 112,
               "total_sequences": 2620,
@@ -4292,7 +4292,7 @@
                 "21J (Delta)": 181,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 235,
               "total_sequences": 4559,
@@ -4323,7 +4323,7 @@
                 "21J (Delta)": 343,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 415,
               "total_sequences": 6144,
@@ -4354,7 +4354,7 @@
                 "21J (Delta)": 816,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 922,
               "total_sequences": 13058,
@@ -4385,7 +4385,7 @@
                 "21J (Delta)": 1503,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 1638,
               "total_sequences": 19038,
@@ -4416,7 +4416,7 @@
                 "21J (Delta)": 1506,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 1626,
               "total_sequences": 19681,
@@ -4447,7 +4447,7 @@
                 "21J (Delta)": 1225,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 1313,
               "total_sequences": 15507,
@@ -4478,7 +4478,7 @@
                 "21J (Delta)": 1364,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1448,
               "total_sequences": 12219,
@@ -4509,7 +4509,7 @@
                 "21J (Delta)": 2518,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2666,
               "total_sequences": 15414,
@@ -4540,7 +4540,7 @@
                 "21J (Delta)": 4836,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5052,
               "total_sequences": 17992,
@@ -4571,7 +4571,7 @@
                 "21J (Delta)": 8546,
                 "21K (Omicron)": 16,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 8822,
               "total_sequences": 23291,
@@ -4602,7 +4602,7 @@
                 "21J (Delta)": 8485,
                 "21K (Omicron)": 213,
                 "21L (Omicron)": 0,
-                "Unknown": 10
+                "others": 10
               },
               "stand_total_cases": 8917,
               "total_sequences": 24116,
@@ -4633,7 +4633,7 @@
                 "21J (Delta)": 4642,
                 "21K (Omicron)": 986,
                 "21L (Omicron)": 2,
-                "Unknown": 8
+                "others": 8
               },
               "stand_total_cases": 5739,
               "total_sequences": 21695,
@@ -4664,7 +4664,7 @@
                 "21J (Delta)": 2126,
                 "21K (Omicron)": 3950,
                 "21L (Omicron)": 71,
-                "Unknown": 5
+                "others": 5
               },
               "stand_total_cases": 6186,
               "total_sequences": 24045,
@@ -4695,7 +4695,7 @@
                 "21J (Delta)": 1466,
                 "21K (Omicron)": 11495,
                 "21L (Omicron)": 945,
-                "Unknown": 20
+                "others": 20
               },
               "stand_total_cases": 13957,
               "total_sequences": 24528,
@@ -4726,7 +4726,7 @@
                 "21J (Delta)": 389,
                 "21K (Omicron)": 22340,
                 "21L (Omicron)": 5153,
-                "Unknown": 15
+                "others": 15
               },
               "stand_total_cases": 27903,
               "total_sequences": 28061,
@@ -4757,7 +4757,7 @@
                 "21J (Delta)": 74,
                 "21K (Omicron)": 19178,
                 "21L (Omicron)": 10989,
-                "Unknown": 37
+                "others": 37
               },
               "stand_total_cases": 30280,
               "total_sequences": 33583,
@@ -4788,7 +4788,7 @@
                 "21J (Delta)": 12,
                 "21K (Omicron)": 9729,
                 "21L (Omicron)": 16706,
-                "Unknown": 104
+                "others": 104
               },
               "stand_total_cases": 26553,
               "total_sequences": 32317,
@@ -4819,7 +4819,7 @@
                 "21J (Delta)": 5,
                 "21K (Omicron)": 7124,
                 "21L (Omicron)": 27202,
-                "Unknown": 99
+                "others": 99
               },
               "stand_total_cases": 34433,
               "total_sequences": 34341,
@@ -4850,7 +4850,7 @@
                 "21J (Delta)": 4,
                 "21K (Omicron)": 3343,
                 "21L (Omicron)": 32134,
-                "Unknown": 131
+                "others": 131
               },
               "stand_total_cases": 35622,
               "total_sequences": 18669,
@@ -4881,7 +4881,7 @@
                 "21J (Delta)": 60,
                 "21K (Omicron)": 1229,
                 "21L (Omicron)": 19730,
-                "Unknown": 59
+                "others": 59
               },
               "stand_total_cases": 21078,
               "total_sequences": 1767,
@@ -4918,7 +4918,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 318
+                "others": 318
               },
               "stand_total_cases": 318,
               "total_sequences": 155,
@@ -4950,7 +4950,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 160
+                "others": 160
               },
               "stand_total_cases": 160,
               "total_sequences": 136,
@@ -4982,7 +4982,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 101
+                "others": 101
               },
               "stand_total_cases": 101,
               "total_sequences": 121,
@@ -5014,7 +5014,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 76
+                "others": 76
               },
               "stand_total_cases": 76,
               "total_sequences": 160,
@@ -5046,7 +5046,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 75
+                "others": 75
               },
               "stand_total_cases": 75,
               "total_sequences": 57,
@@ -5078,7 +5078,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 58
+                "others": 58
               },
               "stand_total_cases": 58,
               "total_sequences": 100,
@@ -5110,7 +5110,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 103
+                "others": 103
               },
               "stand_total_cases": 105,
               "total_sequences": 152,
@@ -5142,7 +5142,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 275
+                "others": 275
               },
               "stand_total_cases": 314,
               "total_sequences": 422,
@@ -5174,7 +5174,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 157
+                "others": 157
               },
               "stand_total_cases": 219,
               "total_sequences": 582,
@@ -5206,7 +5206,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 190
+                "others": 190
               },
               "stand_total_cases": 515,
               "total_sequences": 963,
@@ -5238,7 +5238,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 349
+                "others": 349
               },
               "stand_total_cases": 1160,
               "total_sequences": 1589,
@@ -5270,7 +5270,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 312
+                "others": 312
               },
               "stand_total_cases": 995,
               "total_sequences": 809,
@@ -5302,7 +5302,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 446
+                "others": 446
               },
               "stand_total_cases": 1364,
               "total_sequences": 1417,
@@ -5334,7 +5334,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 739
+                "others": 739
               },
               "stand_total_cases": 2539,
               "total_sequences": 2921,
@@ -5366,7 +5366,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1026
+                "others": 1026
               },
               "stand_total_cases": 2642,
               "total_sequences": 3061,
@@ -5398,7 +5398,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 1,
-                "Unknown": 847
+                "others": 847
               },
               "stand_total_cases": 3460,
               "total_sequences": 4974,
@@ -5430,7 +5430,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1168
+                "others": 1168
               },
               "stand_total_cases": 7539,
               "total_sequences": 9137,
@@ -5462,7 +5462,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 926
+                "others": 926
               },
               "stand_total_cases": 8093,
               "total_sequences": 11634,
@@ -5494,7 +5494,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 228
+                "others": 228
               },
               "stand_total_cases": 2268,
               "total_sequences": 8005,
@@ -5526,7 +5526,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 109
+                "others": 109
               },
               "stand_total_cases": 1195,
               "total_sequences": 4714,
@@ -5558,7 +5558,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 89
+                "others": 89
               },
               "stand_total_cases": 1024,
               "total_sequences": 4348,
@@ -5590,7 +5590,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 45
+                "others": 45
               },
               "stand_total_cases": 1249,
               "total_sequences": 5309,
@@ -5622,7 +5622,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 18
+                "others": 18
               },
               "stand_total_cases": 1834,
               "total_sequences": 6333,
@@ -5654,7 +5654,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 11
+                "others": 11
               },
               "stand_total_cases": 1688,
               "total_sequences": 7143,
@@ -5686,7 +5686,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 1602,
               "total_sequences": 6942,
@@ -5718,7 +5718,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 1768,
               "total_sequences": 7601,
@@ -5750,7 +5750,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 2337,
               "total_sequences": 9576,
@@ -5782,7 +5782,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 2387,
               "total_sequences": 9468,
@@ -5814,7 +5814,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 1632,
               "total_sequences": 5858,
@@ -5846,7 +5846,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 527,
               "total_sequences": 2020,
@@ -5878,7 +5878,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 1080,
               "total_sequences": 5116,
@@ -5910,7 +5910,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2115,
               "total_sequences": 10867,
@@ -5942,7 +5942,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 2109,
               "total_sequences": 10878,
@@ -5974,7 +5974,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 2353,
               "total_sequences": 11178,
@@ -6006,7 +6006,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1980,
               "total_sequences": 8705,
@@ -6038,7 +6038,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 974,
               "total_sequences": 4571,
@@ -6070,7 +6070,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 926,
               "total_sequences": 4847,
@@ -6102,7 +6102,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1482,
               "total_sequences": 7608,
@@ -6134,7 +6134,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 3291,
               "total_sequences": 15373,
@@ -6166,7 +6166,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 6113,
               "total_sequences": 22107,
@@ -6198,7 +6198,7 @@
                 "21K (Omicron)": 4,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 9565,
               "total_sequences": 23565,
@@ -6230,7 +6230,7 @@
                 "21K (Omicron)": 660,
                 "21L (Omicron)": 2,
                 "S:677P.Pelican": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 12980,
               "total_sequences": 30293,
@@ -6262,7 +6262,7 @@
                 "21K (Omicron)": 11781,
                 "21L (Omicron)": 1107,
                 "S:677P.Pelican": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 22473,
               "total_sequences": 11474,
@@ -6294,7 +6294,7 @@
                 "21K (Omicron)": 33878,
                 "21L (Omicron)": 12062,
                 "S:677P.Pelican": 0,
-                "Unknown": 30
+                "others": 30
               },
               "stand_total_cases": 48930,
               "total_sequences": 19046,
@@ -6326,7 +6326,7 @@
                 "21K (Omicron)": 26690,
                 "21L (Omicron)": 46505,
                 "S:677P.Pelican": 0,
-                "Unknown": 103
+                "others": 103
               },
               "stand_total_cases": 73684,
               "total_sequences": 28819,
@@ -6358,7 +6358,7 @@
                 "21K (Omicron)": 15531,
                 "21L (Omicron)": 88313,
                 "S:677P.Pelican": 0,
-                "Unknown": 209
+                "others": 209
               },
               "stand_total_cases": 104107,
               "total_sequences": 24962,
@@ -6390,7 +6390,7 @@
                 "21K (Omicron)": 5056,
                 "21L (Omicron)": 93560,
                 "S:677P.Pelican": 0,
-                "Unknown": 292
+                "others": 292
               },
               "stand_total_cases": 98912,
               "total_sequences": 26392,
@@ -6422,7 +6422,7 @@
                 "21K (Omicron)": 1131,
                 "21L (Omicron)": 47884,
                 "S:677P.Pelican": 0,
-                "Unknown": 180
+                "others": 180
               },
               "stand_total_cases": 49199,
               "total_sequences": 26496,
@@ -6454,7 +6454,7 @@
                 "21K (Omicron)": 296,
                 "21L (Omicron)": 23839,
                 "S:677P.Pelican": 0,
-                "Unknown": 91
+                "others": 91
               },
               "stand_total_cases": 24227,
               "total_sequences": 26353,
@@ -6486,7 +6486,7 @@
                 "21K (Omicron)": 87,
                 "21L (Omicron)": 10501,
                 "S:677P.Pelican": 0,
-                "Unknown": 42
+                "others": 42
               },
               "stand_total_cases": 10630,
               "total_sequences": 24809,
@@ -6518,7 +6518,7 @@
                 "21K (Omicron)": 17,
                 "21L (Omicron)": 5447,
                 "S:677P.Pelican": 0,
-                "Unknown": 26
+                "others": 26
               },
               "stand_total_cases": 5490,
               "total_sequences": 5977,
@@ -6555,7 +6555,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 522
+                "others": 522
               },
               "stand_total_cases": 522,
               "total_sequences": 946,
@@ -6587,7 +6587,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 407
+                "others": 407
               },
               "stand_total_cases": 407,
               "total_sequences": 622,
@@ -6619,7 +6619,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 265
+                "others": 265
               },
               "stand_total_cases": 265,
               "total_sequences": 212,
@@ -6651,7 +6651,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 142
+                "others": 142
               },
               "stand_total_cases": 142,
               "total_sequences": 203,
@@ -6683,7 +6683,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 111
+                "others": 111
               },
               "stand_total_cases": 111,
               "total_sequences": 104,
@@ -6715,7 +6715,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 134
+                "others": 134
               },
               "stand_total_cases": 135,
               "total_sequences": 204,
@@ -6747,7 +6747,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 165
+                "others": 165
               },
               "stand_total_cases": 165,
               "total_sequences": 296,
@@ -6779,7 +6779,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 134
+                "others": 134
               },
               "stand_total_cases": 134,
               "total_sequences": 584,
@@ -6811,7 +6811,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 160
+                "others": 160
               },
               "stand_total_cases": 160,
               "total_sequences": 728,
@@ -6843,7 +6843,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 251
+                "others": 251
               },
               "stand_total_cases": 253,
               "total_sequences": 727,
@@ -6875,7 +6875,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 471
+                "others": 471
               },
               "stand_total_cases": 477,
               "total_sequences": 758,
@@ -6907,7 +6907,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 739
+                "others": 739
               },
               "stand_total_cases": 757,
               "total_sequences": 1061,
@@ -6939,7 +6939,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 852
+                "others": 852
               },
               "stand_total_cases": 894,
               "total_sequences": 1101,
@@ -6971,7 +6971,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1222
+                "others": 1222
               },
               "stand_total_cases": 1286,
               "total_sequences": 1438,
@@ -7003,7 +7003,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 1,
                 "S:677P.Pelican": 0,
-                "Unknown": 1650
+                "others": 1650
               },
               "stand_total_cases": 1757,
               "total_sequences": 1939,
@@ -7035,7 +7035,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 4,
                 "S:677P.Pelican": 3,
-                "Unknown": 2119
+                "others": 2119
               },
               "stand_total_cases": 2257,
               "total_sequences": 2390,
@@ -7067,7 +7067,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 1,
                 "S:677P.Pelican": 2,
-                "Unknown": 2119
+                "others": 2119
               },
               "stand_total_cases": 2488,
               "total_sequences": 2430,
@@ -7099,7 +7099,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 1,
                 "S:677P.Pelican": 2,
-                "Unknown": 3244
+                "others": 3244
               },
               "stand_total_cases": 4039,
               "total_sequences": 4770,
@@ -7131,7 +7131,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 6,
                 "S:677P.Pelican": 0,
-                "Unknown": 1799
+                "others": 1799
               },
               "stand_total_cases": 2178,
               "total_sequences": 4782,
@@ -7163,7 +7163,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 1,
                 "S:677P.Pelican": 0,
-                "Unknown": 1208
+                "others": 1208
               },
               "stand_total_cases": 1447,
               "total_sequences": 3206,
@@ -7195,7 +7195,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 2,
                 "S:677P.Pelican": 0,
-                "Unknown": 806
+                "others": 806
               },
               "stand_total_cases": 1099,
               "total_sequences": 4250,
@@ -7227,7 +7227,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 632
+                "others": 632
               },
               "stand_total_cases": 1094,
               "total_sequences": 4851,
@@ -7259,7 +7259,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 1,
                 "S:677P.Pelican": 0,
-                "Unknown": 521
+                "others": 521
               },
               "stand_total_cases": 1264,
               "total_sequences": 7478,
@@ -7291,7 +7291,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 454
+                "others": 454
               },
               "stand_total_cases": 1910,
               "total_sequences": 10004,
@@ -7323,7 +7323,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 595
+                "others": 595
               },
               "stand_total_cases": 3179,
               "total_sequences": 10754,
@@ -7355,7 +7355,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 370
+                "others": 370
               },
               "stand_total_cases": 2926,
               "total_sequences": 11130,
@@ -7387,7 +7387,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 171
+                "others": 171
               },
               "stand_total_cases": 2412,
               "total_sequences": 8629,
@@ -7419,7 +7419,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 2,
                 "S:677P.Pelican": 0,
-                "Unknown": 52
+                "others": 52
               },
               "stand_total_cases": 1273,
               "total_sequences": 5921,
@@ -7451,7 +7451,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 22
+                "others": 22
               },
               "stand_total_cases": 586,
               "total_sequences": 4261,
@@ -7483,7 +7483,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 16
+                "others": 16
               },
               "stand_total_cases": 283,
               "total_sequences": 3752,
@@ -7515,7 +7515,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 176,
               "total_sequences": 1724,
@@ -7547,7 +7547,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 149,
               "total_sequences": 2707,
@@ -7579,7 +7579,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 346,
               "total_sequences": 7265,
@@ -7611,7 +7611,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 788,
               "total_sequences": 13152,
@@ -7643,7 +7643,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1223,
               "total_sequences": 14067,
@@ -7675,7 +7675,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 1530,
               "total_sequences": 8995,
@@ -7707,7 +7707,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 1555,
               "total_sequences": 7230,
@@ -7739,7 +7739,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1236,
               "total_sequences": 8048,
@@ -7771,7 +7771,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 933,
               "total_sequences": 6832,
@@ -7803,7 +7803,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 873,
               "total_sequences": 7122,
@@ -7835,7 +7835,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1008,
               "total_sequences": 7015,
@@ -7867,7 +7867,7 @@
                 "21L (Omicron)": 1,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 1326,
               "total_sequences": 12922,
@@ -7899,7 +7899,7 @@
                 "21L (Omicron)": 1,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 4990,
               "total_sequences": 14666,
@@ -7931,7 +7931,7 @@
                 "21L (Omicron)": 107,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 13728,
               "total_sequences": 14356,
@@ -7963,7 +7963,7 @@
                 "21L (Omicron)": 398,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 9999,
               "total_sequences": 10220,
@@ -7995,7 +7995,7 @@
                 "21L (Omicron)": 471,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 5350,
               "total_sequences": 10300,
@@ -8027,7 +8027,7 @@
                 "21L (Omicron)": 400,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2994,
               "total_sequences": 7803,
@@ -8059,7 +8059,7 @@
                 "21L (Omicron)": 509,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 2202,
               "total_sequences": 5645,
@@ -8091,7 +8091,7 @@
                 "21L (Omicron)": 723,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 1782,
               "total_sequences": 5239,
@@ -8123,7 +8123,7 @@
                 "21L (Omicron)": 1752,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 2729,
               "total_sequences": 4479,
@@ -8155,7 +8155,7 @@
                 "21L (Omicron)": 3003,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 11
+                "others": 11
               },
               "stand_total_cases": 3548,
               "total_sequences": 332,
@@ -8191,7 +8191,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 19
+                "others": 19
               },
               "stand_total_cases": 19,
               "total_sequences": 421,
@@ -8222,7 +8222,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 4,
               "total_sequences": 117,
@@ -8253,7 +8253,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 4,
               "total_sequences": 146,
@@ -8284,7 +8284,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 5
+                "others": 5
               },
               "stand_total_cases": 5,
               "total_sequences": 190,
@@ -8315,7 +8315,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 14
+                "others": 14
               },
               "stand_total_cases": 14,
               "total_sequences": 390,
@@ -8346,7 +8346,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 44
+                "others": 44
               },
               "stand_total_cases": 44,
               "total_sequences": 806,
@@ -8377,7 +8377,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 109
+                "others": 109
               },
               "stand_total_cases": 109,
               "total_sequences": 1920,
@@ -8408,7 +8408,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 134
+                "others": 134
               },
               "stand_total_cases": 134,
               "total_sequences": 2167,
@@ -8439,7 +8439,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 94
+                "others": 94
               },
               "stand_total_cases": 94,
               "total_sequences": 1498,
@@ -8470,7 +8470,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 61
+                "others": 61
               },
               "stand_total_cases": 61,
               "total_sequences": 788,
@@ -8501,7 +8501,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 51
+                "others": 51
               },
               "stand_total_cases": 51,
               "total_sequences": 535,
@@ -8532,7 +8532,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 56
+                "others": 56
               },
               "stand_total_cases": 56,
               "total_sequences": 560,
@@ -8563,7 +8563,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 61
+                "others": 61
               },
               "stand_total_cases": 61,
               "total_sequences": 700,
@@ -8594,7 +8594,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 89
+                "others": 89
               },
               "stand_total_cases": 89,
               "total_sequences": 836,
@@ -8625,7 +8625,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 194
+                "others": 194
               },
               "stand_total_cases": 194,
               "total_sequences": 1843,
@@ -8656,7 +8656,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 236
+                "others": 236
               },
               "stand_total_cases": 236,
               "total_sequences": 2030,
@@ -8687,7 +8687,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 287
+                "others": 287
               },
               "stand_total_cases": 288,
               "total_sequences": 2336,
@@ -8718,7 +8718,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 1,
-                "Unknown": 704
+                "others": 704
               },
               "stand_total_cases": 714,
               "total_sequences": 4997,
@@ -8749,7 +8749,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 604
+                "others": 604
               },
               "stand_total_cases": 613,
               "total_sequences": 3854,
@@ -8780,7 +8780,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 302
+                "others": 302
               },
               "stand_total_cases": 316,
               "total_sequences": 2503,
@@ -8811,7 +8811,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 140
+                "others": 140
               },
               "stand_total_cases": 152,
               "total_sequences": 1349,
@@ -8842,7 +8842,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 95
+                "others": 95
               },
               "stand_total_cases": 113,
               "total_sequences": 1321,
@@ -8873,7 +8873,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 98
+                "others": 98
               },
               "stand_total_cases": 133,
               "total_sequences": 2208,
@@ -8904,7 +8904,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 100
+                "others": 100
               },
               "stand_total_cases": 229,
               "total_sequences": 4115,
@@ -8935,7 +8935,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 128
+                "others": 128
               },
               "stand_total_cases": 389,
               "total_sequences": 5705,
@@ -8966,7 +8966,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 72
+                "others": 72
               },
               "stand_total_cases": 554,
               "total_sequences": 10533,
@@ -8997,7 +8997,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 52
+                "others": 52
               },
               "stand_total_cases": 633,
               "total_sequences": 9747,
@@ -9028,7 +9028,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 28
+                "others": 28
               },
               "stand_total_cases": 477,
               "total_sequences": 6109,
@@ -9059,7 +9059,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 6
+                "others": 6
               },
               "stand_total_cases": 240,
               "total_sequences": 4322,
@@ -9090,7 +9090,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 162,
               "total_sequences": 4265,
@@ -9121,7 +9121,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 198,
               "total_sequences": 5733,
@@ -9152,7 +9152,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 398,
               "total_sequences": 10226,
@@ -9183,7 +9183,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 1290,
               "total_sequences": 17561,
@@ -9214,7 +9214,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 2183,
               "total_sequences": 29423,
@@ -9245,7 +9245,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 2140,
               "total_sequences": 25137,
@@ -9276,7 +9276,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 814,
               "total_sequences": 9896,
@@ -9307,7 +9307,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 220,
               "total_sequences": 2878,
@@ -9338,7 +9338,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 76,
               "total_sequences": 1222,
@@ -9369,7 +9369,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 31,
               "total_sequences": 575,
@@ -9400,7 +9400,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 20,
               "total_sequences": 482,
@@ -9431,7 +9431,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 12,
               "total_sequences": 309,
@@ -9462,7 +9462,7 @@
                 "21K (Omicron)": 1,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 12,
               "total_sequences": 472,
@@ -9493,7 +9493,7 @@
                 "21K (Omicron)": 7,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 20,
               "total_sequences": 1244,
@@ -9524,7 +9524,7 @@
                 "21K (Omicron)": 228,
                 "21L (Omicron)": 4,
                 "S:677H.Robin1": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 267,
               "total_sequences": 9553,
@@ -9555,7 +9555,7 @@
                 "21K (Omicron)": 3104,
                 "21L (Omicron)": 67,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 3264,
               "total_sequences": 25348,
@@ -9586,7 +9586,7 @@
                 "21K (Omicron)": 8662,
                 "21L (Omicron)": 232,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 8994,
               "total_sequences": 12582,
@@ -9617,7 +9617,7 @@
                 "21K (Omicron)": 8830,
                 "21L (Omicron)": 508,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 9371,
               "total_sequences": 8870,
@@ -9648,7 +9648,7 @@
                 "21K (Omicron)": 6038,
                 "21L (Omicron)": 1124,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 7174,
               "total_sequences": 7403,
@@ -9679,7 +9679,7 @@
                 "21K (Omicron)": 3009,
                 "21L (Omicron)": 2580,
                 "S:677H.Robin1": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 5594,
               "total_sequences": 3990,
@@ -9710,7 +9710,7 @@
                 "21K (Omicron)": 606,
                 "21L (Omicron)": 4142,
                 "S:677H.Robin1": 0,
-                "Unknown": 9
+                "others": 9
               },
               "stand_total_cases": 4762,
               "total_sequences": 967,
@@ -9741,7 +9741,7 @@
                 "21K (Omicron)": 1585,
                 "21L (Omicron)": 3736,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5321,
               "total_sequences": 47,
@@ -9777,7 +9777,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 785
+                "others": 785
               },
               "stand_total_cases": 785,
               "total_sequences": 52,
@@ -9808,7 +9808,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 741
+                "others": 741
               },
               "stand_total_cases": 741,
               "total_sequences": 81,
@@ -9839,7 +9839,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1014
+                "others": 1014
               },
               "stand_total_cases": 1014,
               "total_sequences": 83,
@@ -9870,7 +9870,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1400
+                "others": 1400
               },
               "stand_total_cases": 1400,
               "total_sequences": 36,
@@ -9901,7 +9901,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1157
+                "others": 1157
               },
               "stand_total_cases": 1157,
               "total_sequences": 43,
@@ -9932,7 +9932,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 361
+                "others": 361
               },
               "stand_total_cases": 380,
               "total_sequences": 40,
@@ -9963,7 +9963,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 226
+                "others": 226
               },
               "stand_total_cases": 282,
               "total_sequences": 15,
@@ -9994,7 +9994,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 341
+                "others": 341
               },
               "stand_total_cases": 400,
               "total_sequences": 41,
@@ -10025,7 +10025,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 118
+                "others": 118
               },
               "stand_total_cases": 243,
               "total_sequences": 43,
@@ -10056,7 +10056,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 72
+                "others": 72
               },
               "stand_total_cases": 250,
               "total_sequences": 38,
@@ -10087,7 +10087,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 177
+                "others": 177
               },
               "stand_total_cases": 434,
               "total_sequences": 54,
@@ -10118,7 +10118,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 330
+                "others": 330
               },
               "stand_total_cases": 740,
               "total_sequences": 45,
@@ -10149,7 +10149,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 500
+                "others": 500
               },
               "stand_total_cases": 1195,
               "total_sequences": 43,
@@ -10180,7 +10180,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 940
+                "others": 940
               },
               "stand_total_cases": 3530,
               "total_sequences": 124,
@@ -10211,7 +10211,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 994
+                "others": 994
               },
               "stand_total_cases": 6085,
               "total_sequences": 104,
@@ -10242,7 +10242,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1389
+                "others": 1389
               },
               "stand_total_cases": 6950,
               "total_sequences": 145,
@@ -10273,7 +10273,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1212
+                "others": 1212
               },
               "stand_total_cases": 8681,
               "total_sequences": 172,
@@ -10304,7 +10304,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1099
+                "others": 1099
               },
               "stand_total_cases": 12042,
               "total_sequences": 822,
@@ -10335,7 +10335,7 @@
                 "21J (Delta)": 3,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 530
+                "others": 530
               },
               "stand_total_cases": 5678,
               "total_sequences": 2186,
@@ -10366,7 +10366,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 385
+                "others": 385
               },
               "stand_total_cases": 4025,
               "total_sequences": 5503,
@@ -10397,7 +10397,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 200
+                "others": 200
               },
               "stand_total_cases": 4242,
               "total_sequences": 9224,
@@ -10428,7 +10428,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 110
+                "others": 110
               },
               "stand_total_cases": 5294,
               "total_sequences": 11195,
@@ -10459,7 +10459,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 54
+                "others": 54
               },
               "stand_total_cases": 5837,
               "total_sequences": 13232,
@@ -10490,7 +10490,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 59
+                "others": 59
               },
               "stand_total_cases": 6783,
               "total_sequences": 10161,
@@ -10521,7 +10521,7 @@
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 67
+                "others": 67
               },
               "stand_total_cases": 8557,
               "total_sequences": 7247,
@@ -10552,7 +10552,7 @@
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 58
+                "others": 58
               },
               "stand_total_cases": 7230,
               "total_sequences": 6545,
@@ -10583,7 +10583,7 @@
                 "21J (Delta)": 10,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 31
+                "others": 31
               },
               "stand_total_cases": 6252,
               "total_sequences": 6880,
@@ -10614,7 +10614,7 @@
                 "21J (Delta)": 19,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 20
+                "others": 20
               },
               "stand_total_cases": 3085,
               "total_sequences": 5141,
@@ -10645,7 +10645,7 @@
                 "21J (Delta)": 92,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 12
+                "others": 12
               },
               "stand_total_cases": 1474,
               "total_sequences": 3745,
@@ -10676,7 +10676,7 @@
                 "21J (Delta)": 71,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 535,
               "total_sequences": 3240,
@@ -10707,7 +10707,7 @@
                 "21J (Delta)": 158,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 358,
               "total_sequences": 2103,
@@ -10738,7 +10738,7 @@
                 "21J (Delta)": 300,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 419,
               "total_sequences": 3215,
@@ -10769,7 +10769,7 @@
                 "21J (Delta)": 585,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 761,
               "total_sequences": 4426,
@@ -10800,7 +10800,7 @@
                 "21J (Delta)": 984,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 1185,
               "total_sequences": 5932,
@@ -10831,7 +10831,7 @@
                 "21J (Delta)": 1184,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 1372,
               "total_sequences": 4689,
@@ -10862,7 +10862,7 @@
                 "21J (Delta)": 1269,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 1422,
               "total_sequences": 3902,
@@ -10893,7 +10893,7 @@
                 "21J (Delta)": 775,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 853,
               "total_sequences": 3172,
@@ -10924,7 +10924,7 @@
                 "21J (Delta)": 717,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 814,
               "total_sequences": 2629,
@@ -10955,7 +10955,7 @@
                 "21J (Delta)": 845,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 942,
               "total_sequences": 4664,
@@ -10986,7 +10986,7 @@
                 "21J (Delta)": 1001,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1078,
               "total_sequences": 4632,
@@ -11017,7 +11017,7 @@
                 "21J (Delta)": 1531,
                 "21K (Omicron)": 1,
                 "21L (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 1611,
               "total_sequences": 4140,
@@ -11048,7 +11048,7 @@
                 "21J (Delta)": 2709,
                 "21K (Omicron)": 123,
                 "21L (Omicron)": 1,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 2989,
               "total_sequences": 5625,
@@ -11079,7 +11079,7 @@
                 "21J (Delta)": 2618,
                 "21K (Omicron)": 1503,
                 "21L (Omicron)": 94,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4340,
               "total_sequences": 6027,
@@ -11110,7 +11110,7 @@
                 "21J (Delta)": 2432,
                 "21K (Omicron)": 10022,
                 "21L (Omicron)": 1581,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 14107,
               "total_sequences": 5266,
@@ -11141,7 +11141,7 @@
                 "21J (Delta)": 941,
                 "21K (Omicron)": 22685,
                 "21L (Omicron)": 12501,
-                "Unknown": 5
+                "others": 5
               },
               "stand_total_cases": 36156,
               "total_sequences": 6071,
@@ -11172,7 +11172,7 @@
                 "21J (Delta)": 161,
                 "21K (Omicron)": 19663,
                 "21L (Omicron)": 29732,
-                "Unknown": 27
+                "others": 27
               },
               "stand_total_cases": 49583,
               "total_sequences": 7391,
@@ -11203,7 +11203,7 @@
                 "21J (Delta)": 2,
                 "21K (Omicron)": 3140,
                 "21L (Omicron)": 10150,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 13294,
               "total_sequences": 5907,
@@ -11234,7 +11234,7 @@
                 "21J (Delta)": 1,
                 "21K (Omicron)": 398,
                 "21L (Omicron)": 2858,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 3258,
               "total_sequences": 5496,
@@ -11265,7 +11265,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 93,
                 "21L (Omicron)": 1844,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 1941,
               "total_sequences": 4631,
@@ -11296,7 +11296,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 20,
                 "21L (Omicron)": 1172,
-                "Unknown": 5
+                "others": 5
               },
               "stand_total_cases": 1197,
               "total_sequences": 2526,
@@ -11327,7 +11327,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 11,
                 "21L (Omicron)": 785,
-                "Unknown": 5
+                "others": 5
               },
               "stand_total_cases": 801,
               "total_sequences": 149,
@@ -11363,7 +11363,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 142
+                "others": 142
               },
               "stand_total_cases": 142,
               "total_sequences": 60,
@@ -11394,7 +11394,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 49
+                "others": 49
               },
               "stand_total_cases": 49,
               "total_sequences": 13,
@@ -11425,7 +11425,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 26
+                "others": 26
               },
               "stand_total_cases": 26,
               "total_sequences": 19,
@@ -11456,7 +11456,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 37
+                "others": 37
               },
               "stand_total_cases": 37,
               "total_sequences": 20,
@@ -11487,7 +11487,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 111
+                "others": 111
               },
               "stand_total_cases": 111,
               "total_sequences": 65,
@@ -11518,7 +11518,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 150
+                "others": 150
               },
               "stand_total_cases": 151,
               "total_sequences": 144,
@@ -11549,7 +11549,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 198
+                "others": 198
               },
               "stand_total_cases": 224,
               "total_sequences": 120,
@@ -11580,7 +11580,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 205
+                "others": 205
               },
               "stand_total_cases": 295,
               "total_sequences": 151,
@@ -11611,7 +11611,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 202
+                "others": 202
               },
               "stand_total_cases": 446,
               "total_sequences": 231,
@@ -11642,7 +11642,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 191
+                "others": 191
               },
               "stand_total_cases": 592,
               "total_sequences": 267,
@@ -11673,7 +11673,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 239
+                "others": 239
               },
               "stand_total_cases": 537,
               "total_sequences": 45,
@@ -11704,7 +11704,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 374
+                "others": 374
               },
               "stand_total_cases": 975,
               "total_sequences": 392,
@@ -11735,7 +11735,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1524
+                "others": 1524
               },
               "stand_total_cases": 4966,
               "total_sequences": 948,
@@ -11766,7 +11766,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3132
+                "others": 3132
               },
               "stand_total_cases": 12421,
               "total_sequences": 1491,
@@ -11797,7 +11797,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2762
+                "others": 2762
               },
               "stand_total_cases": 9028,
               "total_sequences": 1517,
@@ -11828,7 +11828,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1917
+                "others": 1917
               },
               "stand_total_cases": 6183,
               "total_sequences": 1219,
@@ -11859,7 +11859,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1673
+                "others": 1673
               },
               "stand_total_cases": 6826,
               "total_sequences": 2027,
@@ -11890,7 +11890,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1618
+                "others": 1618
               },
               "stand_total_cases": 8489,
               "total_sequences": 4187,
@@ -11921,7 +11921,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 706
+                "others": 706
               },
               "stand_total_cases": 3590,
               "total_sequences": 3095,
@@ -11952,7 +11952,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 382
+                "others": 382
               },
               "stand_total_cases": 2592,
               "total_sequences": 2875,
@@ -11983,7 +11983,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 220
+                "others": 220
               },
               "stand_total_cases": 1824,
               "total_sequences": 1745,
@@ -12014,7 +12014,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 133
+                "others": 133
               },
               "stand_total_cases": 1665,
               "total_sequences": 1866,
@@ -12045,7 +12045,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 118
+                "others": 118
               },
               "stand_total_cases": 2101,
               "total_sequences": 2440,
@@ -12076,7 +12076,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 99
+                "others": 99
               },
               "stand_total_cases": 2837,
               "total_sequences": 2428,
@@ -12107,7 +12107,7 @@
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 88
+                "others": 88
               },
               "stand_total_cases": 3104,
               "total_sequences": 3092,
@@ -12138,7 +12138,7 @@
                 "21J (Delta)": 10,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 82
+                "others": 82
               },
               "stand_total_cases": 3163,
               "total_sequences": 3853,
@@ -12169,7 +12169,7 @@
                 "21J (Delta)": 14,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 76
+                "others": 76
               },
               "stand_total_cases": 2241,
               "total_sequences": 2742,
@@ -12200,7 +12200,7 @@
                 "21J (Delta)": 34,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 59
+                "others": 59
               },
               "stand_total_cases": 1550,
               "total_sequences": 2122,
@@ -12231,7 +12231,7 @@
                 "21J (Delta)": 66,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 27
+                "others": 27
               },
               "stand_total_cases": 806,
               "total_sequences": 1068,
@@ -12262,7 +12262,7 @@
                 "21J (Delta)": 58,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 7
+                "others": 7
               },
               "stand_total_cases": 281,
               "total_sequences": 452,
@@ -12293,7 +12293,7 @@
                 "21J (Delta)": 192,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 279,
               "total_sequences": 920,
@@ -12324,7 +12324,7 @@
                 "21J (Delta)": 750,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 5
+                "others": 5
               },
               "stand_total_cases": 886,
               "total_sequences": 2831,
@@ -12355,7 +12355,7 @@
                 "21J (Delta)": 1120,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 16
+                "others": 16
               },
               "stand_total_cases": 1296,
               "total_sequences": 4482,
@@ -12386,7 +12386,7 @@
                 "21J (Delta)": 2995,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 3303,
               "total_sequences": 6246,
@@ -12417,7 +12417,7 @@
                 "21J (Delta)": 3511,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 3778,
               "total_sequences": 4062,
@@ -12448,7 +12448,7 @@
                 "21J (Delta)": 4042,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4289,
               "total_sequences": 4139,
@@ -12479,7 +12479,7 @@
                 "21J (Delta)": 2032,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2122,
               "total_sequences": 3513,
@@ -12510,7 +12510,7 @@
                 "21J (Delta)": 1429,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1493,
               "total_sequences": 3057,
@@ -12541,7 +12541,7 @@
                 "21J (Delta)": 1981,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2061,
               "total_sequences": 4657,
@@ -12572,7 +12572,7 @@
                 "21J (Delta)": 4065,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4185,
               "total_sequences": 6044,
@@ -12603,7 +12603,7 @@
                 "21J (Delta)": 8678,
                 "21K (Omicron)": 32,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 8926,
               "total_sequences": 6058,
@@ -12634,7 +12634,7 @@
                 "21J (Delta)": 13356,
                 "21K (Omicron)": 682,
                 "21L (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 14352,
               "total_sequences": 5851,
@@ -12665,7 +12665,7 @@
                 "21J (Delta)": 7863,
                 "21K (Omicron)": 5187,
                 "21L (Omicron)": 3,
-                "Unknown": 6
+                "others": 6
               },
               "stand_total_cases": 13249,
               "total_sequences": 5109,
@@ -12696,7 +12696,7 @@
                 "21J (Delta)": 5664,
                 "21K (Omicron)": 23491,
                 "21L (Omicron)": 65,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 29351,
               "total_sequences": 4488,
@@ -12727,7 +12727,7 @@
                 "21J (Delta)": 1856,
                 "21K (Omicron)": 43059,
                 "21L (Omicron)": 497,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 45448,
               "total_sequences": 5117,
@@ -12758,7 +12758,7 @@
                 "21J (Delta)": 581,
                 "21K (Omicron)": 51206,
                 "21L (Omicron)": 3894,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 55681,
               "total_sequences": 4790,
@@ -12789,7 +12789,7 @@
                 "21J (Delta)": 105,
                 "21K (Omicron)": 25685,
                 "21L (Omicron)": 8576,
-                "Unknown": 7
+                "others": 7
               },
               "stand_total_cases": 34373,
               "total_sequences": 4894,
@@ -12820,7 +12820,7 @@
                 "21J (Delta)": 20,
                 "21K (Omicron)": 12151,
                 "21L (Omicron)": 13781,
-                "Unknown": 21
+                "others": 21
               },
               "stand_total_cases": 25973,
               "total_sequences": 3807,
@@ -12851,7 +12851,7 @@
                 "21J (Delta)": 13,
                 "21K (Omicron)": 8421,
                 "21L (Omicron)": 34941,
-                "Unknown": 40
+                "others": 40
               },
               "stand_total_cases": 43415,
               "total_sequences": 3248,
@@ -12882,7 +12882,7 @@
                 "21J (Delta)": 12,
                 "21K (Omicron)": 2053,
                 "21L (Omicron)": 25187,
-                "Unknown": 96
+                "others": 96
               },
               "stand_total_cases": 27348,
               "total_sequences": 2265,
@@ -12913,7 +12913,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 211,
                 "21L (Omicron)": 6823,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 7034,
               "total_sequences": 300,
@@ -12950,7 +12950,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 264
+                "others": 264
               },
               "stand_total_cases": 264,
               "total_sequences": 172,
@@ -12982,7 +12982,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 154
+                "others": 154
               },
               "stand_total_cases": 154,
               "total_sequences": 226,
@@ -13014,7 +13014,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 133
+                "others": 133
               },
               "stand_total_cases": 133,
               "total_sequences": 107,
@@ -13046,7 +13046,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 103
+                "others": 103
               },
               "stand_total_cases": 111,
               "total_sequences": 78,
@@ -13078,7 +13078,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 58
+                "others": 58
               },
               "stand_total_cases": 58,
               "total_sequences": 76,
@@ -13110,7 +13110,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 65
+                "others": 65
               },
               "stand_total_cases": 73,
               "total_sequences": 41,
@@ -13142,7 +13142,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 202
+                "others": 202
               },
               "stand_total_cases": 211,
               "total_sequences": 85,
@@ -13174,7 +13174,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 415
+                "others": 415
               },
               "stand_total_cases": 476,
               "total_sequences": 108,
@@ -13206,7 +13206,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 212
+                "others": 212
               },
               "stand_total_cases": 426,
               "total_sequences": 95,
@@ -13238,7 +13238,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 291
+                "others": 291
               },
               "stand_total_cases": 746,
               "total_sequences": 95,
@@ -13270,7 +13270,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 377
+                "others": 377
               },
               "stand_total_cases": 1818,
               "total_sequences": 251,
@@ -13302,7 +13302,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 579
+                "others": 579
               },
               "stand_total_cases": 3902,
               "total_sequences": 283,
@@ -13334,7 +13334,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 1090
+                "others": 1090
               },
               "stand_total_cases": 6997,
               "total_sequences": 417,
@@ -13366,7 +13366,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 792
+                "others": 792
               },
               "stand_total_cases": 6594,
               "total_sequences": 408,
@@ -13398,7 +13398,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 343
+                "others": 343
               },
               "stand_total_cases": 4378,
               "total_sequences": 433,
@@ -13430,7 +13430,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 300
+                "others": 300
               },
               "stand_total_cases": 4344,
               "total_sequences": 536,
@@ -13462,7 +13462,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 259
+                "others": 259
               },
               "stand_total_cases": 7964,
               "total_sequences": 826,
@@ -13494,7 +13494,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 440
+                "others": 440
               },
               "stand_total_cases": 10342,
               "total_sequences": 1929,
@@ -13526,7 +13526,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 169
+                "others": 169
               },
               "stand_total_cases": 4360,
               "total_sequences": 1740,
@@ -13558,7 +13558,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 153
+                "others": 153
               },
               "stand_total_cases": 3214,
               "total_sequences": 2247,
@@ -13590,7 +13590,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 1,
-                "Unknown": 96
+                "others": 96
               },
               "stand_total_cases": 3081,
               "total_sequences": 2402,
@@ -13622,7 +13622,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 35
+                "others": 35
               },
               "stand_total_cases": 3676,
               "total_sequences": 3153,
@@ -13654,7 +13654,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 41
+                "others": 41
               },
               "stand_total_cases": 4887,
               "total_sequences": 4027,
@@ -13686,7 +13686,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 31
+                "others": 31
               },
               "stand_total_cases": 5806,
               "total_sequences": 3842,
@@ -13718,7 +13718,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 10
+                "others": 10
               },
               "stand_total_cases": 6029,
               "total_sequences": 3594,
@@ -13750,7 +13750,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 15
+                "others": 15
               },
               "stand_total_cases": 6165,
               "total_sequences": 3926,
@@ -13782,7 +13782,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 6
+                "others": 6
               },
               "stand_total_cases": 4905,
               "total_sequences": 3482,
@@ -13814,7 +13814,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 11
+                "others": 11
               },
               "stand_total_cases": 2829,
               "total_sequences": 2964,
@@ -13846,7 +13846,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 14
+                "others": 14
               },
               "stand_total_cases": 1411,
               "total_sequences": 2622,
@@ -13878,7 +13878,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 7
+                "others": 7
               },
               "stand_total_cases": 600,
               "total_sequences": 1903,
@@ -13910,7 +13910,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 18
+                "others": 18
               },
               "stand_total_cases": 3091,
               "total_sequences": 3553,
@@ -13942,7 +13942,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 6438,
               "total_sequences": 4831,
@@ -13974,7 +13974,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 2370,
               "total_sequences": 3150,
@@ -14006,7 +14006,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 1966,
               "total_sequences": 3160,
@@ -14038,7 +14038,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2074,
               "total_sequences": 3443,
@@ -14070,7 +14070,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1756,
               "total_sequences": 2736,
@@ -14102,7 +14102,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1376,
               "total_sequences": 2360,
@@ -14134,7 +14134,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 2418,
               "total_sequences": 2861,
@@ -14166,7 +14166,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 5166,
               "total_sequences": 3269,
@@ -14198,7 +14198,7 @@
                 "21K (Omicron)": 3,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 10166,
               "total_sequences": 3754,
@@ -14230,7 +14230,7 @@
                 "21K (Omicron)": 309,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 17862,
               "total_sequences": 3933,
@@ -14262,7 +14262,7 @@
                 "21K (Omicron)": 871,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 15911,
               "total_sequences": 4166,
@@ -14294,7 +14294,7 @@
                 "21K (Omicron)": 2931,
                 "21L (Omicron)": 5,
                 "S:677H.Robin1": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 10619,
               "total_sequences": 4036,
@@ -14326,7 +14326,7 @@
                 "21K (Omicron)": 13058,
                 "21L (Omicron)": 79,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 17266,
               "total_sequences": 3927,
@@ -14358,7 +14358,7 @@
                 "21K (Omicron)": 31546,
                 "21L (Omicron)": 1294,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 34102,
               "total_sequences": 4243,
@@ -14390,7 +14390,7 @@
                 "21K (Omicron)": 50749,
                 "21L (Omicron)": 7846,
                 "S:677H.Robin1": 0,
-                "Unknown": 16
+                "others": 16
               },
               "stand_total_cases": 59143,
               "total_sequences": 3558,
@@ -14422,7 +14422,7 @@
                 "21K (Omicron)": 46625,
                 "21L (Omicron)": 20180,
                 "S:677H.Robin1": 0,
-                "Unknown": 20
+                "others": 20
               },
               "stand_total_cases": 66907,
               "total_sequences": 3289,
@@ -14454,7 +14454,7 @@
                 "21K (Omicron)": 15080,
                 "21L (Omicron)": 23974,
                 "S:677H.Robin1": 0,
-                "Unknown": 125
+                "others": 125
               },
               "stand_total_cases": 39179,
               "total_sequences": 3110,
@@ -14486,7 +14486,7 @@
                 "21K (Omicron)": 7668,
                 "21L (Omicron)": 39040,
                 "S:677H.Robin1": 0,
-                "Unknown": 124
+                "others": 124
               },
               "stand_total_cases": 46832,
               "total_sequences": 3023,
@@ -14518,7 +14518,7 @@
                 "21K (Omicron)": 1542,
                 "21L (Omicron)": 21602,
                 "S:677H.Robin1": 0,
-                "Unknown": 92
+                "others": 92
               },
               "stand_total_cases": 23236,
               "total_sequences": 2019,
@@ -14550,7 +14550,7 @@
                 "21K (Omicron)": 317,
                 "21L (Omicron)": 5820,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 6137,
               "total_sequences": 116,
@@ -14585,7 +14585,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 597
+                "others": 597
               },
               "stand_total_cases": 597,
               "total_sequences": 134,
@@ -14615,7 +14615,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 344
+                "others": 344
               },
               "stand_total_cases": 344,
               "total_sequences": 67,
@@ -14645,7 +14645,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 183
+                "others": 183
               },
               "stand_total_cases": 183,
               "total_sequences": 15,
@@ -14675,7 +14675,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 113
+                "others": 113
               },
               "stand_total_cases": 113,
               "total_sequences": 38,
@@ -14705,7 +14705,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 123
+                "others": 123
               },
               "stand_total_cases": 126,
               "total_sequences": 39,
@@ -14735,7 +14735,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 130
+                "others": 130
               },
               "stand_total_cases": 145,
               "total_sequences": 39,
@@ -14765,7 +14765,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 342
+                "others": 342
               },
               "stand_total_cases": 528,
               "total_sequences": 146,
@@ -14795,7 +14795,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 424
+                "others": 424
               },
               "stand_total_cases": 728,
               "total_sequences": 129,
@@ -14825,7 +14825,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 193
+                "others": 193
               },
               "stand_total_cases": 577,
               "total_sequences": 54,
@@ -14855,7 +14855,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 308
+                "others": 308
               },
               "stand_total_cases": 723,
               "total_sequences": 87,
@@ -14885,7 +14885,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 695
+                "others": 695
               },
               "stand_total_cases": 1781,
               "total_sequences": 246,
@@ -14915,7 +14915,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 731
+                "others": 731
               },
               "stand_total_cases": 4133,
               "total_sequences": 130,
@@ -14945,7 +14945,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1830
+                "others": 1830
               },
               "stand_total_cases": 13649,
               "total_sequences": 358,
@@ -14975,7 +14975,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2198
+                "others": 2198
               },
               "stand_total_cases": 15453,
               "total_sequences": 218,
@@ -15005,7 +15005,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 411
+                "others": 411
               },
               "stand_total_cases": 4985,
               "total_sequences": 243,
@@ -15035,7 +15035,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 321
+                "others": 321
               },
               "stand_total_cases": 2834,
               "total_sequences": 150,
@@ -15065,7 +15065,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1413
+                "others": 1413
               },
               "stand_total_cases": 2937,
               "total_sequences": 343,
@@ -15095,7 +15095,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 513
+                "others": 513
               },
               "stand_total_cases": 3295,
               "total_sequences": 527,
@@ -15125,7 +15125,7 @@
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 215
+                "others": 215
               },
               "stand_total_cases": 2527,
               "total_sequences": 1324,
@@ -15155,7 +15155,7 @@
                 "21J (Delta)": 2,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 261
+                "others": 261
               },
               "stand_total_cases": 2746,
               "total_sequences": 1758,
@@ -15185,7 +15185,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 274
+                "others": 274
               },
               "stand_total_cases": 2481,
               "total_sequences": 1752,
@@ -15215,7 +15215,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 294
+                "others": 294
               },
               "stand_total_cases": 2872,
               "total_sequences": 2188,
@@ -15245,7 +15245,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 327
+                "others": 327
               },
               "stand_total_cases": 4222,
               "total_sequences": 2875,
@@ -15275,7 +15275,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 314
+                "others": 314
               },
               "stand_total_cases": 5501,
               "total_sequences": 3388,
@@ -15305,7 +15305,7 @@
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 183
+                "others": 183
               },
               "stand_total_cases": 4212,
               "total_sequences": 2887,
@@ -15335,7 +15335,7 @@
                 "21J (Delta)": 56,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 192
+                "others": 192
               },
               "stand_total_cases": 3917,
               "total_sequences": 3272,
@@ -15365,7 +15365,7 @@
                 "21J (Delta)": 18,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 95
+                "others": 95
               },
               "stand_total_cases": 3125,
               "total_sequences": 3048,
@@ -15395,7 +15395,7 @@
                 "21J (Delta)": 98,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 64
+                "others": 64
               },
               "stand_total_cases": 2516,
               "total_sequences": 2922,
@@ -15425,7 +15425,7 @@
                 "21J (Delta)": 58,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 17
+                "others": 17
               },
               "stand_total_cases": 1301,
               "total_sequences": 1959,
@@ -15455,7 +15455,7 @@
                 "21J (Delta)": 107,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 6
+                "others": 6
               },
               "stand_total_cases": 527,
               "total_sequences": 1148,
@@ -15485,7 +15485,7 @@
                 "21J (Delta)": 521,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 10
+                "others": 10
               },
               "stand_total_cases": 964,
               "total_sequences": 2538,
@@ -15515,7 +15515,7 @@
                 "21J (Delta)": 1133,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 1699,
               "total_sequences": 3788,
@@ -15545,7 +15545,7 @@
                 "21J (Delta)": 1566,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 1999,
               "total_sequences": 3929,
@@ -15575,7 +15575,7 @@
                 "21J (Delta)": 1958,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2321,
               "total_sequences": 4496,
@@ -15605,7 +15605,7 @@
                 "21J (Delta)": 2090,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 2431,
               "total_sequences": 4432,
@@ -15635,7 +15635,7 @@
                 "21J (Delta)": 2189,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 2390,
               "total_sequences": 3070,
@@ -15665,7 +15665,7 @@
                 "21J (Delta)": 2127,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2354,
               "total_sequences": 2883,
@@ -15695,7 +15695,7 @@
                 "21J (Delta)": 2631,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2808,
               "total_sequences": 3307,
@@ -15725,7 +15725,7 @@
                 "21J (Delta)": 6600,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 6944,
               "total_sequences": 3799,
@@ -15755,7 +15755,7 @@
                 "21J (Delta)": 10261,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 10665,
               "total_sequences": 3036,
@@ -15785,7 +15785,7 @@
                 "21J (Delta)": 18040,
                 "21K (Omicron)": 35,
                 "21L (Omicron)": 0,
-                "Unknown": 10
+                "others": 10
               },
               "stand_total_cases": 18648,
               "total_sequences": 3775,
@@ -15815,7 +15815,7 @@
                 "21J (Delta)": 17477,
                 "21K (Omicron)": 1508,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 19612,
               "total_sequences": 4006,
@@ -15845,7 +15845,7 @@
                 "21J (Delta)": 5601,
                 "21K (Omicron)": 3478,
                 "21L (Omicron)": 3,
-                "Unknown": 31
+                "others": 31
               },
               "stand_total_cases": 9313,
               "total_sequences": 3211,
@@ -15875,7 +15875,7 @@
                 "21J (Delta)": 2630,
                 "21K (Omicron)": 13851,
                 "21L (Omicron)": 70,
-                "Unknown": 15
+                "others": 15
               },
               "stand_total_cases": 16641,
               "total_sequences": 3543,
@@ -15905,7 +15905,7 @@
                 "21J (Delta)": 830,
                 "21K (Omicron)": 37626,
                 "21L (Omicron)": 1537,
-                "Unknown": 19
+                "others": 19
               },
               "stand_total_cases": 40022,
               "total_sequences": 4193,
@@ -15935,7 +15935,7 @@
                 "21J (Delta)": 285,
                 "21K (Omicron)": 46104,
                 "21L (Omicron)": 5062,
-                "Unknown": 13
+                "others": 13
               },
               "stand_total_cases": 51477,
               "total_sequences": 3976,
@@ -15965,7 +15965,7 @@
                 "21J (Delta)": 27,
                 "21K (Omicron)": 12238,
                 "21L (Omicron)": 4724,
-                "Unknown": 48
+                "others": 48
               },
               "stand_total_cases": 17037,
               "total_sequences": 3181,
@@ -15995,7 +15995,7 @@
                 "21J (Delta)": 13,
                 "21K (Omicron)": 3601,
                 "21L (Omicron)": 4256,
-                "Unknown": 44
+                "others": 44
               },
               "stand_total_cases": 7914,
               "total_sequences": 2477,
@@ -16025,7 +16025,7 @@
                 "21J (Delta)": 14,
                 "21K (Omicron)": 1603,
                 "21L (Omicron)": 8742,
-                "Unknown": 66
+                "others": 66
               },
               "stand_total_cases": 10425,
               "total_sequences": 2881,
@@ -16055,7 +16055,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 781,
                 "21L (Omicron)": 11504,
-                "Unknown": 50
+                "others": 50
               },
               "stand_total_cases": 12335,
               "total_sequences": 2686,
@@ -16085,7 +16085,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 236,
                 "21L (Omicron)": 10181,
-                "Unknown": 63
+                "others": 63
               },
               "stand_total_cases": 10480,
               "total_sequences": 1156,
@@ -16119,7 +16119,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 9
+                "others": 9
               },
               "stand_total_cases": 9,
               "total_sequences": 113,
@@ -16148,7 +16148,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 6
+                "others": 6
               },
               "stand_total_cases": 6,
               "total_sequences": 81,
@@ -16177,7 +16177,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 5
+                "others": 5
               },
               "stand_total_cases": 5,
               "total_sequences": 88,
@@ -16206,7 +16206,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 8
+                "others": 8
               },
               "stand_total_cases": 8,
               "total_sequences": 159,
@@ -16235,7 +16235,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 43
+                "others": 43
               },
               "stand_total_cases": 43,
               "total_sequences": 807,
@@ -16264,7 +16264,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 135
+                "others": 135
               },
               "stand_total_cases": 135,
               "total_sequences": 2651,
@@ -16293,7 +16293,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 242
+                "others": 242
               },
               "stand_total_cases": 242,
               "total_sequences": 3899,
@@ -16322,7 +16322,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 203
+                "others": 203
               },
               "stand_total_cases": 203,
               "total_sequences": 2392,
@@ -16351,7 +16351,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 84
+                "others": 84
               },
               "stand_total_cases": 84,
               "total_sequences": 1563,
@@ -16380,7 +16380,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 36
+                "others": 36
               },
               "stand_total_cases": 36,
               "total_sequences": 643,
@@ -16409,7 +16409,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 13
+                "others": 13
               },
               "stand_total_cases": 13,
               "total_sequences": 267,
@@ -16438,7 +16438,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 9
+                "others": 9
               },
               "stand_total_cases": 9,
               "total_sequences": 156,
@@ -16467,7 +16467,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 9
+                "others": 9
               },
               "stand_total_cases": 9,
               "total_sequences": 108,
@@ -16496,7 +16496,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 5,
               "total_sequences": 58,
@@ -16525,7 +16525,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 6
+                "others": 6
               },
               "stand_total_cases": 6,
               "total_sequences": 61,
@@ -16554,7 +16554,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 5,
               "total_sequences": 44,
@@ -16583,7 +16583,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 8
+                "others": 8
               },
               "stand_total_cases": 8,
               "total_sequences": 135,
@@ -16612,7 +16612,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 11
+                "others": 11
               },
               "stand_total_cases": 16,
               "total_sequences": 247,
@@ -16641,7 +16641,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 6,
               "total_sequences": 89,
@@ -16670,7 +16670,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 3,
               "total_sequences": 46,
@@ -16699,7 +16699,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2,
               "total_sequences": 73,
@@ -16728,7 +16728,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 4,
               "total_sequences": 71,
@@ -16757,7 +16757,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 6,
               "total_sequences": 114,
@@ -16786,7 +16786,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 5,
               "total_sequences": 119,
@@ -16815,7 +16815,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 6,
               "total_sequences": 144,
@@ -16844,7 +16844,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 11,
               "total_sequences": 189,
@@ -16873,7 +16873,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 5,
               "total_sequences": 94,
@@ -16902,7 +16902,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 4,
               "total_sequences": 88,
@@ -16931,7 +16931,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 6,
               "total_sequences": 123,
@@ -16960,7 +16960,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 10,
               "total_sequences": 243,
@@ -16989,7 +16989,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 26,
               "total_sequences": 750,
@@ -17018,7 +17018,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 72,
               "total_sequences": 1691,
@@ -17047,7 +17047,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 137,
               "total_sequences": 2706,
@@ -17076,7 +17076,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 321,
               "total_sequences": 3117,
@@ -17105,7 +17105,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 707,
               "total_sequences": 3506,
@@ -17134,7 +17134,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 929,
               "total_sequences": 3659,
@@ -17163,7 +17163,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1019,
               "total_sequences": 2282,
@@ -17192,7 +17192,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1235,
               "total_sequences": 2414,
@@ -17221,7 +17221,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1037,
               "total_sequences": 1838,
@@ -17250,7 +17250,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 720,
               "total_sequences": 2079,
@@ -17279,7 +17279,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 718,
               "total_sequences": 1975,
@@ -17308,7 +17308,7 @@
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 838,
               "total_sequences": 3532,
@@ -17337,7 +17337,7 @@
                 "21L (Omicron)": 1,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 3090,
               "total_sequences": 4436,
@@ -17366,7 +17366,7 @@
                 "21L (Omicron)": 98,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 28494,
               "total_sequences": 4079,
@@ -17395,7 +17395,7 @@
                 "21L (Omicron)": 1353,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 45905,
               "total_sequences": 3222,
@@ -17424,7 +17424,7 @@
                 "21L (Omicron)": 1591,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 21337,
               "total_sequences": 2696,
@@ -17453,7 +17453,7 @@
                 "21L (Omicron)": 2111,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 11591,
               "total_sequences": 3278,
@@ -17482,7 +17482,7 @@
                 "21L (Omicron)": 4511,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 11
+                "others": 11
               },
               "stand_total_cases": 13004,
               "total_sequences": 3546,
@@ -17511,7 +17511,7 @@
                 "21L (Omicron)": 15778,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 9
+                "others": 9
               },
               "stand_total_cases": 21682,
               "total_sequences": 4888,
@@ -17540,7 +17540,7 @@
                 "21L (Omicron)": 27165,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 23
+                "others": 23
               },
               "stand_total_cases": 29994,
               "total_sequences": 5323,
@@ -17569,7 +17569,7 @@
                 "21L (Omicron)": 25299,
                 "S:677H.Robin1": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 53
+                "others": 53
               },
               "stand_total_cases": 27148,
               "total_sequences": 514,
@@ -17603,7 +17603,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 749
+                "others": 749
               },
               "stand_total_cases": 749,
               "total_sequences": 111,
@@ -17632,7 +17632,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 329
+                "others": 329
               },
               "stand_total_cases": 329,
               "total_sequences": 43,
@@ -17661,7 +17661,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 112
+                "others": 112
               },
               "stand_total_cases": 112,
               "total_sequences": 8,
@@ -17690,7 +17690,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 35
+                "others": 35
               },
               "stand_total_cases": 35,
               "total_sequences": 5,
@@ -17719,7 +17719,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 29
+                "others": 29
               },
               "stand_total_cases": 29,
               "total_sequences": 9,
@@ -17748,7 +17748,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 45
+                "others": 45
               },
               "stand_total_cases": 46,
               "total_sequences": 31,
@@ -17777,7 +17777,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 17
+                "others": 17
               },
               "stand_total_cases": 80,
               "total_sequences": 58,
@@ -17806,7 +17806,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 59
+                "others": 59
               },
               "stand_total_cases": 219,
               "total_sequences": 85,
@@ -17835,7 +17835,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 172
+                "others": 172
               },
               "stand_total_cases": 301,
               "total_sequences": 21,
@@ -17864,7 +17864,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 96
+                "others": 96
               },
               "stand_total_cases": 446,
               "total_sequences": 79,
@@ -17893,7 +17893,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 175
+                "others": 175
               },
               "stand_total_cases": 803,
               "total_sequences": 101,
@@ -17922,7 +17922,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 177
+                "others": 177
               },
               "stand_total_cases": 1512,
               "total_sequences": 85,
@@ -17951,7 +17951,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 329
+                "others": 329
               },
               "stand_total_cases": 2930,
               "total_sequences": 98,
@@ -17980,7 +17980,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 80
+                "others": 80
               },
               "stand_total_cases": 1658,
               "total_sequences": 62,
@@ -18009,7 +18009,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 54
+                "others": 54
               },
               "stand_total_cases": 1016,
               "total_sequences": 94,
@@ -18038,7 +18038,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 59
+                "others": 59
               },
               "stand_total_cases": 759,
               "total_sequences": 89,
@@ -18067,7 +18067,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 122
+                "others": 122
               },
               "stand_total_cases": 1062,
               "total_sequences": 96,
@@ -18096,7 +18096,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 569
+                "others": 569
               },
               "stand_total_cases": 13660,
               "total_sequences": 336,
@@ -18125,7 +18125,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 480
+                "others": 480
               },
               "stand_total_cases": 8015,
               "total_sequences": 484,
@@ -18154,7 +18154,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 88
+                "others": 88
               },
               "stand_total_cases": 3213,
               "total_sequences": 1132,
@@ -18183,7 +18183,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 88
+                "others": 88
               },
               "stand_total_cases": 2305,
               "total_sequences": 1450,
@@ -18212,7 +18212,7 @@
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 32
+                "others": 32
               },
               "stand_total_cases": 1638,
               "total_sequences": 1609,
@@ -18241,7 +18241,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 26
+                "others": 26
               },
               "stand_total_cases": 1481,
               "total_sequences": 1705,
@@ -18270,7 +18270,7 @@
                 "21J (Delta)": 7,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 41
+                "others": 41
               },
               "stand_total_cases": 1514,
               "total_sequences": 1360,
@@ -18299,7 +18299,7 @@
                 "21J (Delta)": 3,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 53
+                "others": 53
               },
               "stand_total_cases": 1075,
               "total_sequences": 1431,
@@ -18328,7 +18328,7 @@
                 "21J (Delta)": 11,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 43
+                "others": 43
               },
               "stand_total_cases": 1270,
               "total_sequences": 1903,
@@ -18357,7 +18357,7 @@
                 "21J (Delta)": 13,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 31
+                "others": 31
               },
               "stand_total_cases": 1177,
               "total_sequences": 1405,
@@ -18386,7 +18386,7 @@
                 "21J (Delta)": 10,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 13
+                "others": 13
               },
               "stand_total_cases": 1197,
               "total_sequences": 2357,
@@ -18415,7 +18415,7 @@
                 "21J (Delta)": 63,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 30
+                "others": 30
               },
               "stand_total_cases": 1029,
               "total_sequences": 1205,
@@ -18444,7 +18444,7 @@
                 "21J (Delta)": 212,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 894,
               "total_sequences": 1557,
@@ -18473,7 +18473,7 @@
                 "21J (Delta)": 834,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 1335,
               "total_sequences": 1760,
@@ -18502,7 +18502,7 @@
                 "21J (Delta)": 2490,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 8
+                "others": 8
               },
               "stand_total_cases": 3031,
               "total_sequences": 2644,
@@ -18531,7 +18531,7 @@
                 "21J (Delta)": 3464,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 3907,
               "total_sequences": 2878,
@@ -18560,7 +18560,7 @@
                 "21J (Delta)": 4490,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 4947,
               "total_sequences": 2904,
@@ -18589,7 +18589,7 @@
                 "21J (Delta)": 4114,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4296,
               "total_sequences": 2200,
@@ -18618,7 +18618,7 @@
                 "21J (Delta)": 3777,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 3958,
               "total_sequences": 2426,
@@ -18647,7 +18647,7 @@
                 "21J (Delta)": 3500,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 3664,
               "total_sequences": 1673,
@@ -18676,7 +18676,7 @@
                 "21J (Delta)": 4164,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4312,
               "total_sequences": 2672,
@@ -18705,7 +18705,7 @@
                 "21J (Delta)": 5919,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 6116,
               "total_sequences": 2789,
@@ -18734,7 +18734,7 @@
                 "21J (Delta)": 10344,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 10607,
               "total_sequences": 967,
@@ -18763,7 +18763,7 @@
                 "21J (Delta)": 11941,
                 "21K (Omicron)": 164,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 12363,
               "total_sequences": 527,
@@ -18792,7 +18792,7 @@
                 "21J (Delta)": 11192,
                 "21K (Omicron)": 1314,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 12757,
               "total_sequences": 2389,
@@ -18821,7 +18821,7 @@
                 "21J (Delta)": 6965,
                 "21K (Omicron)": 11351,
                 "21L (Omicron)": 0,
-                "Unknown": 7
+                "others": 7
               },
               "stand_total_cases": 18483,
               "total_sequences": 2996,
@@ -18850,7 +18850,7 @@
                 "21J (Delta)": 2208,
                 "21K (Omicron)": 50339,
                 "21L (Omicron)": 36,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 52655,
               "total_sequences": 2910,
@@ -18879,7 +18879,7 @@
                 "21J (Delta)": 388,
                 "21K (Omicron)": 32678,
                 "21L (Omicron)": 595,
-                "Unknown": 9
+                "others": 9
               },
               "stand_total_cases": 33687,
               "total_sequences": 3907,
@@ -18908,7 +18908,7 @@
                 "21J (Delta)": 42,
                 "21K (Omicron)": 10501,
                 "21L (Omicron)": 1479,
-                "Unknown": 8
+                "others": 8
               },
               "stand_total_cases": 12030,
               "total_sequences": 1448,
@@ -18937,7 +18937,7 @@
                 "21J (Delta)": 18,
                 "21K (Omicron)": 4355,
                 "21L (Omicron)": 8601,
-                "Unknown": 18
+                "others": 18
               },
               "stand_total_cases": 12992,
               "total_sequences": 719,
@@ -18966,7 +18966,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 3226,
                 "21L (Omicron)": 6698,
-                "Unknown": 105
+                "others": 105
               },
               "stand_total_cases": 10029,
               "total_sequences": 286,
@@ -18995,7 +18995,7 @@
                 "21J (Delta)": 6,
                 "21K (Omicron)": 832,
                 "21L (Omicron)": 9252,
-                "Unknown": 17
+                "others": 17
               },
               "stand_total_cases": 10107,
               "total_sequences": 1726,
@@ -19024,7 +19024,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 914,
                 "21L (Omicron)": 19032,
-                "Unknown": 59
+                "others": 59
               },
               "stand_total_cases": 20005,
               "total_sequences": 1007,
@@ -19053,7 +19053,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 520,
                 "21L (Omicron)": 6239,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 6759,
               "total_sequences": 39,
@@ -19084,7 +19084,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 29
+                "others": 29
               },
               "stand_total_cases": 29,
               "total_sequences": 4,
@@ -19110,7 +19110,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 8
+                "others": 8
               },
               "stand_total_cases": 8,
               "total_sequences": 4,
@@ -19136,7 +19136,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 16
+                "others": 16
               },
               "stand_total_cases": 16,
               "total_sequences": 11,
@@ -19162,7 +19162,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 86
+                "others": 86
               },
               "stand_total_cases": 86,
               "total_sequences": 49,
@@ -19188,7 +19188,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 118
+                "others": 118
               },
               "stand_total_cases": 118,
               "total_sequences": 56,
@@ -19214,7 +19214,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 110
+                "others": 110
               },
               "stand_total_cases": 112,
               "total_sequences": 65,
@@ -19240,7 +19240,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 70
+                "others": 70
               },
               "stand_total_cases": 113,
               "total_sequences": 74,
@@ -19266,7 +19266,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 106
+                "others": 106
               },
               "stand_total_cases": 215,
               "total_sequences": 94,
@@ -19292,7 +19292,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 138
+                "others": 138
               },
               "stand_total_cases": 402,
               "total_sequences": 166,
@@ -19318,7 +19318,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 228
+                "others": 228
               },
               "stand_total_cases": 792,
               "total_sequences": 163,
@@ -19344,7 +19344,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 607
+                "others": 607
               },
               "stand_total_cases": 1593,
               "total_sequences": 336,
@@ -19370,7 +19370,7 @@
                 "21J (Delta)": 58,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2901
+                "others": 2901
               },
               "stand_total_cases": 6872,
               "total_sequences": 353,
@@ -19396,7 +19396,7 @@
                 "21J (Delta)": 84,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2948
+                "others": 2948
               },
               "stand_total_cases": 10684,
               "total_sequences": 888,
@@ -19422,7 +19422,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2998
+                "others": 2998
               },
               "stand_total_cases": 9692,
               "total_sequences": 139,
@@ -19448,7 +19448,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2131
+                "others": 2131
               },
               "stand_total_cases": 9860,
               "total_sequences": 953,
@@ -19474,7 +19474,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1607
+                "others": 1607
               },
               "stand_total_cases": 9666,
               "total_sequences": 866,
@@ -19500,7 +19500,7 @@
                 "21J (Delta)": 15,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1276
+                "others": 1276
               },
               "stand_total_cases": 16058,
               "total_sequences": 1083,
@@ -19526,7 +19526,7 @@
                 "21J (Delta)": 144,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1516
+                "others": 1516
               },
               "stand_total_cases": 8923,
               "total_sequences": 371,
@@ -19552,7 +19552,7 @@
                 "21J (Delta)": 30,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1666
+                "others": 1666
               },
               "stand_total_cases": 7635,
               "total_sequences": 1539,
@@ -19578,7 +19578,7 @@
                 "21J (Delta)": 8,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 456
+                "others": 456
               },
               "stand_total_cases": 5322,
               "total_sequences": 1274,
@@ -19604,7 +19604,7 @@
                 "21J (Delta)": 11,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 339
+                "others": 339
               },
               "stand_total_cases": 5147,
               "total_sequences": 1430,
@@ -19630,7 +19630,7 @@
                 "21J (Delta)": 8,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 147
+                "others": 147
               },
               "stand_total_cases": 5079,
               "total_sequences": 1248,
@@ -19656,7 +19656,7 @@
                 "21J (Delta)": 17,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 110
+                "others": 110
               },
               "stand_total_cases": 6790,
               "total_sequences": 1604,
@@ -19682,7 +19682,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 37
+                "others": 37
               },
               "stand_total_cases": 5739,
               "total_sequences": 2005,
@@ -19708,7 +19708,7 @@
                 "21J (Delta)": 2,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 32
+                "others": 32
               },
               "stand_total_cases": 4618,
               "total_sequences": 1923,
@@ -19734,7 +19734,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 20
+                "others": 20
               },
               "stand_total_cases": 3674,
               "total_sequences": 1143,
@@ -19760,7 +19760,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 16
+                "others": 16
               },
               "stand_total_cases": 2078,
               "total_sequences": 680,
@@ -19786,7 +19786,7 @@
                 "21J (Delta)": 11,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 9
+                "others": 9
               },
               "stand_total_cases": 1352,
               "total_sequences": 640,
@@ -19812,7 +19812,7 @@
                 "21J (Delta)": 39,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 11
+                "others": 11
               },
               "stand_total_cases": 383,
               "total_sequences": 286,
@@ -19838,7 +19838,7 @@
                 "21J (Delta)": 195,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 11
+                "others": 11
               },
               "stand_total_cases": 299,
               "total_sequences": 235,
@@ -19864,7 +19864,7 @@
                 "21J (Delta)": 346,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 379,
               "total_sequences": 617,
@@ -19890,7 +19890,7 @@
                 "21J (Delta)": 646,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 701,
               "total_sequences": 1256,
@@ -19916,7 +19916,7 @@
                 "21J (Delta)": 1555,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1653,
               "total_sequences": 1891,
@@ -19942,7 +19942,7 @@
                 "21J (Delta)": 2947,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 3251,
               "total_sequences": 2371,
@@ -19968,7 +19968,7 @@
                 "21J (Delta)": 5973,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 6336,
               "total_sequences": 2184,
@@ -19994,7 +19994,7 @@
                 "21J (Delta)": 5651,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 5955,
               "total_sequences": 2192,
@@ -20020,7 +20020,7 @@
                 "21J (Delta)": 5504,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 5906,
               "total_sequences": 2470,
@@ -20046,7 +20046,7 @@
                 "21J (Delta)": 12661,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 13332,
               "total_sequences": 2643,
@@ -20072,7 +20072,7 @@
                 "21J (Delta)": 19306,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 20345,
               "total_sequences": 2272,
@@ -20098,7 +20098,7 @@
                 "21J (Delta)": 17882,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 18874,
               "total_sequences": 2722,
@@ -20124,7 +20124,7 @@
                 "21J (Delta)": 10418,
                 "21K (Omicron)": 28,
                 "21L (Omicron)": 0,
-                "Unknown": 17
+                "others": 17
               },
               "stand_total_cases": 10860,
               "total_sequences": 2332,
@@ -20150,7 +20150,7 @@
                 "21J (Delta)": 6338,
                 "21K (Omicron)": 1090,
                 "21L (Omicron)": 0,
-                "Unknown": 17
+                "others": 17
               },
               "stand_total_cases": 7747,
               "total_sequences": 1947,
@@ -20176,7 +20176,7 @@
                 "21J (Delta)": 3680,
                 "21K (Omicron)": 12950,
                 "21L (Omicron)": 4,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 16705,
               "total_sequences": 4213,
@@ -20202,7 +20202,7 @@
                 "21J (Delta)": 2707,
                 "21K (Omicron)": 51033,
                 "21L (Omicron)": 407,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 54147,
               "total_sequences": 2660,
@@ -20228,7 +20228,7 @@
                 "21J (Delta)": 768,
                 "21K (Omicron)": 87868,
                 "21L (Omicron)": 3296,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 91932,
               "total_sequences": 2036,
@@ -20254,7 +20254,7 @@
                 "21J (Delta)": 47,
                 "21K (Omicron)": 35941,
                 "21L (Omicron)": 4225,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 40213,
               "total_sequences": 2570,
@@ -20280,7 +20280,7 @@
                 "21J (Delta)": 35,
                 "21K (Omicron)": 9081,
                 "21L (Omicron)": 3223,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 12339,
               "total_sequences": 1409,
@@ -20306,7 +20306,7 @@
                 "21J (Delta)": 12,
                 "21K (Omicron)": 8311,
                 "21L (Omicron)": 7606,
-                "Unknown": 23
+                "others": 23
               },
               "stand_total_cases": 15952,
               "total_sequences": 1380,
@@ -20332,7 +20332,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 4453,
                 "21L (Omicron)": 13340,
-                "Unknown": 20
+                "others": 20
               },
               "stand_total_cases": 17813,
               "total_sequences": 904,
@@ -20367,7 +20367,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 105
+                "others": 105
               },
               "stand_total_cases": 105,
               "total_sequences": 27,
@@ -20397,7 +20397,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 45
+                "others": 45
               },
               "stand_total_cases": 45,
               "total_sequences": 17,
@@ -20427,7 +20427,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 35
+                "others": 35
               },
               "stand_total_cases": 35,
               "total_sequences": 8,
@@ -20457,7 +20457,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 36
+                "others": 36
               },
               "stand_total_cases": 36,
               "total_sequences": 30,
@@ -20487,7 +20487,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 31
+                "others": 31
               },
               "stand_total_cases": 33,
               "total_sequences": 59,
@@ -20517,7 +20517,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 17
+                "others": 17
               },
               "stand_total_cases": 17,
               "total_sequences": 32,
@@ -20547,7 +20547,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 35
+                "others": 35
               },
               "stand_total_cases": 43,
               "total_sequences": 84,
@@ -20577,7 +20577,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 39
+                "others": 39
               },
               "stand_total_cases": 134,
               "total_sequences": 164,
@@ -20607,7 +20607,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 95
+                "others": 95
               },
               "stand_total_cases": 116,
               "total_sequences": 47,
@@ -20637,7 +20637,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 209
+                "others": 209
               },
               "stand_total_cases": 276,
               "total_sequences": 108,
@@ -20667,7 +20667,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 79
+                "others": 79
               },
               "stand_total_cases": 282,
               "total_sequences": 117,
@@ -20697,7 +20697,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 73
+                "others": 73
               },
               "stand_total_cases": 334,
               "total_sequences": 156,
@@ -20727,7 +20727,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 109
+                "others": 109
               },
               "stand_total_cases": 436,
               "total_sequences": 200,
@@ -20757,7 +20757,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 580
+                "others": 580
               },
               "stand_total_cases": 1248,
               "total_sequences": 260,
@@ -20787,7 +20787,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 758
+                "others": 758
               },
               "stand_total_cases": 1469,
               "total_sequences": 163,
@@ -20817,7 +20817,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 670
+                "others": 670
               },
               "stand_total_cases": 1016,
               "total_sequences": 188,
@@ -20847,7 +20847,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 777
+                "others": 777
               },
               "stand_total_cases": 1021,
               "total_sequences": 268,
@@ -20877,7 +20877,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 1122
+                "others": 1122
               },
               "stand_total_cases": 2116,
               "total_sequences": 538,
@@ -20907,7 +20907,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 542
+                "others": 542
               },
               "stand_total_cases": 1026,
               "total_sequences": 738,
@@ -20937,7 +20937,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 334
+                "others": 334
               },
               "stand_total_cases": 675,
               "total_sequences": 1410,
@@ -20967,7 +20967,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 228
+                "others": 228
               },
               "stand_total_cases": 687,
               "total_sequences": 1472,
@@ -20997,7 +20997,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 126
+                "others": 126
               },
               "stand_total_cases": 1172,
               "total_sequences": 1602,
@@ -21027,7 +21027,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 64
+                "others": 64
               },
               "stand_total_cases": 2194,
               "total_sequences": 1814,
@@ -21057,7 +21057,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 34
+                "others": 34
               },
               "stand_total_cases": 2147,
               "total_sequences": 1428,
@@ -21087,7 +21087,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 16
+                "others": 16
               },
               "stand_total_cases": 1616,
               "total_sequences": 1933,
@@ -21117,7 +21117,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 7
+                "others": 7
               },
               "stand_total_cases": 1090,
               "total_sequences": 1711,
@@ -21147,7 +21147,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 7
+                "others": 7
               },
               "stand_total_cases": 1066,
               "total_sequences": 1839,
@@ -21177,7 +21177,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 7
+                "others": 7
               },
               "stand_total_cases": 1010,
               "total_sequences": 1416,
@@ -21207,7 +21207,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 589,
               "total_sequences": 1130,
@@ -21237,7 +21237,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 465,
               "total_sequences": 820,
@@ -21267,7 +21267,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 477,
               "total_sequences": 862,
@@ -21297,7 +21297,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 470,
               "total_sequences": 888,
@@ -21327,7 +21327,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 927,
               "total_sequences": 1314,
@@ -21357,7 +21357,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 1421,
               "total_sequences": 1761,
@@ -21387,7 +21387,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 3413,
               "total_sequences": 1965,
@@ -21417,7 +21417,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 2739,
               "total_sequences": 2280,
@@ -21447,7 +21447,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1517,
               "total_sequences": 1806,
@@ -21477,7 +21477,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1064,
               "total_sequences": 1499,
@@ -21507,7 +21507,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1999,
               "total_sequences": 2151,
@@ -21537,7 +21537,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 3887,
               "total_sequences": 2090,
@@ -21567,7 +21567,7 @@
                 "21K (Omicron)": 18,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5927,
               "total_sequences": 2244,
@@ -21597,7 +21597,7 @@
                 "21K (Omicron)": 2762,
                 "21L (Omicron)": 4,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 10421,
               "total_sequences": 2445,
@@ -21627,7 +21627,7 @@
                 "21K (Omicron)": 5159,
                 "21L (Omicron)": 17,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 10329,
               "total_sequences": 1780,
@@ -21657,7 +21657,7 @@
                 "21K (Omicron)": 9773,
                 "21L (Omicron)": 999,
                 "S:677H.Robin1": 0,
-                "Unknown": 10
+                "others": 10
               },
               "stand_total_cases": 12812,
               "total_sequences": 2487,
@@ -21687,7 +21687,7 @@
                 "21K (Omicron)": 26982,
                 "21L (Omicron)": 4686,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 32608,
               "total_sequences": 2498,
@@ -21717,7 +21717,7 @@
                 "21K (Omicron)": 32223,
                 "21L (Omicron)": 17069,
                 "S:677H.Robin1": 0,
-                "Unknown": 65
+                "others": 65
               },
               "stand_total_cases": 49575,
               "total_sequences": 2277,
@@ -21747,7 +21747,7 @@
                 "21K (Omicron)": 17852,
                 "21L (Omicron)": 26472,
                 "S:677H.Robin1": 0,
-                "Unknown": 36
+                "others": 36
               },
               "stand_total_cases": 44432,
               "total_sequences": 2469,
@@ -21777,7 +21777,7 @@
                 "21K (Omicron)": 6142,
                 "21L (Omicron)": 25232,
                 "S:677H.Robin1": 0,
-                "Unknown": 69
+                "others": 69
               },
               "stand_total_cases": 31457,
               "total_sequences": 2269,
@@ -21807,7 +21807,7 @@
                 "21K (Omicron)": 935,
                 "21L (Omicron)": 12061,
                 "S:677H.Robin1": 0,
-                "Unknown": 17
+                "others": 17
               },
               "stand_total_cases": 13013,
               "total_sequences": 1476,
@@ -21837,7 +21837,7 @@
                 "21K (Omicron)": 236,
                 "21L (Omicron)": 5074,
                 "S:677H.Robin1": 0,
-                "Unknown": 39
+                "others": 39
               },
               "stand_total_cases": 5349,
               "total_sequences": 136,
@@ -21870,7 +21870,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 107
+                "others": 107
               },
               "stand_total_cases": 107,
               "total_sequences": 1,
@@ -21898,7 +21898,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 29
+                "others": 29
               },
               "stand_total_cases": 29,
               "total_sequences": 1,
@@ -21926,7 +21926,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 131
+                "others": 131
               },
               "stand_total_cases": 131,
               "total_sequences": 18,
@@ -21954,7 +21954,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 319
+                "others": 319
               },
               "stand_total_cases": 319,
               "total_sequences": 6,
@@ -21982,7 +21982,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1000
+                "others": 1000
               },
               "stand_total_cases": 1000,
               "total_sequences": 16,
@@ -22010,7 +22010,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2195
+                "others": 2195
               },
               "stand_total_cases": 2195,
               "total_sequences": 5,
@@ -22038,7 +22038,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2423
+                "others": 2423
               },
               "stand_total_cases": 2423,
               "total_sequences": 42,
@@ -22066,7 +22066,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2189
+                "others": 2189
               },
               "stand_total_cases": 2189,
               "total_sequences": 7,
@@ -22094,7 +22094,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2294
+                "others": 2294
               },
               "stand_total_cases": 2294,
               "total_sequences": 1,
@@ -22122,7 +22122,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 4465
+                "others": 4465
               },
               "stand_total_cases": 4465,
               "total_sequences": 3,
@@ -22150,7 +22150,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 8175
+                "others": 8175
               },
               "stand_total_cases": 8175,
               "total_sequences": 1,
@@ -22178,7 +22178,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2010
+                "others": 2010
               },
               "stand_total_cases": 2010,
               "total_sequences": 1,
@@ -22206,7 +22206,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1437
+                "others": 1437
               },
               "stand_total_cases": 1677,
               "total_sequences": 7,
@@ -22234,7 +22234,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2457
+                "others": 2457
               },
               "stand_total_cases": 3213,
               "total_sequences": 51,
@@ -22262,7 +22262,7 @@
                 "21J (Delta)": 20,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 7336
+                "others": 7336
               },
               "stand_total_cases": 12545,
               "total_sequences": 1840,
@@ -22290,7 +22290,7 @@
                 "21J (Delta)": 48,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 4398
+                "others": 4398
               },
               "stand_total_cases": 11417,
               "total_sequences": 955,
@@ -22318,7 +22318,7 @@
                 "21J (Delta)": 24,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2276
+                "others": 2276
               },
               "stand_total_cases": 10192,
               "total_sequences": 2099,
@@ -22346,7 +22346,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 396
+                "others": 396
               },
               "stand_total_cases": 6236,
               "total_sequences": 708,
@@ -22374,7 +22374,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 249
+                "others": 249
               },
               "stand_total_cases": 5546,
               "total_sequences": 1741,
@@ -22402,7 +22402,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 20
+                "others": 20
               },
               "stand_total_cases": 2819,
               "total_sequences": 846,
@@ -22430,7 +22430,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 696,
               "total_sequences": 763,
@@ -22458,7 +22458,7 @@
                 "21J (Delta)": 14,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 307,
               "total_sequences": 402,
@@ -22486,7 +22486,7 @@
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 162,
               "total_sequences": 309,
@@ -22514,7 +22514,7 @@
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 60,
               "total_sequences": 160,
@@ -22542,7 +22542,7 @@
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 36,
               "total_sequences": 129,
@@ -22570,7 +22570,7 @@
                 "21J (Delta)": 13,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 22,
               "total_sequences": 75,
@@ -22598,7 +22598,7 @@
                 "21J (Delta)": 125,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 131,
               "total_sequences": 751,
@@ -22626,7 +22626,7 @@
                 "21J (Delta)": 512,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 6
+                "others": 6
               },
               "stand_total_cases": 564,
               "total_sequences": 1309,
@@ -22654,7 +22654,7 @@
                 "21J (Delta)": 1343,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 10
+                "others": 10
               },
               "stand_total_cases": 1562,
               "total_sequences": 364,
@@ -22682,7 +22682,7 @@
                 "21J (Delta)": 3775,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 4286,
               "total_sequences": 1182,
@@ -22710,7 +22710,7 @@
                 "21J (Delta)": 8848,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 10
+                "others": 10
               },
               "stand_total_cases": 9691,
               "total_sequences": 1081,
@@ -22738,7 +22738,7 @@
                 "21J (Delta)": 13038,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 13676,
               "total_sequences": 1630,
@@ -22766,7 +22766,7 @@
                 "21J (Delta)": 11748,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 11896,
               "total_sequences": 1852,
@@ -22794,7 +22794,7 @@
                 "21J (Delta)": 6622,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 6673,
               "total_sequences": 526,
@@ -22822,7 +22822,7 @@
                 "21J (Delta)": 2717,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 2818,
               "total_sequences": 1093,
@@ -22850,7 +22850,7 @@
                 "21J (Delta)": 1156,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1199,
               "total_sequences": 818,
@@ -22878,7 +22878,7 @@
                 "21J (Delta)": 1021,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1047,
               "total_sequences": 1148,
@@ -22906,7 +22906,7 @@
                 "21J (Delta)": 649,
                 "21K (Omicron)": 2,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 663,
               "total_sequences": 1850,
@@ -22934,7 +22934,7 @@
                 "21J (Delta)": 803,
                 "21K (Omicron)": 44,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 861,
               "total_sequences": 1869,
@@ -22962,7 +22962,7 @@
                 "21J (Delta)": 751,
                 "21K (Omicron)": 821,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 1586,
               "total_sequences": 1898,
@@ -22990,7 +22990,7 @@
                 "21J (Delta)": 1374,
                 "21K (Omicron)": 13372,
                 "21L (Omicron)": 108,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 14866,
               "total_sequences": 2348,
@@ -23018,7 +23018,7 @@
                 "21J (Delta)": 666,
                 "21K (Omicron)": 70912,
                 "21L (Omicron)": 4755,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 76364,
               "total_sequences": 2409,
@@ -23046,7 +23046,7 @@
                 "21J (Delta)": 182,
                 "21K (Omicron)": 94872,
                 "21L (Omicron)": 10849,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 105903,
               "total_sequences": 3485,
@@ -23074,7 +23074,7 @@
                 "21J (Delta)": 11,
                 "21K (Omicron)": 28874,
                 "21L (Omicron)": 9423,
-                "Unknown": 31
+                "others": 31
               },
               "stand_total_cases": 38350,
               "total_sequences": 3614,
@@ -23102,7 +23102,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 6796,
                 "21L (Omicron)": 6130,
-                "Unknown": 16
+                "others": 16
               },
               "stand_total_cases": 12942,
               "total_sequences": 3961,
@@ -23130,7 +23130,7 @@
                 "21J (Delta)": 8,
                 "21K (Omicron)": 1830,
                 "21L (Omicron)": 8840,
-                "Unknown": 47
+                "others": 47
               },
               "stand_total_cases": 10725,
               "total_sequences": 4279,
@@ -23158,7 +23158,7 @@
                 "21J (Delta)": 14,
                 "21K (Omicron)": 970,
                 "21L (Omicron)": 17638,
-                "Unknown": 55
+                "others": 55
               },
               "stand_total_cases": 18677,
               "total_sequences": 4007,
@@ -23189,7 +23189,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 54
+                "others": 54
               },
               "stand_total_cases": 54,
               "total_sequences": 13,
@@ -23215,7 +23215,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 33
+                "others": 33
               },
               "stand_total_cases": 33,
               "total_sequences": 2,
@@ -23241,7 +23241,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 65
+                "others": 65
               },
               "stand_total_cases": 65,
               "total_sequences": 9,
@@ -23267,7 +23267,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 113
+                "others": 113
               },
               "stand_total_cases": 113,
               "total_sequences": 16,
@@ -23293,7 +23293,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 134
+                "others": 134
               },
               "stand_total_cases": 170,
               "total_sequences": 14,
@@ -23319,7 +23319,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 102
+                "others": 102
               },
               "stand_total_cases": 171,
               "total_sequences": 30,
@@ -23345,7 +23345,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 292
+                "others": 292
               },
               "stand_total_cases": 390,
               "total_sequences": 4,
@@ -23371,7 +23371,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 482
+                "others": 482
               },
               "stand_total_cases": 643,
               "total_sequences": 4,
@@ -23397,7 +23397,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 757
+                "others": 757
               },
               "stand_total_cases": 1513,
               "total_sequences": 2,
@@ -23423,7 +23423,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5373,
               "total_sequences": 3,
@@ -23449,7 +23449,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2447
+                "others": 2447
               },
               "stand_total_cases": 8317,
               "total_sequences": 17,
@@ -23475,7 +23475,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 4621
+                "others": 4621
               },
               "stand_total_cases": 10287,
               "total_sequences": 187,
@@ -23501,7 +23501,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 5195
+                "others": 5195
               },
               "stand_total_cases": 14213,
               "total_sequences": 197,
@@ -23527,7 +23527,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3595
+                "others": 3595
               },
               "stand_total_cases": 18152,
               "total_sequences": 202,
@@ -23553,7 +23553,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 957
+                "others": 957
               },
               "stand_total_cases": 5561,
               "total_sequences": 151,
@@ -23579,7 +23579,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 621
+                "others": 621
               },
               "stand_total_cases": 3742,
               "total_sequences": 181,
@@ -23605,7 +23605,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 375
+                "others": 375
               },
               "stand_total_cases": 2706,
               "total_sequences": 950,
@@ -23631,7 +23631,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 415
+                "others": 415
               },
               "stand_total_cases": 3034,
               "total_sequences": 1281,
@@ -23657,7 +23657,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 123
+                "others": 123
               },
               "stand_total_cases": 2526,
               "total_sequences": 1334,
@@ -23683,7 +23683,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 90
+                "others": 90
               },
               "stand_total_cases": 3939,
               "total_sequences": 1593,
@@ -23709,7 +23709,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 95
+                "others": 95
               },
               "stand_total_cases": 5213,
               "total_sequences": 1720,
@@ -23735,7 +23735,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 81
+                "others": 81
               },
               "stand_total_cases": 5966,
               "total_sequences": 1680,
@@ -23761,7 +23761,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 50
+                "others": 50
               },
               "stand_total_cases": 5894,
               "total_sequences": 1426,
@@ -23787,7 +23787,7 @@
                 "21J (Delta)": 2,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 22
+                "others": 22
               },
               "stand_total_cases": 3220,
               "total_sequences": 1477,
@@ -23813,7 +23813,7 @@
                 "21J (Delta)": 15,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 8
+                "others": 8
               },
               "stand_total_cases": 1318,
               "total_sequences": 1200,
@@ -23839,7 +23839,7 @@
                 "21J (Delta)": 31,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 345,
               "total_sequences": 307,
@@ -23865,7 +23865,7 @@
                 "21J (Delta)": 124,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 192,
               "total_sequences": 230,
@@ -23891,7 +23891,7 @@
                 "21J (Delta)": 643,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 659,
               "total_sequences": 983,
@@ -23917,7 +23917,7 @@
                 "21J (Delta)": 1884,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1909,
               "total_sequences": 1499,
@@ -23943,7 +23943,7 @@
                 "21J (Delta)": 2831,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2849,
               "total_sequences": 1459,
@@ -23969,7 +23969,7 @@
                 "21J (Delta)": 3257,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 3292,
               "total_sequences": 1310,
@@ -23995,7 +23995,7 @@
                 "21J (Delta)": 4916,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4953,
               "total_sequences": 929,
@@ -24021,7 +24021,7 @@
                 "21J (Delta)": 7919,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 7980,
               "total_sequences": 784,
@@ -24047,7 +24047,7 @@
                 "21J (Delta)": 11532,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 11608,
               "total_sequences": 917,
@@ -24073,7 +24073,7 @@
                 "21J (Delta)": 14836,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 14898,
               "total_sequences": 963,
@@ -24099,7 +24099,7 @@
                 "21J (Delta)": 12718,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 12830,
               "total_sequences": 1144,
@@ -24125,7 +24125,7 @@
                 "21J (Delta)": 9109,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 9172,
               "total_sequences": 1158,
@@ -24151,7 +24151,7 @@
                 "21J (Delta)": 8556,
                 "21K (Omicron)": 34,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 8633,
               "total_sequences": 1799,
@@ -24177,7 +24177,7 @@
                 "21J (Delta)": 6015,
                 "21K (Omicron)": 1557,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 7605,
               "total_sequences": 1617,
@@ -24203,7 +24203,7 @@
                 "21J (Delta)": 5707,
                 "21K (Omicron)": 5662,
                 "21L (Omicron)": 38,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 11422,
               "total_sequences": 1517,
@@ -24229,7 +24229,7 @@
                 "21J (Delta)": 3260,
                 "21K (Omicron)": 20767,
                 "21L (Omicron)": 604,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 24631,
               "total_sequences": 816,
@@ -24255,7 +24255,7 @@
                 "21J (Delta)": 814,
                 "21K (Omicron)": 43009,
                 "21L (Omicron)": 8615,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 52439,
               "total_sequences": 773,
@@ -24281,7 +24281,7 @@
                 "21J (Delta)": 150,
                 "21K (Omicron)": 23834,
                 "21L (Omicron)": 17815,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 41799,
               "total_sequences": 1389,
@@ -24307,7 +24307,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 8798,
                 "21L (Omicron)": 17141,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 25939,
               "total_sequences": 743,
@@ -24333,7 +24333,7 @@
                 "21J (Delta)": 150,
                 "21K (Omicron)": 2194,
                 "21L (Omicron)": 20064,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 22408,
               "total_sequences": 1195,
@@ -24359,7 +24359,7 @@
                 "21J (Delta)": 741,
                 "21K (Omicron)": 794,
                 "21L (Omicron)": 12908,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 14442,
               "total_sequences": 546,
@@ -24385,7 +24385,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 146,
                 "21L (Omicron)": 6707,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 6853,
               "total_sequences": 47,
@@ -24414,7 +24414,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 580
+                "others": 580
               },
               "stand_total_cases": 870,
               "total_sequences": 3,
@@ -24438,7 +24438,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 649
+                "others": 649
               },
               "stand_total_cases": 835,
               "total_sequences": 9,
@@ -24462,7 +24462,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 652
+                "others": 652
               },
               "stand_total_cases": 652,
               "total_sequences": 1,
@@ -24486,7 +24486,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 945
+                "others": 945
               },
               "stand_total_cases": 1039,
               "total_sequences": 11,
@@ -24510,7 +24510,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 4314
+                "others": 4314
               },
               "stand_total_cases": 8935,
               "total_sequences": 29,
@@ -24534,7 +24534,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 10929
+                "others": 10929
               },
               "stand_total_cases": 10929,
               "total_sequences": 1,
@@ -24558,7 +24558,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 3873
+                "others": 3873
               },
               "stand_total_cases": 6132,
               "total_sequences": 19,
@@ -24582,7 +24582,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 448
+                "others": 448
               },
               "stand_total_cases": 2187,
               "total_sequences": 44,
@@ -24606,7 +24606,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 220
+                "others": 220
               },
               "stand_total_cases": 1588,
               "total_sequences": 151,
@@ -24630,7 +24630,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 96
+                "others": 96
               },
               "stand_total_cases": 1113,
               "total_sequences": 384,
@@ -24654,7 +24654,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 48
+                "others": 48
               },
               "stand_total_cases": 1609,
               "total_sequences": 575,
@@ -24678,7 +24678,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 13
+                "others": 13
               },
               "stand_total_cases": 2725,
               "total_sequences": 616,
@@ -24702,7 +24702,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 37
+                "others": 37
               },
               "stand_total_cases": 5484,
               "total_sequences": 740,
@@ -24726,7 +24726,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 56
+                "others": 56
               },
               "stand_total_cases": 6802,
               "total_sequences": 363,
@@ -24750,7 +24750,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 86
+                "others": 86
               },
               "stand_total_cases": 6708,
               "total_sequences": 708,
@@ -24774,7 +24774,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 11
+                "others": 11
               },
               "stand_total_cases": 3728,
               "total_sequences": 637,
@@ -24798,7 +24798,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 19
+                "others": 19
               },
               "stand_total_cases": 1408,
               "total_sequences": 359,
@@ -24822,7 +24822,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 593,
               "total_sequences": 254,
@@ -24846,7 +24846,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 266,
               "total_sequences": 104,
@@ -24870,7 +24870,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 287,
               "total_sequences": 204,
@@ -24894,7 +24894,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 439,
               "total_sequences": 242,
@@ -24918,7 +24918,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 593,
               "total_sequences": 329,
@@ -24942,7 +24942,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1156,
               "total_sequences": 572,
@@ -24966,7 +24966,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1977,
               "total_sequences": 755,
@@ -24990,7 +24990,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 3465,
               "total_sequences": 611,
@@ -25014,7 +25014,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4095,
               "total_sequences": 593,
@@ -25038,7 +25038,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4707,
               "total_sequences": 554,
@@ -25062,7 +25062,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 10396,
               "total_sequences": 598,
@@ -25086,7 +25086,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 16758,
               "total_sequences": 658,
@@ -25110,7 +25110,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 15818,
               "total_sequences": 695,
@@ -25134,7 +25134,7 @@
                 "21K (Omicron)": 58,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 12466,
               "total_sequences": 1294,
@@ -25158,7 +25158,7 @@
                 "21K (Omicron)": 294,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 9567,
               "total_sequences": 2892,
@@ -25182,7 +25182,7 @@
                 "21K (Omicron)": 7410,
                 "21L (Omicron)": 13,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 17726,
               "total_sequences": 2818,
@@ -25206,7 +25206,7 @@
                 "21K (Omicron)": 24456,
                 "21L (Omicron)": 206,
                 "S:677H.Robin1": 9,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 27306,
               "total_sequences": 2922,
@@ -25230,7 +25230,7 @@
                 "21K (Omicron)": 24627,
                 "21L (Omicron)": 1247,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 26146,
               "total_sequences": 2117,
@@ -25254,7 +25254,7 @@
                 "21K (Omicron)": 12076,
                 "21L (Omicron)": 1979,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 14070,
               "total_sequences": 1856,
@@ -25278,7 +25278,7 @@
                 "21K (Omicron)": 3491,
                 "21L (Omicron)": 2039,
                 "S:677H.Robin1": 0,
-                "Unknown": 5
+                "others": 5
               },
               "stand_total_cases": 5540,
               "total_sequences": 1076,
@@ -25302,7 +25302,7 @@
                 "21K (Omicron)": 1748,
                 "21L (Omicron)": 3197,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4945,
               "total_sequences": 925,
@@ -25326,7 +25326,7 @@
                 "21K (Omicron)": 716,
                 "21L (Omicron)": 3869,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4585,
               "total_sequences": 692,
@@ -25359,7 +25359,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 3,
               "total_sequences": 47,
@@ -25387,7 +25387,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 5
+                "others": 5
               },
               "stand_total_cases": 5,
               "total_sequences": 64,
@@ -25415,7 +25415,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 11
+                "others": 11
               },
               "stand_total_cases": 11,
               "total_sequences": 165,
@@ -25443,7 +25443,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 12
+                "others": 12
               },
               "stand_total_cases": 12,
               "total_sequences": 108,
@@ -25471,7 +25471,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 13
+                "others": 13
               },
               "stand_total_cases": 13,
               "total_sequences": 158,
@@ -25499,7 +25499,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 12
+                "others": 12
               },
               "stand_total_cases": 12,
               "total_sequences": 110,
@@ -25527,7 +25527,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 12
+                "others": 12
               },
               "stand_total_cases": 12,
               "total_sequences": 98,
@@ -25555,7 +25555,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 21
+                "others": 21
               },
               "stand_total_cases": 21,
               "total_sequences": 123,
@@ -25583,7 +25583,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 86
+                "others": 86
               },
               "stand_total_cases": 86,
               "total_sequences": 175,
@@ -25611,7 +25611,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 45
+                "others": 45
               },
               "stand_total_cases": 45,
               "total_sequences": 61,
@@ -25639,7 +25639,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 26
+                "others": 26
               },
               "stand_total_cases": 26,
               "total_sequences": 62,
@@ -25667,7 +25667,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 17
+                "others": 17
               },
               "stand_total_cases": 20,
               "total_sequences": 57,
@@ -25695,7 +25695,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 19
+                "others": 19
               },
               "stand_total_cases": 24,
               "total_sequences": 84,
@@ -25723,7 +25723,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 29
+                "others": 29
               },
               "stand_total_cases": 31,
               "total_sequences": 77,
@@ -25751,7 +25751,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 65
+                "others": 65
               },
               "stand_total_cases": 67,
               "total_sequences": 170,
@@ -25779,7 +25779,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 130
+                "others": 130
               },
               "stand_total_cases": 139,
               "total_sequences": 158,
@@ -25807,7 +25807,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 228
+                "others": 228
               },
               "stand_total_cases": 242,
               "total_sequences": 172,
@@ -25835,7 +25835,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 324
+                "others": 324
               },
               "stand_total_cases": 361,
               "total_sequences": 247,
@@ -25863,7 +25863,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 99
+                "others": 99
               },
               "stand_total_cases": 124,
               "total_sequences": 142,
@@ -25891,7 +25891,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 83
+                "others": 83
               },
               "stand_total_cases": 110,
               "total_sequences": 191,
@@ -25919,7 +25919,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 87
+                "others": 87
               },
               "stand_total_cases": 119,
               "total_sequences": 236,
@@ -25947,7 +25947,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 88
+                "others": 88
               },
               "stand_total_cases": 107,
               "total_sequences": 254,
@@ -25975,7 +25975,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 110
+                "others": 110
               },
               "stand_total_cases": 121,
               "total_sequences": 265,
@@ -26003,7 +26003,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 94
+                "others": 94
               },
               "stand_total_cases": 130,
               "total_sequences": 316,
@@ -26031,7 +26031,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 122
+                "others": 122
               },
               "stand_total_cases": 173,
               "total_sequences": 394,
@@ -26059,7 +26059,7 @@
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 90
+                "others": 90
               },
               "stand_total_cases": 177,
               "total_sequences": 523,
@@ -26087,7 +26087,7 @@
                 "21J (Delta)": 7,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 58
+                "others": 58
               },
               "stand_total_cases": 166,
               "total_sequences": 217,
@@ -26115,7 +26115,7 @@
                 "21J (Delta)": 7,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 75
+                "others": 75
               },
               "stand_total_cases": 156,
               "total_sequences": 206,
@@ -26143,7 +26143,7 @@
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 112
+                "others": 112
               },
               "stand_total_cases": 154,
               "total_sequences": 466,
@@ -26171,7 +26171,7 @@
                 "21J (Delta)": 18,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 70
+                "others": 70
               },
               "stand_total_cases": 142,
               "total_sequences": 552,
@@ -26199,7 +26199,7 @@
                 "21J (Delta)": 39,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 95
+                "others": 95
               },
               "stand_total_cases": 264,
               "total_sequences": 675,
@@ -26227,7 +26227,7 @@
                 "21J (Delta)": 63,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 102
+                "others": 102
               },
               "stand_total_cases": 409,
               "total_sequences": 1038,
@@ -26255,7 +26255,7 @@
                 "21J (Delta)": 42,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 46
+                "others": 46
               },
               "stand_total_cases": 434,
               "total_sequences": 936,
@@ -26283,7 +26283,7 @@
                 "21J (Delta)": 76,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 11
+                "others": 11
               },
               "stand_total_cases": 493,
               "total_sequences": 896,
@@ -26311,7 +26311,7 @@
                 "21J (Delta)": 46,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 467,
               "total_sequences": 1289,
@@ -26339,7 +26339,7 @@
                 "21J (Delta)": 64,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 502,
               "total_sequences": 1201,
@@ -26367,7 +26367,7 @@
                 "21J (Delta)": 132,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 628,
               "total_sequences": 922,
@@ -26395,7 +26395,7 @@
                 "21J (Delta)": 96,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 461,
               "total_sequences": 1109,
@@ -26423,7 +26423,7 @@
                 "21J (Delta)": 116,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 447,
               "total_sequences": 1534,
@@ -26451,7 +26451,7 @@
                 "21J (Delta)": 213,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 605,
               "total_sequences": 1512,
@@ -26479,7 +26479,7 @@
                 "21J (Delta)": 389,
                 "21K (Omicron)": 1,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 910,
               "total_sequences": 1316,
@@ -26507,7 +26507,7 @@
                 "21J (Delta)": 725,
                 "21K (Omicron)": 71,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1537,
               "total_sequences": 1665,
@@ -26535,7 +26535,7 @@
                 "21J (Delta)": 833,
                 "21K (Omicron)": 101,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1726,
               "total_sequences": 1747,
@@ -26563,7 +26563,7 @@
                 "21J (Delta)": 360,
                 "21K (Omicron)": 426,
                 "21L (Omicron)": 8,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 1086,
               "total_sequences": 1823,
@@ -26591,7 +26591,7 @@
                 "21J (Delta)": 146,
                 "21K (Omicron)": 1136,
                 "21L (Omicron)": 39,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1442,
               "total_sequences": 1501,
@@ -26619,7 +26619,7 @@
                 "21J (Delta)": 127,
                 "21K (Omicron)": 5101,
                 "21L (Omicron)": 641,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5916,
               "total_sequences": 1256,
@@ -26647,7 +26647,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 15373,
                 "21L (Omicron)": 4375,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 19748,
               "total_sequences": 1607,
@@ -26675,7 +26675,7 @@
                 "21J (Delta)": 30,
                 "21K (Omicron)": 28766,
                 "21L (Omicron)": 22051,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 50848,
               "total_sequences": 1681,
@@ -26703,7 +26703,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 31055,
                 "21L (Omicron)": 64760,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 95815,
               "total_sequences": 1049,
@@ -26731,7 +26731,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 31317,
                 "21L (Omicron)": 54806,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 86123,
               "total_sequences": 11,
@@ -26765,7 +26765,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 231
+                "others": 231
               },
               "stand_total_cases": 231,
               "total_sequences": 102,
@@ -26794,7 +26794,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 112
+                "others": 112
               },
               "stand_total_cases": 112,
               "total_sequences": 51,
@@ -26823,7 +26823,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 50
+                "others": 50
               },
               "stand_total_cases": 50,
               "total_sequences": 36,
@@ -26852,7 +26852,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 17
+                "others": 17
               },
               "stand_total_cases": 17,
               "total_sequences": 4,
@@ -26881,7 +26881,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 56
+                "others": 56
               },
               "stand_total_cases": 56,
               "total_sequences": 10,
@@ -26910,7 +26910,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 67
+                "others": 67
               },
               "stand_total_cases": 67,
               "total_sequences": 14,
@@ -26939,7 +26939,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 66
+                "others": 66
               },
               "stand_total_cases": 101,
               "total_sequences": 23,
@@ -26968,7 +26968,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 175
+                "others": 175
               },
               "stand_total_cases": 209,
               "total_sequences": 96,
@@ -26997,7 +26997,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 429
+                "others": 429
               },
               "stand_total_cases": 485,
               "total_sequences": 283,
@@ -27026,7 +27026,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 385
+                "others": 385
               },
               "stand_total_cases": 455,
               "total_sequences": 98,
@@ -27055,7 +27055,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 435
+                "others": 435
               },
               "stand_total_cases": 516,
               "total_sequences": 51,
@@ -27084,7 +27084,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 646
+                "others": 646
               },
               "stand_total_cases": 742,
               "total_sequences": 54,
@@ -27113,7 +27113,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 893
+                "others": 893
               },
               "stand_total_cases": 1105,
               "total_sequences": 156,
@@ -27142,7 +27142,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 766
+                "others": 766
               },
               "stand_total_cases": 950,
               "total_sequences": 108,
@@ -27171,7 +27171,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 296
+                "others": 296
               },
               "stand_total_cases": 954,
               "total_sequences": 257,
@@ -27200,7 +27200,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 243
+                "others": 243
               },
               "stand_total_cases": 729,
               "total_sequences": 722,
@@ -27229,7 +27229,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 233
+                "others": 233
               },
               "stand_total_cases": 954,
               "total_sequences": 1165,
@@ -27258,7 +27258,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 146
+                "others": 146
               },
               "stand_total_cases": 1082,
               "total_sequences": 1507,
@@ -27287,7 +27287,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 197
+                "others": 197
               },
               "stand_total_cases": 1515,
               "total_sequences": 1528,
@@ -27316,7 +27316,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 127
+                "others": 127
               },
               "stand_total_cases": 1735,
               "total_sequences": 1529,
@@ -27345,7 +27345,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 71
+                "others": 71
               },
               "stand_total_cases": 1361,
               "total_sequences": 862,
@@ -27374,7 +27374,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 21
+                "others": 21
               },
               "stand_total_cases": 838,
               "total_sequences": 547,
@@ -27403,7 +27403,7 @@
                 "21J (Delta)": 14,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 13
+                "others": 13
               },
               "stand_total_cases": 543,
               "total_sequences": 501,
@@ -27432,7 +27432,7 @@
                 "21J (Delta)": 30,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 7
+                "others": 7
               },
               "stand_total_cases": 529,
               "total_sequences": 501,
@@ -27461,7 +27461,7 @@
                 "21J (Delta)": 76,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 5
+                "others": 5
               },
               "stand_total_cases": 407,
               "total_sequences": 467,
@@ -27490,7 +27490,7 @@
                 "21J (Delta)": 39,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 237,
               "total_sequences": 202,
@@ -27519,7 +27519,7 @@
                 "21J (Delta)": 209,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 260,
               "total_sequences": 603,
@@ -27548,7 +27548,7 @@
                 "21J (Delta)": 474,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 531,
               "total_sequences": 643,
@@ -27577,7 +27577,7 @@
                 "21J (Delta)": 840,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 898,
               "total_sequences": 1416,
@@ -27606,7 +27606,7 @@
                 "21J (Delta)": 1616,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 1725,
               "total_sequences": 1580,
@@ -27635,7 +27635,7 @@
                 "21J (Delta)": 1694,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 1741,
               "total_sequences": 956,
@@ -27664,7 +27664,7 @@
                 "21J (Delta)": 1437,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 1479,
               "total_sequences": 917,
@@ -27693,7 +27693,7 @@
                 "21J (Delta)": 1066,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 1086,
               "total_sequences": 701,
@@ -27722,7 +27722,7 @@
                 "21J (Delta)": 1185,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1226,
               "total_sequences": 950,
@@ -27751,7 +27751,7 @@
                 "21J (Delta)": 1433,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1448,
               "total_sequences": 842,
@@ -27780,7 +27780,7 @@
                 "21J (Delta)": 1392,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1401,
               "total_sequences": 633,
@@ -27809,7 +27809,7 @@
                 "21J (Delta)": 1982,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1987,
               "total_sequences": 429,
@@ -27838,7 +27838,7 @@
                 "21J (Delta)": 2749,
                 "21K (Omicron)": 5,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2784,
               "total_sequences": 562,
@@ -27867,7 +27867,7 @@
                 "21J (Delta)": 3269,
                 "21K (Omicron)": 251,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 3551,
               "total_sequences": 1047,
@@ -27896,7 +27896,7 @@
                 "21J (Delta)": 3535,
                 "21K (Omicron)": 2518,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 6071,
               "total_sequences": 1039,
@@ -27925,7 +27925,7 @@
                 "21J (Delta)": 3457,
                 "21K (Omicron)": 14303,
                 "21L (Omicron)": 43,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 17803,
               "total_sequences": 824,
@@ -27954,7 +27954,7 @@
                 "21J (Delta)": 613,
                 "21K (Omicron)": 18765,
                 "21L (Omicron)": 454,
-                "Unknown": 204
+                "others": 204
               },
               "stand_total_cases": 20036,
               "total_sequences": 883,
@@ -27983,7 +27983,7 @@
                 "21J (Delta)": 121,
                 "21K (Omicron)": 10962,
                 "21L (Omicron)": 702,
-                "Unknown": 48
+                "others": 48
               },
               "stand_total_cases": 11833,
               "total_sequences": 489,
@@ -28012,7 +28012,7 @@
                 "21J (Delta)": 26,
                 "21K (Omicron)": 12366,
                 "21L (Omicron)": 2648,
-                "Unknown": 1208
+                "others": 1208
               },
               "stand_total_cases": 16248,
               "total_sequences": 632,
@@ -28041,7 +28041,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 7663,
                 "21L (Omicron)": 4145,
-                "Unknown": 218
+                "others": 218
               },
               "stand_total_cases": 12026,
               "total_sequences": 441,
@@ -28070,7 +28070,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 9948,
                 "21L (Omicron)": 10529,
-                "Unknown": 166
+                "others": 166
               },
               "stand_total_cases": 20643,
               "total_sequences": 249,
@@ -28102,7 +28102,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 256
+                "others": 256
               },
               "stand_total_cases": 256,
               "total_sequences": 6,
@@ -28129,7 +28129,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 166
+                "others": 166
               },
               "stand_total_cases": 166,
               "total_sequences": 12,
@@ -28156,7 +28156,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 127
+                "others": 127
               },
               "stand_total_cases": 127,
               "total_sequences": 4,
@@ -28183,7 +28183,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 633
+                "others": 633
               },
               "stand_total_cases": 633,
               "total_sequences": 20,
@@ -28210,7 +28210,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1706
+                "others": 1706
               },
               "stand_total_cases": 1706,
               "total_sequences": 24,
@@ -28237,7 +28237,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1969
+                "others": 1969
               },
               "stand_total_cases": 1969,
               "total_sequences": 20,
@@ -28264,7 +28264,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 893
+                "others": 893
               },
               "stand_total_cases": 949,
               "total_sequences": 17,
@@ -28291,7 +28291,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 811
+                "others": 811
               },
               "stand_total_cases": 811,
               "total_sequences": 4,
@@ -28318,7 +28318,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 481
+                "others": 481
               },
               "stand_total_cases": 841,
               "total_sequences": 7,
@@ -28345,7 +28345,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 751
+                "others": 751
               },
               "stand_total_cases": 1691,
               "total_sequences": 18,
@@ -28372,7 +28372,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 620
+                "others": 620
               },
               "stand_total_cases": 2345,
               "total_sequences": 34,
@@ -28399,7 +28399,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 738
+                "others": 738
               },
               "stand_total_cases": 4929,
               "total_sequences": 394,
@@ -28426,7 +28426,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2003
+                "others": 2003
               },
               "stand_total_cases": 14106,
               "total_sequences": 535,
@@ -28453,7 +28453,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1528
+                "others": 1528
               },
               "stand_total_cases": 12532,
               "total_sequences": 443,
@@ -28480,7 +28480,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1399
+                "others": 1399
               },
               "stand_total_cases": 11428,
               "total_sequences": 768,
@@ -28507,7 +28507,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1231
+                "others": 1231
               },
               "stand_total_cases": 10571,
               "total_sequences": 670,
@@ -28534,7 +28534,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 903
+                "others": 903
               },
               "stand_total_cases": 6326,
               "total_sequences": 378,
@@ -28561,7 +28561,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 388
+                "others": 388
               },
               "stand_total_cases": 2668,
               "total_sequences": 254,
@@ -28588,7 +28588,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 348
+                "others": 348
               },
               "stand_total_cases": 3267,
               "total_sequences": 579,
@@ -28615,7 +28615,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 343
+                "others": 343
               },
               "stand_total_cases": 3575,
               "total_sequences": 353,
@@ -28642,7 +28642,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 607
+                "others": 607
               },
               "stand_total_cases": 3960,
               "total_sequences": 744,
@@ -28669,7 +28669,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 331
+                "others": 331
               },
               "stand_total_cases": 4188,
               "total_sequences": 673,
@@ -28696,7 +28696,7 @@
                 "21J (Delta)": 42,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 126
+                "others": 126
               },
               "stand_total_cases": 4962,
               "total_sequences": 940,
@@ -28723,7 +28723,7 @@
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 44
+                "others": 44
               },
               "stand_total_cases": 4160,
               "total_sequences": 1037,
@@ -28750,7 +28750,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 68
+                "others": 68
               },
               "stand_total_cases": 3873,
               "total_sequences": 1063,
@@ -28777,7 +28777,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 125
+                "others": 125
               },
               "stand_total_cases": 2704,
               "total_sequences": 731,
@@ -28804,7 +28804,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 100
+                "others": 100
               },
               "stand_total_cases": 1430,
               "total_sequences": 388,
@@ -28831,7 +28831,7 @@
                 "21J (Delta)": 84,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 18
+                "others": 18
               },
               "stand_total_cases": 907,
               "total_sequences": 238,
@@ -28858,7 +28858,7 @@
                 "21J (Delta)": 124,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 305,
               "total_sequences": 130,
@@ -28885,7 +28885,7 @@
                 "21J (Delta)": 614,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 2221,
               "total_sequences": 937,
@@ -28912,7 +28912,7 @@
                 "21J (Delta)": 1152,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 2208,
               "total_sequences": 696,
@@ -28939,7 +28939,7 @@
                 "21J (Delta)": 995,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 1338,
               "total_sequences": 460,
@@ -28966,7 +28966,7 @@
                 "21J (Delta)": 1027,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1138,
               "total_sequences": 410,
@@ -28993,7 +28993,7 @@
                 "21J (Delta)": 1617,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1759,
               "total_sequences": 545,
@@ -29020,7 +29020,7 @@
                 "21J (Delta)": 1576,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1712,
               "total_sequences": 591,
@@ -29047,7 +29047,7 @@
                 "21J (Delta)": 1750,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1791,
               "total_sequences": 701,
@@ -29074,7 +29074,7 @@
                 "21J (Delta)": 2183,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2195,
               "total_sequences": 742,
@@ -29101,7 +29101,7 @@
                 "21J (Delta)": 3072,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 3092,
               "total_sequences": 787,
@@ -29128,7 +29128,7 @@
                 "21J (Delta)": 3940,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4040,
               "total_sequences": 767,
@@ -29155,7 +29155,7 @@
                 "21J (Delta)": 6027,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 6080,
               "total_sequences": 1039,
@@ -29182,7 +29182,7 @@
                 "21J (Delta)": 8286,
                 "21K (Omicron)": 29,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 8381,
               "total_sequences": 1144,
@@ -29209,7 +29209,7 @@
                 "21J (Delta)": 6761,
                 "21K (Omicron)": 1871,
                 "21L (Omicron)": 7,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 8749,
               "total_sequences": 1342,
@@ -29236,7 +29236,7 @@
                 "21J (Delta)": 3377,
                 "21K (Omicron)": 17411,
                 "21L (Omicron)": 18,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 20824,
               "total_sequences": 1147,
@@ -29263,7 +29263,7 @@
                 "21J (Delta)": 844,
                 "21K (Omicron)": 38543,
                 "21L (Omicron)": 572,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 39959,
               "total_sequences": 1467,
@@ -29290,7 +29290,7 @@
                 "21J (Delta)": 181,
                 "21K (Omicron)": 41718,
                 "21L (Omicron)": 2819,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 44718,
               "total_sequences": 1729,
@@ -29320,7 +29320,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1780
+                "others": 1780
               },
               "stand_total_cases": 1780,
               "total_sequences": 110,
@@ -29345,7 +29345,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1518
+                "others": 1518
               },
               "stand_total_cases": 1518,
               "total_sequences": 70,
@@ -29370,7 +29370,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1154
+                "others": 1154
               },
               "stand_total_cases": 1154,
               "total_sequences": 59,
@@ -29395,7 +29395,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 767
+                "others": 767
               },
               "stand_total_cases": 767,
               "total_sequences": 48,
@@ -29420,7 +29420,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 496
+                "others": 496
               },
               "stand_total_cases": 496,
               "total_sequences": 70,
@@ -29445,7 +29445,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 570
+                "others": 570
               },
               "stand_total_cases": 570,
               "total_sequences": 73,
@@ -29470,7 +29470,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 900
+                "others": 900
               },
               "stand_total_cases": 900,
               "total_sequences": 21,
@@ -29495,7 +29495,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 535
+                "others": 535
               },
               "stand_total_cases": 535,
               "total_sequences": 18,
@@ -29520,7 +29520,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 187
+                "others": 187
               },
               "stand_total_cases": 187,
               "total_sequences": 28,
@@ -29545,7 +29545,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 116
+                "others": 116
               },
               "stand_total_cases": 116,
               "total_sequences": 24,
@@ -29570,7 +29570,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 53
+                "others": 53
               },
               "stand_total_cases": 53,
               "total_sequences": 11,
@@ -29595,7 +29595,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 30
+                "others": 30
               },
               "stand_total_cases": 32,
               "total_sequences": 27,
@@ -29620,7 +29620,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 16
+                "others": 16
               },
               "stand_total_cases": 17,
               "total_sequences": 23,
@@ -29645,7 +29645,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 11
+                "others": 11
               },
               "stand_total_cases": 15,
               "total_sequences": 23,
@@ -29670,7 +29670,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 18
+                "others": 18
               },
               "stand_total_cases": 19,
               "total_sequences": 26,
@@ -29695,7 +29695,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 18
+                "others": 18
               },
               "stand_total_cases": 18,
               "total_sequences": 24,
@@ -29720,7 +29720,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 26
+                "others": 26
               },
               "stand_total_cases": 29,
               "total_sequences": 35,
@@ -29745,7 +29745,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 77
+                "others": 77
               },
               "stand_total_cases": 88,
               "total_sequences": 98,
@@ -29770,7 +29770,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 48
+                "others": 48
               },
               "stand_total_cases": 73,
               "total_sequences": 64,
@@ -29795,7 +29795,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 46
+                "others": 46
               },
               "stand_total_cases": 71,
               "total_sequences": 72,
@@ -29820,7 +29820,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 23
+                "others": 23
               },
               "stand_total_cases": 31,
               "total_sequences": 42,
@@ -29845,7 +29845,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 16
+                "others": 16
               },
               "stand_total_cases": 30,
               "total_sequences": 30,
@@ -29870,7 +29870,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 10
+                "others": 10
               },
               "stand_total_cases": 29,
               "total_sequences": 45,
@@ -29895,7 +29895,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 8
+                "others": 8
               },
               "stand_total_cases": 51,
               "total_sequences": 159,
@@ -29920,7 +29920,7 @@
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 12
+                "others": 12
               },
               "stand_total_cases": 64,
               "total_sequences": 178,
@@ -29945,7 +29945,7 @@
                 "21J (Delta)": 15,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 70,
               "total_sequences": 190,
@@ -29970,7 +29970,7 @@
                 "21J (Delta)": 41,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 67,
               "total_sequences": 216,
@@ -29995,7 +29995,7 @@
                 "21J (Delta)": 47,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 5
+                "others": 5
               },
               "stand_total_cases": 81,
               "total_sequences": 327,
@@ -30020,7 +30020,7 @@
                 "21J (Delta)": 38,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 45,
               "total_sequences": 178,
@@ -30045,7 +30045,7 @@
                 "21J (Delta)": 46,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 49,
               "total_sequences": 215,
@@ -30070,7 +30070,7 @@
                 "21J (Delta)": 15,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 27,
               "total_sequences": 75,
@@ -30095,7 +30095,7 @@
                 "21J (Delta)": 267,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 272,
               "total_sequences": 836,
@@ -30120,7 +30120,7 @@
                 "21J (Delta)": 288,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 290,
               "total_sequences": 861,
@@ -30145,7 +30145,7 @@
                 "21J (Delta)": 118,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 130,
               "total_sequences": 640,
@@ -30170,7 +30170,7 @@
                 "21J (Delta)": 392,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 400,
               "total_sequences": 1008,
@@ -30195,7 +30195,7 @@
                 "21J (Delta)": 1669,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1676,
               "total_sequences": 700,
@@ -30220,7 +30220,7 @@
                 "21J (Delta)": 4758,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4774,
               "total_sequences": 610,
@@ -30245,7 +30245,7 @@
                 "21J (Delta)": 8129,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 8129,
               "total_sequences": 571,
@@ -30270,7 +30270,7 @@
                 "21J (Delta)": 9187,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 9204,
               "total_sequences": 537,
@@ -30295,7 +30295,7 @@
                 "21J (Delta)": 7119,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 7119,
               "total_sequences": 540,
@@ -30320,7 +30320,7 @@
                 "21J (Delta)": 4587,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4617,
               "total_sequences": 463,
@@ -30345,7 +30345,7 @@
                 "21J (Delta)": 1842,
                 "21K (Omicron)": 137,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2013,
               "total_sequences": 411,
@@ -30370,7 +30370,7 @@
                 "21J (Delta)": 367,
                 "21K (Omicron)": 427,
                 "21L (Omicron)": 4,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 807,
               "total_sequences": 682,
@@ -30395,7 +30395,7 @@
                 "21J (Delta)": 305,
                 "21K (Omicron)": 962,
                 "21L (Omicron)": 170,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1445,
               "total_sequences": 568,
@@ -30420,7 +30420,7 @@
                 "21J (Delta)": 287,
                 "21K (Omicron)": 2745,
                 "21L (Omicron)": 2125,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5157,
               "total_sequences": 682,
@@ -30445,7 +30445,7 @@
                 "21J (Delta)": 36,
                 "21K (Omicron)": 6125,
                 "21L (Omicron)": 7829,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 13990,
               "total_sequences": 386,
@@ -30470,7 +30470,7 @@
                 "21J (Delta)": 80,
                 "21K (Omicron)": 17337,
                 "21L (Omicron)": 17894,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 35310,
               "total_sequences": 444,
@@ -30495,7 +30495,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 12065,
                 "21L (Omicron)": 33809,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 45874,
               "total_sequences": 635,
@@ -30520,7 +30520,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 2784,
                 "21L (Omicron)": 30624,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 33408,
               "total_sequences": 456,
@@ -30545,7 +30545,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 872,
                 "21L (Omicron)": 16466,
-                "Unknown": 31
+                "others": 31
               },
               "stand_total_cases": 17369,
               "total_sequences": 558,
@@ -30570,7 +30570,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 221,
                 "21L (Omicron)": 9049,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 9270,
               "total_sequences": 336,
@@ -30599,7 +30599,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 68
+                "others": 68
               },
               "stand_total_cases": 68,
               "total_sequences": 19,
@@ -30623,7 +30623,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 21
+                "others": 21
               },
               "stand_total_cases": 21,
               "total_sequences": 3,
@@ -30647,7 +30647,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 12
+                "others": 12
               },
               "stand_total_cases": 12,
               "total_sequences": 5,
@@ -30671,7 +30671,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 6
+                "others": 6
               },
               "stand_total_cases": 6,
               "total_sequences": 3,
@@ -30695,7 +30695,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 36
+                "others": 36
               },
               "stand_total_cases": 36,
               "total_sequences": 29,
@@ -30719,7 +30719,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 27
+                "others": 27
               },
               "stand_total_cases": 27,
               "total_sequences": 11,
@@ -30743,7 +30743,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 42
+                "others": 42
               },
               "stand_total_cases": 42,
               "total_sequences": 18,
@@ -30767,7 +30767,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 16
+                "others": 16
               },
               "stand_total_cases": 38,
               "total_sequences": 21,
@@ -30791,7 +30791,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 33
+                "others": 33
               },
               "stand_total_cases": 43,
               "total_sequences": 23,
@@ -30815,7 +30815,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 87
+                "others": 87
               },
               "stand_total_cases": 108,
               "total_sequences": 46,
@@ -30839,7 +30839,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 427
+                "others": 427
               },
               "stand_total_cases": 532,
               "total_sequences": 296,
@@ -30863,7 +30863,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 806
+                "others": 806
               },
               "stand_total_cases": 1075,
               "total_sequences": 12,
@@ -30887,7 +30887,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1830
+                "others": 1830
               },
               "stand_total_cases": 1830,
               "total_sequences": 1,
@@ -30911,7 +30911,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2691
+                "others": 2691
               },
               "stand_total_cases": 2691,
               "total_sequences": 1,
@@ -30935,7 +30935,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5156,
               "total_sequences": 7,
@@ -30959,7 +30959,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 4989
+                "others": 4989
               },
               "stand_total_cases": 9977,
               "total_sequences": 4,
@@ -30983,7 +30983,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1967
+                "others": 1967
               },
               "stand_total_cases": 6127,
               "total_sequences": 81,
@@ -31007,7 +31007,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2308
+                "others": 2308
               },
               "stand_total_cases": 5780,
               "total_sequences": 248,
@@ -31031,7 +31031,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1584
+                "others": 1584
               },
               "stand_total_cases": 5205,
               "total_sequences": 427,
@@ -31055,7 +31055,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1203
+                "others": 1203
               },
               "stand_total_cases": 4720,
               "total_sequences": 467,
@@ -31079,7 +31079,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 726
+                "others": 726
               },
               "stand_total_cases": 3791,
               "total_sequences": 1214,
@@ -31103,7 +31103,7 @@
                 "21J (Delta)": 33,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 361
+                "others": 361
               },
               "stand_total_cases": 3586,
               "total_sequences": 966,
@@ -31127,7 +31127,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 210
+                "others": 210
               },
               "stand_total_cases": 3872,
               "total_sequences": 739,
@@ -31151,7 +31151,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 205
+                "others": 205
               },
               "stand_total_cases": 4507,
               "total_sequences": 789,
@@ -31175,7 +31175,7 @@
                 "21J (Delta)": 42,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 135
+                "others": 135
               },
               "stand_total_cases": 4407,
               "total_sequences": 525,
@@ -31199,7 +31199,7 @@
                 "21J (Delta)": 89,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 69
+                "others": 69
               },
               "stand_total_cases": 2742,
               "total_sequences": 555,
@@ -31223,7 +31223,7 @@
                 "21J (Delta)": 230,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 51
+                "others": 51
               },
               "stand_total_cases": 1570,
               "total_sequences": 307,
@@ -31247,7 +31247,7 @@
                 "21J (Delta)": 250,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 5
+                "others": 5
               },
               "stand_total_cases": 632,
               "total_sequences": 129,
@@ -31271,7 +31271,7 @@
                 "21J (Delta)": 273,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 11
+                "others": 11
               },
               "stand_total_cases": 369,
               "total_sequences": 250,
@@ -31295,7 +31295,7 @@
                 "21J (Delta)": 271,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 311,
               "total_sequences": 139,
@@ -31319,7 +31319,7 @@
                 "21J (Delta)": 486,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 503,
               "total_sequences": 146,
@@ -31343,7 +31343,7 @@
                 "21J (Delta)": 760,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 869,
               "total_sequences": 143,
@@ -31367,7 +31367,7 @@
                 "21J (Delta)": 1680,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 1860,
               "total_sequences": 413,
@@ -31391,7 +31391,7 @@
                 "21J (Delta)": 2982,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 3236,
               "total_sequences": 102,
@@ -31415,7 +31415,7 @@
                 "21J (Delta)": 5638,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5935,
               "total_sequences": 240,
@@ -31439,7 +31439,7 @@
                 "21J (Delta)": 12404,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 12840,
               "total_sequences": 383,
@@ -31463,7 +31463,7 @@
                 "21J (Delta)": 17314,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 17957,
               "total_sequences": 614,
@@ -31487,7 +31487,7 @@
                 "21J (Delta)": 11118,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 11356,
               "total_sequences": 620,
@@ -31511,7 +31511,7 @@
                 "21J (Delta)": 6391,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 6466,
               "total_sequences": 429,
@@ -31535,7 +31535,7 @@
                 "21J (Delta)": 4950,
                 "21K (Omicron)": 21,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5105,
               "total_sequences": 724,
@@ -31559,7 +31559,7 @@
                 "21J (Delta)": 4416,
                 "21K (Omicron)": 560,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 5081,
               "total_sequences": 481,
@@ -31583,7 +31583,7 @@
                 "21J (Delta)": 5086,
                 "21K (Omicron)": 3675,
                 "21L (Omicron)": 17,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 8795,
               "total_sequences": 517,
@@ -31607,7 +31607,7 @@
                 "21J (Delta)": 4660,
                 "21K (Omicron)": 20884,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 25544,
               "total_sequences": 148,
@@ -31633,7 +31633,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 136
+                "others": 136
               },
               "stand_total_cases": 228,
               "total_sequences": 5,
@@ -31654,7 +31654,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 344
+                "others": 344
               },
               "stand_total_cases": 395,
               "total_sequences": 117,
@@ -31675,7 +31675,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 464
+                "others": 464
               },
               "stand_total_cases": 501,
               "total_sequences": 53,
@@ -31696,7 +31696,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 325
+                "others": 325
               },
               "stand_total_cases": 412,
               "total_sequences": 19,
@@ -31717,7 +31717,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 794
+                "others": 794
               },
               "stand_total_cases": 1293,
               "total_sequences": 44,
@@ -31738,7 +31738,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 799
+                "others": 799
               },
               "stand_total_cases": 2715,
               "total_sequences": 17,
@@ -31759,7 +31759,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5143,
               "total_sequences": 2,
@@ -31780,7 +31780,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2211
+                "others": 2211
               },
               "stand_total_cases": 8845,
               "total_sequences": 48,
@@ -31801,7 +31801,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2173
+                "others": 2173
               },
               "stand_total_cases": 5433,
               "total_sequences": 10,
@@ -31822,7 +31822,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1505
+                "others": 1505
               },
               "stand_total_cases": 5442,
               "total_sequences": 47,
@@ -31843,7 +31843,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2550
+                "others": 2550
               },
               "stand_total_cases": 7310,
               "total_sequences": 559,
@@ -31864,7 +31864,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2285
+                "others": 2285
               },
               "stand_total_cases": 13120,
               "total_sequences": 155,
@@ -31885,7 +31885,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1905
+                "others": 1905
               },
               "stand_total_cases": 15392,
               "total_sequences": 978,
@@ -31906,7 +31906,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 645
+                "others": 645
               },
               "stand_total_cases": 10563,
               "total_sequences": 1079,
@@ -31927,7 +31927,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 16
+                "others": 16
               },
               "stand_total_cases": 6153,
               "total_sequences": 366,
@@ -31948,7 +31948,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 34
+                "others": 34
               },
               "stand_total_cases": 3871,
               "total_sequences": 349,
@@ -31969,7 +31969,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 51
+                "others": 51
               },
               "stand_total_cases": 3296,
               "total_sequences": 326,
@@ -31990,7 +31990,7 @@
                 "21J (Delta)": 11,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 772,
               "total_sequences": 137,
@@ -32011,7 +32011,7 @@
                 "21J (Delta)": 15,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 345,
               "total_sequences": 45,
@@ -32032,7 +32032,7 @@
                 "21J (Delta)": 357,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 391,
               "total_sequences": 138,
@@ -32053,7 +32053,7 @@
                 "21J (Delta)": 700,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 732,
               "total_sequences": 251,
@@ -32074,7 +32074,7 @@
                 "21J (Delta)": 1887,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 1975,
               "total_sequences": 359,
@@ -32095,7 +32095,7 @@
                 "21J (Delta)": 2557,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2815,
               "total_sequences": 371,
@@ -32116,7 +32116,7 @@
                 "21J (Delta)": 3493,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 3758,
               "total_sequences": 369,
@@ -32137,7 +32137,7 @@
                 "21J (Delta)": 4178,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4518,
               "total_sequences": 345,
@@ -32158,7 +32158,7 @@
                 "21J (Delta)": 5842,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 6475,
               "total_sequences": 348,
@@ -32179,7 +32179,7 @@
                 "21J (Delta)": 9608,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 10683,
               "total_sequences": 318,
@@ -32200,7 +32200,7 @@
                 "21J (Delta)": 15366,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 16190,
               "total_sequences": 334,
@@ -32221,7 +32221,7 @@
                 "21J (Delta)": 12885,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 13678,
               "total_sequences": 276,
@@ -32242,7 +32242,7 @@
                 "21J (Delta)": 6852,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 7133,
               "total_sequences": 330,
@@ -32263,7 +32263,7 @@
                 "21J (Delta)": 4961,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5078,
               "total_sequences": 347,
@@ -32284,7 +32284,7 @@
                 "21J (Delta)": 6093,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 6252,
               "total_sequences": 275,
@@ -32305,7 +32305,7 @@
                 "21J (Delta)": 11794,
                 "21K (Omicron)": 122,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 12037,
               "total_sequences": 99,
@@ -32326,7 +32326,7 @@
                 "21J (Delta)": 24957,
                 "21K (Omicron)": 4404,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 29361,
               "total_sequences": 20,
@@ -32347,7 +32347,7 @@
                 "21J (Delta)": 2252,
                 "21K (Omicron)": 41282,
                 "21L (Omicron)": 24018,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 67552,
               "total_sequences": 90,
@@ -32368,7 +32368,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 22802,
                 "21L (Omicron)": 36662,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 59464,
               "total_sequences": 266,
@@ -32389,7 +32389,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 10414,
                 "21L (Omicron)": 31814,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 42228,
               "total_sequences": 369,
@@ -32410,7 +32410,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 1599,
                 "21L (Omicron)": 18476,
-                "Unknown": 56
+                "others": 56
               },
               "stand_total_cases": 20131,
               "total_sequences": 365,
@@ -32431,7 +32431,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 425,
                 "21L (Omicron)": 11890,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 12315,
               "total_sequences": 58,
@@ -32461,7 +32461,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 5
+                "others": 5
               },
               "stand_total_cases": 5,
               "total_sequences": 8,
@@ -32486,7 +32486,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 1,
               "total_sequences": 1,
@@ -32511,7 +32511,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 1,
               "total_sequences": 5,
@@ -32536,7 +32536,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 4,
               "total_sequences": 3,
@@ -32561,7 +32561,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 3,
               "total_sequences": 3,
@@ -32586,7 +32586,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 2,
               "total_sequences": 2,
@@ -32611,7 +32611,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 12
+                "others": 12
               },
               "stand_total_cases": 12,
               "total_sequences": 37,
@@ -32636,7 +32636,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 20
+                "others": 20
               },
               "stand_total_cases": 20,
               "total_sequences": 74,
@@ -32661,7 +32661,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 11
+                "others": 11
               },
               "stand_total_cases": 11,
               "total_sequences": 33,
@@ -32686,7 +32686,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 6
+                "others": 6
               },
               "stand_total_cases": 6,
               "total_sequences": 16,
@@ -32711,7 +32711,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 7,
               "total_sequences": 14,
@@ -32736,7 +32736,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 10
+                "others": 10
               },
               "stand_total_cases": 13,
               "total_sequences": 36,
@@ -32761,7 +32761,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 6
+                "others": 6
               },
               "stand_total_cases": 8,
               "total_sequences": 32,
@@ -32786,7 +32786,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 5
+                "others": 5
               },
               "stand_total_cases": 8,
               "total_sequences": 20,
@@ -32811,7 +32811,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 8
+                "others": 8
               },
               "stand_total_cases": 9,
               "total_sequences": 28,
@@ -32836,7 +32836,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 8,
               "total_sequences": 20,
@@ -32861,7 +32861,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 10
+                "others": 10
               },
               "stand_total_cases": 19,
               "total_sequences": 39,
@@ -32886,7 +32886,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 12,
               "total_sequences": 22,
@@ -32911,7 +32911,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 6,
               "total_sequences": 17,
@@ -32936,7 +32936,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 7,
               "total_sequences": 19,
@@ -32961,7 +32961,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 9,
               "total_sequences": 26,
@@ -32986,7 +32986,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 11,
               "total_sequences": 28,
@@ -33011,7 +33011,7 @@
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 8,
               "total_sequences": 29,
@@ -33036,7 +33036,7 @@
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 17,
               "total_sequences": 26,
@@ -33061,7 +33061,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 5,
               "total_sequences": 19,
@@ -33086,7 +33086,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 5,
               "total_sequences": 7,
@@ -33111,7 +33111,7 @@
                 "21J (Delta)": 2,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 4,
               "total_sequences": 8,
@@ -33136,7 +33136,7 @@
                 "21J (Delta)": 3,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 7,
               "total_sequences": 14,
@@ -33161,7 +33161,7 @@
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 5,
               "total_sequences": 13,
@@ -33186,7 +33186,7 @@
                 "21J (Delta)": 2,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 5,
               "total_sequences": 12,
@@ -33211,7 +33211,7 @@
                 "21J (Delta)": 12,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 18,
               "total_sequences": 49,
@@ -33236,7 +33236,7 @@
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5,
               "total_sequences": 31,
@@ -33261,7 +33261,7 @@
                 "21J (Delta)": 30,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 31,
               "total_sequences": 173,
@@ -33286,7 +33286,7 @@
                 "21J (Delta)": 143,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 143,
               "total_sequences": 613,
@@ -33311,7 +33311,7 @@
                 "21J (Delta)": 56,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 56,
               "total_sequences": 238,
@@ -33336,7 +33336,7 @@
                 "21J (Delta)": 57,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 58,
               "total_sequences": 276,
@@ -33361,7 +33361,7 @@
                 "21J (Delta)": 131,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 131,
               "total_sequences": 583,
@@ -33386,7 +33386,7 @@
                 "21J (Delta)": 300,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 300,
               "total_sequences": 605,
@@ -33411,7 +33411,7 @@
                 "21J (Delta)": 442,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 443,
               "total_sequences": 567,
@@ -33436,7 +33436,7 @@
                 "21J (Delta)": 502,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 502,
               "total_sequences": 462,
@@ -33461,7 +33461,7 @@
                 "21J (Delta)": 297,
                 "21K (Omicron)": 3,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 300,
               "total_sequences": 353,
@@ -33486,7 +33486,7 @@
                 "21J (Delta)": 154,
                 "21K (Omicron)": 24,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 178,
               "total_sequences": 440,
@@ -33511,7 +33511,7 @@
                 "21J (Delta)": 93,
                 "21K (Omicron)": 63,
                 "21L (Omicron)": 5,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 162,
               "total_sequences": 516,
@@ -33536,7 +33536,7 @@
                 "21J (Delta)": 51,
                 "21K (Omicron)": 94,
                 "21L (Omicron)": 29,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 174,
               "total_sequences": 534,
@@ -33561,7 +33561,7 @@
                 "21J (Delta)": 38,
                 "21K (Omicron)": 291,
                 "21L (Omicron)": 130,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 460,
               "total_sequences": 674,
@@ -33586,7 +33586,7 @@
                 "21J (Delta)": 36,
                 "21K (Omicron)": 2094,
                 "21L (Omicron)": 859,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 2990,
               "total_sequences": 821,
@@ -33611,7 +33611,7 @@
                 "21J (Delta)": 67,
                 "21K (Omicron)": 15117,
                 "21L (Omicron)": 25128,
-                "Unknown": 68
+                "others": 68
               },
               "stand_total_cases": 40380,
               "total_sequences": 601,
@@ -33636,7 +33636,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 11530,
                 "21L (Omicron)": 38683,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 50213,
               "total_sequences": 675,
@@ -33661,7 +33661,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 5211,
                 "21L (Omicron)": 34811,
-                "Unknown": 111
+                "others": 111
               },
               "stand_total_cases": 40133,
               "total_sequences": 362,
@@ -33689,7 +33689,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 180
+                "others": 180
               },
               "stand_total_cases": 184,
               "total_sequences": 50,
@@ -33712,7 +33712,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 250
+                "others": 250
               },
               "stand_total_cases": 282,
               "total_sequences": 79,
@@ -33735,7 +33735,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 209
+                "others": 209
               },
               "stand_total_cases": 254,
               "total_sequences": 74,
@@ -33758,7 +33758,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 98
+                "others": 98
               },
               "stand_total_cases": 162,
               "total_sequences": 41,
@@ -33781,7 +33781,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 178
+                "others": 178
               },
               "stand_total_cases": 1241,
               "total_sequences": 453,
@@ -33804,7 +33804,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 97
+                "others": 97
               },
               "stand_total_cases": 2448,
               "total_sequences": 837,
@@ -33827,7 +33827,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 156
+                "others": 156
               },
               "stand_total_cases": 2500,
               "total_sequences": 775,
@@ -33850,7 +33850,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 143
+                "others": 143
               },
               "stand_total_cases": 1708,
               "total_sequences": 520,
@@ -33873,7 +33873,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 260
+                "others": 260
               },
               "stand_total_cases": 539,
               "total_sequences": 158,
@@ -33896,7 +33896,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 69
+                "others": 69
               },
               "stand_total_cases": 555,
               "total_sequences": 176,
@@ -33919,7 +33919,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 77
+                "others": 77
               },
               "stand_total_cases": 433,
               "total_sequences": 146,
@@ -33942,7 +33942,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 173
+                "others": 173
               },
               "stand_total_cases": 672,
               "total_sequences": 237,
@@ -33965,7 +33965,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 87
+                "others": 87
               },
               "stand_total_cases": 246,
               "total_sequences": 75,
@@ -33988,7 +33988,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 33
+                "others": 33
               },
               "stand_total_cases": 108,
               "total_sequences": 26,
@@ -34011,7 +34011,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 11
+                "others": 11
               },
               "stand_total_cases": 67,
               "total_sequences": 18,
@@ -34034,7 +34034,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 37,
               "total_sequences": 12,
@@ -34057,7 +34057,7 @@
                 "21D (Eta)": 2,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 103,
               "total_sequences": 51,
@@ -34080,7 +34080,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 347,
               "total_sequences": 101,
@@ -34103,7 +34103,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 165,
               "total_sequences": 83,
@@ -34126,7 +34126,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 504,
               "total_sequences": 147,
@@ -34149,7 +34149,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
-                "Unknown": 6
+                "others": 6
               },
               "stand_total_cases": 176,
               "total_sequences": 59,
@@ -34172,7 +34172,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 0,
                 "21J (Delta)": 5,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 105,
               "total_sequences": 39,
@@ -34195,7 +34195,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 4,
                 "21J (Delta)": 11,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 108,
               "total_sequences": 29,
@@ -34218,7 +34218,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 8,
                 "21J (Delta)": 14,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 56,
               "total_sequences": 33,
@@ -34241,7 +34241,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 8,
                 "21J (Delta)": 54,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 103,
               "total_sequences": 38,
@@ -34264,7 +34264,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 603,
                 "21J (Delta)": 885,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 1513,
               "total_sequences": 612,
@@ -34287,7 +34287,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 2433,
                 "21J (Delta)": 1713,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4230,
               "total_sequences": 1415,
@@ -34310,7 +34310,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 1907,
                 "21J (Delta)": 1619,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 3584,
               "total_sequences": 1242,
@@ -34333,7 +34333,7 @@
                 "21D (Eta)": 0,
                 "21I (Delta)": 921,
                 "21J (Delta)": 1552,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2486,
               "total_sequences": 394,
@@ -34363,7 +34363,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 9142
+                "others": 9142
               },
               "stand_total_cases": 9142,
               "total_sequences": 4,
@@ -34388,7 +34388,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 8349
+                "others": 8349
               },
               "stand_total_cases": 8349,
               "total_sequences": 1,
@@ -34413,7 +34413,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 4886
+                "others": 4886
               },
               "stand_total_cases": 6352,
               "total_sequences": 26,
@@ -34438,7 +34438,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 4065
+                "others": 4065
               },
               "stand_total_cases": 4664,
               "total_sequences": 109,
@@ -34463,7 +34463,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 56,
-                "Unknown": 2424
+                "others": 2424
               },
               "stand_total_cases": 4207,
               "total_sequences": 151,
@@ -34488,7 +34488,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 467
+                "others": 467
               },
               "stand_total_cases": 4067,
               "total_sequences": 122,
@@ -34513,7 +34513,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 311
+                "others": 311
               },
               "stand_total_cases": 6166,
               "total_sequences": 99,
@@ -34538,7 +34538,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 89
+                "others": 89
               },
               "stand_total_cases": 8088,
               "total_sequences": 91,
@@ -34563,7 +34563,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 274
+                "others": 274
               },
               "stand_total_cases": 6399,
               "total_sequences": 141,
@@ -34588,7 +34588,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 44
+                "others": 44
               },
               "stand_total_cases": 3041,
               "total_sequences": 135,
@@ -34613,7 +34613,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 38
+                "others": 38
               },
               "stand_total_cases": 1903,
               "total_sequences": 100,
@@ -34638,7 +34638,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1156,
               "total_sequences": 104,
@@ -34663,7 +34663,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 951,
               "total_sequences": 86,
@@ -34688,7 +34688,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 475,
               "total_sequences": 24,
@@ -34713,7 +34713,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 354,
               "total_sequences": 29,
@@ -34738,7 +34738,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1987,
               "total_sequences": 97,
@@ -34763,7 +34763,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 10009,
               "total_sequences": 340,
@@ -34788,7 +34788,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 14440,
               "total_sequences": 524,
@@ -34813,7 +34813,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 7546,
               "total_sequences": 260,
@@ -34838,7 +34838,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4076,
               "total_sequences": 139,
@@ -34863,7 +34863,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2677,
               "total_sequences": 176,
@@ -34888,7 +34888,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1716,
               "total_sequences": 37,
@@ -34913,7 +34913,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1473,
               "total_sequences": 73,
@@ -34938,7 +34938,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2248,
               "total_sequences": 43,
@@ -34963,7 +34963,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2509,
               "total_sequences": 100,
@@ -34988,7 +34988,7 @@
                 "21K (Omicron)": 2356,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 9841,
               "total_sequences": 71,
@@ -35013,7 +35013,7 @@
                 "21K (Omicron)": 87653,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 90899,
               "total_sequences": 28,
@@ -35038,7 +35038,7 @@
                 "21K (Omicron)": 2835,
                 "21L (Omicron)": 0,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2835,
               "total_sequences": 7,
@@ -35063,7 +35063,7 @@
                 "21K (Omicron)": 194,
                 "21L (Omicron)": 1746,
                 "S:677H.Robin1": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1940,
               "total_sequences": 10,
@@ -35085,7 +35085,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 2,
@@ -35102,7 +35102,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 3,
@@ -35119,7 +35119,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 2,
               "total_sequences": 14,
@@ -35136,7 +35136,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 1,
@@ -35153,7 +35153,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 1,
               "total_sequences": 5,
@@ -35170,7 +35170,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 3,
               "total_sequences": 2,
@@ -35187,7 +35187,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 3,
@@ -35204,7 +35204,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 5,
               "total_sequences": 12,
@@ -35221,7 +35221,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 26,
               "total_sequences": 14,
@@ -35238,7 +35238,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 43,
               "total_sequences": 13,
@@ -35255,7 +35255,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 37
+                "others": 37
               },
               "stand_total_cases": 55,
               "total_sequences": 3,
@@ -35272,7 +35272,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 11
+                "others": 11
               },
               "stand_total_cases": 218,
               "total_sequences": 38,
@@ -35289,7 +35289,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 479,
               "total_sequences": 56,
@@ -35306,7 +35306,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 452,
               "total_sequences": 52,
@@ -35323,7 +35323,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 24
+                "others": 24
               },
               "stand_total_cases": 426,
               "total_sequences": 69,
@@ -35340,7 +35340,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 36
+                "others": 36
               },
               "stand_total_cases": 532,
               "total_sequences": 75,
@@ -35357,7 +35357,7 @@
                 "21J (Delta)": 6,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 544,
               "total_sequences": 94,
@@ -35374,7 +35374,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 785,
               "total_sequences": 77,
@@ -35391,7 +35391,7 @@
                 "21J (Delta)": 49,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 705,
               "total_sequences": 114,
@@ -35408,7 +35408,7 @@
                 "21J (Delta)": 61,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 529,
               "total_sequences": 69,
@@ -35425,7 +35425,7 @@
                 "21J (Delta)": 34,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 433,
               "total_sequences": 103,
@@ -35442,7 +35442,7 @@
                 "21J (Delta)": 28,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 358,
               "total_sequences": 89,
@@ -35459,7 +35459,7 @@
                 "21J (Delta)": 100,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 518,
               "total_sequences": 114,
@@ -35476,7 +35476,7 @@
                 "21J (Delta)": 51,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 540,
               "total_sequences": 84,
@@ -35493,7 +35493,7 @@
                 "21J (Delta)": 29,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 201,
               "total_sequences": 123,
@@ -35510,7 +35510,7 @@
                 "21J (Delta)": 31,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 109,
               "total_sequences": 128,
@@ -35527,7 +35527,7 @@
                 "21J (Delta)": 15,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 59,
               "total_sequences": 142,
@@ -35544,7 +35544,7 @@
                 "21J (Delta)": 12,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 32,
               "total_sequences": 148,
@@ -35561,7 +35561,7 @@
                 "21J (Delta)": 7,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 15,
               "total_sequences": 124,
@@ -35578,7 +35578,7 @@
                 "21J (Delta)": 2,
                 "21K (Omicron)": 1,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5,
               "total_sequences": 93,
@@ -35595,7 +35595,7 @@
                 "21J (Delta)": 3,
                 "21K (Omicron)": 6,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 10,
               "total_sequences": 107,
@@ -35612,7 +35612,7 @@
                 "21J (Delta)": 5,
                 "21K (Omicron)": 14,
                 "21L (Omicron)": 3,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 23,
               "total_sequences": 119,
@@ -35629,7 +35629,7 @@
                 "21J (Delta)": 2,
                 "21K (Omicron)": 14,
                 "21L (Omicron)": 28,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 44,
               "total_sequences": 176,
@@ -35646,7 +35646,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 31,
                 "21L (Omicron)": 247,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 278,
               "total_sequences": 168,
@@ -35663,7 +35663,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 22,
                 "21L (Omicron)": 326,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 348,
               "total_sequences": 189,
@@ -35680,7 +35680,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 3,
                 "21L (Omicron)": 149,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 152,
               "total_sequences": 103,
@@ -35697,7 +35697,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 44,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 44,
               "total_sequences": 54,
@@ -35714,7 +35714,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 18,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 18,
               "total_sequences": 20,
@@ -35741,7 +35741,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 1,
               "total_sequences": 3,
@@ -35763,7 +35763,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 2,
               "total_sequences": 3,
@@ -35785,7 +35785,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 5
+                "others": 5
               },
               "stand_total_cases": 5,
               "total_sequences": 8,
@@ -35807,7 +35807,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 3,
               "total_sequences": 5,
@@ -35829,7 +35829,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 18
+                "others": 18
               },
               "stand_total_cases": 18,
               "total_sequences": 31,
@@ -35851,7 +35851,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 81
+                "others": 81
               },
               "stand_total_cases": 81,
               "total_sequences": 231,
@@ -35873,7 +35873,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 215
+                "others": 215
               },
               "stand_total_cases": 215,
               "total_sequences": 239,
@@ -35895,7 +35895,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 127
+                "others": 127
               },
               "stand_total_cases": 128,
               "total_sequences": 105,
@@ -35917,7 +35917,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 41
+                "others": 41
               },
               "stand_total_cases": 42,
               "total_sequences": 55,
@@ -35939,7 +35939,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 19
+                "others": 19
               },
               "stand_total_cases": 20,
               "total_sequences": 26,
@@ -35961,7 +35961,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 13
+                "others": 13
               },
               "stand_total_cases": 14,
               "total_sequences": 40,
@@ -35983,7 +35983,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 15
+                "others": 15
               },
               "stand_total_cases": 15,
               "total_sequences": 64,
@@ -36005,7 +36005,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 8
+                "others": 8
               },
               "stand_total_cases": 14,
               "total_sequences": 13,
@@ -36027,7 +36027,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 9
+                "others": 9
               },
               "stand_total_cases": 10,
               "total_sequences": 25,
@@ -36049,7 +36049,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 31
+                "others": 31
               },
               "stand_total_cases": 33,
               "total_sequences": 112,
@@ -36071,7 +36071,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 164
+                "others": 164
               },
               "stand_total_cases": 168,
               "total_sequences": 229,
@@ -36093,7 +36093,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 158
+                "others": 158
               },
               "stand_total_cases": 166,
               "total_sequences": 134,
@@ -36115,7 +36115,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 134
+                "others": 134
               },
               "stand_total_cases": 144,
               "total_sequences": 201,
@@ -36137,7 +36137,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 109
+                "others": 109
               },
               "stand_total_cases": 111,
               "total_sequences": 67,
@@ -36159,7 +36159,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 72
+                "others": 72
               },
               "stand_total_cases": 72,
               "total_sequences": 45,
@@ -36181,7 +36181,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 22
+                "others": 22
               },
               "stand_total_cases": 30,
               "total_sequences": 12,
@@ -36203,7 +36203,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 22
+                "others": 22
               },
               "stand_total_cases": 29,
               "total_sequences": 28,
@@ -36225,7 +36225,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 32
+                "others": 32
               },
               "stand_total_cases": 38,
               "total_sequences": 137,
@@ -36247,7 +36247,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 6
+                "others": 6
               },
               "stand_total_cases": 17,
               "total_sequences": 40,
@@ -36269,7 +36269,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 7
+                "others": 7
               },
               "stand_total_cases": 23,
               "total_sequences": 74,
@@ -36291,7 +36291,7 @@
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 13,
               "total_sequences": 41,
@@ -36313,7 +36313,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 5,
               "total_sequences": 19,
@@ -36335,7 +36335,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 1,
               "total_sequences": 8,
@@ -36357,7 +36357,7 @@
                 "21J (Delta)": 2,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 5,
               "total_sequences": 32,
@@ -36379,7 +36379,7 @@
                 "21J (Delta)": 5,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5,
               "total_sequences": 51,
@@ -36401,7 +36401,7 @@
                 "21J (Delta)": 3,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4,
               "total_sequences": 33,
@@ -36423,7 +36423,7 @@
                 "21J (Delta)": 2,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 3,
               "total_sequences": 15,
@@ -36445,7 +36445,7 @@
                 "21J (Delta)": 3,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 4,
               "total_sequences": 26,
@@ -36467,7 +36467,7 @@
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5,
               "total_sequences": 27,
@@ -36489,7 +36489,7 @@
                 "21J (Delta)": 3,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 8,
               "total_sequences": 48,
@@ -36511,7 +36511,7 @@
                 "21J (Delta)": 3,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5,
               "total_sequences": 31,
@@ -36533,7 +36533,7 @@
                 "21J (Delta)": 6,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 8,
               "total_sequences": 24,
@@ -36555,7 +36555,7 @@
                 "21J (Delta)": 11,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 12,
               "total_sequences": 30,
@@ -36577,7 +36577,7 @@
                 "21J (Delta)": 5,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 6,
               "total_sequences": 25,
@@ -36599,7 +36599,7 @@
                 "21J (Delta)": 3,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 4,
               "total_sequences": 51,
@@ -36621,7 +36621,7 @@
                 "21J (Delta)": 5,
                 "21K (Omicron)": 1,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 6,
               "total_sequences": 77,
@@ -36643,7 +36643,7 @@
                 "21J (Delta)": 6,
                 "21K (Omicron)": 1,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 8,
               "total_sequences": 99,
@@ -36665,7 +36665,7 @@
                 "21J (Delta)": 2,
                 "21K (Omicron)": 11,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 13,
               "total_sequences": 163,
@@ -36687,7 +36687,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 31,
                 "21L (Omicron)": 14,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 45,
               "total_sequences": 156,
@@ -36709,7 +36709,7 @@
                 "21J (Delta)": 5,
                 "21K (Omicron)": 14,
                 "21L (Omicron)": 28,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 46,
               "total_sequences": 224,
@@ -36731,7 +36731,7 @@
                 "21J (Delta)": 31,
                 "21K (Omicron)": 10,
                 "21L (Omicron)": 238,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 280,
               "total_sequences": 161,
@@ -36753,7 +36753,7 @@
                 "21J (Delta)": 90,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 4864,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4954,
               "total_sequences": 219,
@@ -36775,7 +36775,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 81025,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 81025,
               "total_sequences": 150,
@@ -36797,7 +36797,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 50695,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 50695,
               "total_sequences": 52,
@@ -36819,7 +36819,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 16382,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 16382,
               "total_sequences": 291,
@@ -36841,7 +36841,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 109,
                 "21L (Omicron)": 3386,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 3495,
               "total_sequences": 32,
@@ -36861,7 +36861,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 4,
@@ -36876,7 +36876,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 10
+                "others": 10
               },
               "stand_total_cases": 10,
               "total_sequences": 29,
@@ -36891,7 +36891,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 25
+                "others": 25
               },
               "stand_total_cases": 25,
               "total_sequences": 45,
@@ -36906,7 +36906,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 14
+                "others": 14
               },
               "stand_total_cases": 14,
               "total_sequences": 4,
@@ -36921,7 +36921,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 5
+                "others": 5
               },
               "stand_total_cases": 5,
               "total_sequences": 2,
@@ -36936,7 +36936,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 2,
               "total_sequences": 2,
@@ -36951,7 +36951,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 2,
               "total_sequences": 6,
@@ -36966,7 +36966,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 7
+                "others": 7
               },
               "stand_total_cases": 7,
               "total_sequences": 22,
@@ -36981,7 +36981,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 9
+                "others": 9
               },
               "stand_total_cases": 9,
               "total_sequences": 7,
@@ -36996,7 +36996,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 5
+                "others": 5
               },
               "stand_total_cases": 5,
               "total_sequences": 13,
@@ -37011,7 +37011,7 @@
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 2,
               "total_sequences": 3,
@@ -37026,7 +37026,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 6
+                "others": 6
               },
               "stand_total_cases": 6,
               "total_sequences": 10,
@@ -37041,7 +37041,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 8
+                "others": 8
               },
               "stand_total_cases": 8,
               "total_sequences": 47,
@@ -37056,7 +37056,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 67
+                "others": 67
               },
               "stand_total_cases": 67,
               "total_sequences": 174,
@@ -37071,7 +37071,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 164
+                "others": 164
               },
               "stand_total_cases": 164,
               "total_sequences": 316,
@@ -37086,7 +37086,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 432
+                "others": 432
               },
               "stand_total_cases": 433,
               "total_sequences": 486,
@@ -37101,7 +37101,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 296
+                "others": 296
               },
               "stand_total_cases": 296,
               "total_sequences": 89,
@@ -37116,7 +37116,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 160
+                "others": 160
               },
               "stand_total_cases": 160,
               "total_sequences": 100,
@@ -37131,7 +37131,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 274
+                "others": 274
               },
               "stand_total_cases": 274,
               "total_sequences": 136,
@@ -37146,7 +37146,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 234
+                "others": 234
               },
               "stand_total_cases": 234,
               "total_sequences": 14,
@@ -37161,7 +37161,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 91
+                "others": 91
               },
               "stand_total_cases": 91,
               "total_sequences": 13,
@@ -37176,7 +37176,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 45
+                "others": 45
               },
               "stand_total_cases": 45,
               "total_sequences": 2,
@@ -37191,7 +37191,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3
+                "others": 3
               },
               "stand_total_cases": 26,
               "total_sequences": 8,
@@ -37206,7 +37206,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 19
+                "others": 19
               },
               "stand_total_cases": 32,
               "total_sequences": 14,
@@ -37221,7 +37221,7 @@
                 "21J (Delta)": 12,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 15,
               "total_sequences": 17,
@@ -37236,7 +37236,7 @@
                 "21J (Delta)": 5,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 6,
               "total_sequences": 94,
@@ -37251,7 +37251,7 @@
                 "21J (Delta)": 8,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 10,
               "total_sequences": 313,
@@ -37266,7 +37266,7 @@
                 "21J (Delta)": 28,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 67,
               "total_sequences": 187,
@@ -37281,7 +37281,7 @@
                 "21J (Delta)": 105,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 233,
               "total_sequences": 341,
@@ -37296,7 +37296,7 @@
                 "21J (Delta)": 142,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 369,
               "total_sequences": 307,
@@ -37311,7 +37311,7 @@
                 "21J (Delta)": 251,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 622,
               "total_sequences": 193,
@@ -37326,7 +37326,7 @@
                 "21J (Delta)": 206,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 355,
               "total_sequences": 62,
@@ -37341,7 +37341,7 @@
                 "21J (Delta)": 95,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 227,
               "total_sequences": 50,
@@ -37356,7 +37356,7 @@
                 "21J (Delta)": 45,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 98,
               "total_sequences": 13,
@@ -37371,7 +37371,7 @@
                 "21J (Delta)": 6,
                 "21K (Omicron)": 2,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 20,
               "total_sequences": 10,
@@ -37386,7 +37386,7 @@
                 "21J (Delta)": 4,
                 "21K (Omicron)": 4,
                 "21L (Omicron)": 17,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 27,
               "total_sequences": 21,
@@ -37401,7 +37401,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 2,
                 "21L (Omicron)": 6,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 9,
               "total_sequences": 24,
@@ -37416,7 +37416,7 @@
                 "21J (Delta)": 1,
                 "21K (Omicron)": 1,
                 "21L (Omicron)": 101,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 103,
               "total_sequences": 100,
@@ -37431,7 +37431,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 276,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 276,
               "total_sequences": 86,
@@ -37460,7 +37460,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 30
+                "others": 30
               },
               "stand_total_cases": 30,
               "total_sequences": 3,
@@ -37484,7 +37484,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1353
+                "others": 1353
               },
               "stand_total_cases": 1353,
               "total_sequences": 1,
@@ -37508,7 +37508,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1668
+                "others": 1668
               },
               "stand_total_cases": 1668,
               "total_sequences": 3,
@@ -37532,7 +37532,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1269
+                "others": 1269
               },
               "stand_total_cases": 1450,
               "total_sequences": 8,
@@ -37556,7 +37556,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 3956
+                "others": 3956
               },
               "stand_total_cases": 3956,
               "total_sequences": 4,
@@ -37580,7 +37580,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 8416
+                "others": 8416
               },
               "stand_total_cases": 8416,
               "total_sequences": 2,
@@ -37604,7 +37604,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 4921
+                "others": 4921
               },
               "stand_total_cases": 4921,
               "total_sequences": 8,
@@ -37628,7 +37628,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 2480
+                "others": 2480
               },
               "stand_total_cases": 3100,
               "total_sequences": 10,
@@ -37652,7 +37652,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 438
+                "others": 438
               },
               "stand_total_cases": 546,
               "total_sequences": 15,
@@ -37676,7 +37676,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 237
+                "others": 237
               },
               "stand_total_cases": 394,
               "total_sequences": 15,
@@ -37700,7 +37700,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 11,
-                "Unknown": 57
+                "others": 57
               },
               "stand_total_cases": 412,
               "total_sequences": 36,
@@ -37724,7 +37724,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 64
+                "others": 64
               },
               "stand_total_cases": 764,
               "total_sequences": 48,
@@ -37748,7 +37748,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 7221,
               "total_sequences": 53,
@@ -37772,7 +37772,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 23623,
               "total_sequences": 56,
@@ -37796,7 +37796,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 198
+                "others": 198
               },
               "stand_total_cases": 12087,
               "total_sequences": 61,
@@ -37820,7 +37820,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 45
+                "others": 45
               },
               "stand_total_cases": 1990,
               "total_sequences": 45,
@@ -37844,7 +37844,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 266,
               "total_sequences": 25,
@@ -37868,7 +37868,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 109,
               "total_sequences": 10,
@@ -37892,7 +37892,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 139,
               "total_sequences": 3,
@@ -37916,7 +37916,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 212,
               "total_sequences": 16,
@@ -37940,7 +37940,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 358,
               "total_sequences": 36,
@@ -37964,7 +37964,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5236,
               "total_sequences": 67,
@@ -37988,7 +37988,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5279,
               "total_sequences": 62,
@@ -38012,7 +38012,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4945,
               "total_sequences": 49,
@@ -38036,7 +38036,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 3234,
               "total_sequences": 46,
@@ -38060,7 +38060,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 3555,
               "total_sequences": 58,
@@ -38084,7 +38084,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 3355,
               "total_sequences": 56,
@@ -38108,7 +38108,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1972,
               "total_sequences": 53,
@@ -38132,7 +38132,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 910,
               "total_sequences": 47,
@@ -38156,7 +38156,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 855,
               "total_sequences": 28,
@@ -38180,7 +38180,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1043,
               "total_sequences": 20,
@@ -38204,7 +38204,7 @@
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1165,
               "total_sequences": 52,
@@ -38228,7 +38228,7 @@
                 "21K (Omicron)": 4847,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 8859,
               "total_sequences": 53,
@@ -38252,7 +38252,7 @@
                 "21K (Omicron)": 57315,
                 "21L (Omicron)": 0,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 58338,
               "total_sequences": 57,
@@ -38276,7 +38276,7 @@
                 "21K (Omicron)": 39610,
                 "21L (Omicron)": 312,
                 "S:677P.Pelican": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 44600,
               "total_sequences": 143,
@@ -38300,7 +38300,7 @@
                 "21K (Omicron)": 10324,
                 "21L (Omicron)": 191,
                 "S:677P.Pelican": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 10898,
               "total_sequences": 57,
@@ -38324,7 +38324,7 @@
                 "21K (Omicron)": 5136,
                 "21L (Omicron)": 373,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5509,
               "total_sequences": 59,
@@ -38348,7 +38348,7 @@
                 "21K (Omicron)": 1285,
                 "21L (Omicron)": 1239,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2524,
               "total_sequences": 55,
@@ -38372,7 +38372,7 @@
                 "21K (Omicron)": 728,
                 "21L (Omicron)": 3641,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4369,
               "total_sequences": 48,
@@ -38396,7 +38396,7 @@
                 "21K (Omicron)": 348,
                 "21L (Omicron)": 4615,
                 "S:677P.Pelican": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4963,
               "total_sequences": 57,
@@ -38419,7 +38419,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 2,
@@ -38437,7 +38437,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 18,
@@ -38455,7 +38455,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 50,
@@ -38473,7 +38473,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 37,
@@ -38491,7 +38491,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 34,
@@ -38509,7 +38509,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 9,
@@ -38527,7 +38527,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1436,
               "total_sequences": 8,
@@ -38545,7 +38545,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 567,
               "total_sequences": 4,
@@ -38563,7 +38563,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 264,
               "total_sequences": 1,
@@ -38581,7 +38581,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 794,
               "total_sequences": 20,
@@ -38599,7 +38599,7 @@
                 "21J (Delta)": 160,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 718,
               "total_sequences": 9,
@@ -38617,7 +38617,7 @@
                 "21J (Delta)": 333,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 1285,
               "total_sequences": 27,
@@ -38635,7 +38635,7 @@
                 "21J (Delta)": 537,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1172,
               "total_sequences": 24,
@@ -38653,7 +38653,7 @@
                 "21J (Delta)": 1014,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1890,
               "total_sequences": 41,
@@ -38671,7 +38671,7 @@
                 "21J (Delta)": 1718,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2382,
               "total_sequences": 61,
@@ -38689,7 +38689,7 @@
                 "21J (Delta)": 3557,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 5104,
               "total_sequences": 66,
@@ -38707,7 +38707,7 @@
                 "21J (Delta)": 3541,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 6390,
               "total_sequences": 83,
@@ -38725,7 +38725,7 @@
                 "21J (Delta)": 5479,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 7335,
               "total_sequences": 83,
@@ -38743,7 +38743,7 @@
                 "21J (Delta)": 3001,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 3781,
               "total_sequences": 63,
@@ -38761,7 +38761,7 @@
                 "21J (Delta)": 5213,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 7298,
               "total_sequences": 63,
@@ -38779,7 +38779,7 @@
                 "21J (Delta)": 9075,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 9869,
               "total_sequences": 87,
@@ -38797,7 +38797,7 @@
                 "21J (Delta)": 8003,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 9415,
               "total_sequences": 80,
@@ -38815,7 +38815,7 @@
                 "21J (Delta)": 3574,
                 "21K (Omicron)": 1332,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5256,
               "total_sequences": 75,
@@ -38833,7 +38833,7 @@
                 "21J (Delta)": 4727,
                 "21K (Omicron)": 37024,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 42276,
               "total_sequences": 161,
@@ -38851,7 +38851,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 76536,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 76536,
               "total_sequences": 66,
@@ -38869,7 +38869,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 29873,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 29873,
               "total_sequences": 74,
@@ -38887,7 +38887,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 11533,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 11533,
               "total_sequences": 31,
@@ -38905,7 +38905,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 3857,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 3857,
               "total_sequences": 1,
@@ -38923,7 +38923,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 4179,
                 "21L (Omicron)": 27395,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 31574,
               "total_sequences": 68,
@@ -38944,7 +38944,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 6848,
               "total_sequences": 3,
@@ -38960,7 +38960,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 8704,
               "total_sequences": 1,
@@ -38976,7 +38976,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 7319,
               "total_sequences": 2,
@@ -38992,7 +38992,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 946
+                "others": 946
               },
               "stand_total_cases": 10404,
               "total_sequences": 11,
@@ -39008,7 +39008,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 15004,
               "total_sequences": 13,
@@ -39024,7 +39024,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2823,
               "total_sequences": 1,
@@ -39040,7 +39040,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2195,
               "total_sequences": 5,
@@ -39056,7 +39056,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1699
+                "others": 1699
               },
               "stand_total_cases": 1699,
               "total_sequences": 1,
@@ -39072,7 +39072,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2407
+                "others": 2407
               },
               "stand_total_cases": 3476,
               "total_sequences": 13,
@@ -39088,7 +39088,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 2395
+                "others": 2395
               },
               "stand_total_cases": 3293,
               "total_sequences": 11,
@@ -39104,7 +39104,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1150
+                "others": 1150
               },
               "stand_total_cases": 1150,
               "total_sequences": 5,
@@ -39120,7 +39120,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 313
+                "others": 313
               },
               "stand_total_cases": 627,
               "total_sequences": 2,
@@ -39136,7 +39136,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 444,
               "total_sequences": 2,
@@ -39152,7 +39152,7 @@
                 "21J (Delta)": 182,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 182,
               "total_sequences": 2,
@@ -39168,7 +39168,7 @@
                 "21J (Delta)": 679,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 679,
               "total_sequences": 1,
@@ -39184,7 +39184,7 @@
                 "21J (Delta)": 679,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 679,
               "total_sequences": 3,
@@ -39200,7 +39200,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 731,
               "total_sequences": 1,
@@ -39216,7 +39216,7 @@
                 "21J (Delta)": 3555,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 3555,
               "total_sequences": 8,
@@ -39232,7 +39232,7 @@
                 "21J (Delta)": 2666,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2666,
               "total_sequences": 2,
@@ -39248,7 +39248,7 @@
                 "21J (Delta)": 2221,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2221,
               "total_sequences": 3,
@@ -39264,7 +39264,7 @@
                 "21J (Delta)": 810,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 810,
               "total_sequences": 4,
@@ -39280,7 +39280,7 @@
                 "21J (Delta)": 490,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 653,
               "total_sequences": 4,
@@ -39296,7 +39296,7 @@
                 "21J (Delta)": 2039,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 2039,
               "total_sequences": 7,
@@ -39312,7 +39312,7 @@
                 "21J (Delta)": 4809,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4809,
               "total_sequences": 60,
@@ -39328,7 +39328,7 @@
                 "21J (Delta)": 17279,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 17279,
               "total_sequences": 104,
@@ -39344,7 +39344,7 @@
                 "21J (Delta)": 21279,
                 "21K (Omicron)": 156,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 21435,
               "total_sequences": 137,
@@ -39360,7 +39360,7 @@
                 "21J (Delta)": 11825,
                 "21K (Omicron)": 4042,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 15867,
               "total_sequences": 106,
@@ -39376,7 +39376,7 @@
                 "21J (Delta)": 4258,
                 "21K (Omicron)": 14668,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 18926,
               "total_sequences": 40,
@@ -39392,7 +39392,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 30846,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 30846,
               "total_sequences": 3,
@@ -39408,7 +39408,7 @@
                 "21J (Delta)": 3578,
                 "21K (Omicron)": 25044,
                 "21L (Omicron)": 19320,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 47942,
               "total_sequences": 67,
@@ -39424,7 +39424,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 16747,
                 "21L (Omicron)": 24189,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 40936,
               "total_sequences": 66,
@@ -39440,7 +39440,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 28587,
                 "21L (Omicron)": 15134,
-                "Unknown": 561
+                "others": 561
               },
               "stand_total_cases": 44282,
               "total_sequences": 79,
@@ -39456,7 +39456,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 62215,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 62215,
               "total_sequences": 32,
@@ -39472,7 +39472,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 17407,
                 "21L (Omicron)": 11792,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 29199,
               "total_sequences": 52,
@@ -39495,7 +39495,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 31,
               "total_sequences": 1,
@@ -39513,7 +39513,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 15,
               "total_sequences": 1,
@@ -39531,7 +39531,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 31,
               "total_sequences": 3,
@@ -39549,7 +39549,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 7
+                "others": 7
               },
               "stand_total_cases": 7,
               "total_sequences": 1,
@@ -39567,7 +39567,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 7
+                "others": 7
               },
               "stand_total_cases": 14,
               "total_sequences": 2,
@@ -39585,7 +39585,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 7
+                "others": 7
               },
               "stand_total_cases": 11,
               "total_sequences": 8,
@@ -39603,7 +39603,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 7
+                "others": 7
               },
               "stand_total_cases": 13,
               "total_sequences": 4,
@@ -39621,7 +39621,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 21
+                "others": 21
               },
               "stand_total_cases": 21,
               "total_sequences": 1,
@@ -39639,7 +39639,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 14
+                "others": 14
               },
               "stand_total_cases": 14,
               "total_sequences": 1,
@@ -39657,7 +39657,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 28
+                "others": 28
               },
               "stand_total_cases": 28,
               "total_sequences": 4,
@@ -39675,7 +39675,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 135
+                "others": 135
               },
               "stand_total_cases": 135,
               "total_sequences": 69,
@@ -39693,7 +39693,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 235
+                "others": 235
               },
               "stand_total_cases": 235,
               "total_sequences": 10,
@@ -39711,7 +39711,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 71
+                "others": 71
               },
               "stand_total_cases": 71,
               "total_sequences": 3,
@@ -39729,7 +39729,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 29
+                "others": 29
               },
               "stand_total_cases": 29,
               "total_sequences": 8,
@@ -39747,7 +39747,7 @@
                 "21J (Delta)": 1,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 34
+                "others": 34
               },
               "stand_total_cases": 36,
               "total_sequences": 39,
@@ -39765,7 +39765,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 82
+                "others": 82
               },
               "stand_total_cases": 82,
               "total_sequences": 8,
@@ -39783,7 +39783,7 @@
                 "21J (Delta)": 38,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 210
+                "others": 210
               },
               "stand_total_cases": 248,
               "total_sequences": 13,
@@ -39801,7 +39801,7 @@
                 "21J (Delta)": 71,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 39
+                "others": 39
               },
               "stand_total_cases": 134,
               "total_sequences": 17,
@@ -39819,7 +39819,7 @@
                 "21J (Delta)": 9,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 179
+                "others": 179
               },
               "stand_total_cases": 197,
               "total_sequences": 22,
@@ -39837,7 +39837,7 @@
                 "21J (Delta)": 119,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1135
+                "others": 1135
               },
               "stand_total_cases": 1254,
               "total_sequences": 21,
@@ -39855,7 +39855,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1005
+                "others": 1005
               },
               "stand_total_cases": 1005,
               "total_sequences": 10,
@@ -39873,7 +39873,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1101
+                "others": 1101
               },
               "stand_total_cases": 2201,
               "total_sequences": 6,
@@ -39891,7 +39891,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 3315
+                "others": 3315
               },
               "stand_total_cases": 3315,
               "total_sequences": 18,
@@ -39909,7 +39909,7 @@
                 "21J (Delta)": 95,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1766
+                "others": 1766
               },
               "stand_total_cases": 1861,
               "total_sequences": 39,
@@ -39927,7 +39927,7 @@
                 "21J (Delta)": 211,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 853
+                "others": 853
               },
               "stand_total_cases": 1075,
               "total_sequences": 102,
@@ -39945,7 +39945,7 @@
                 "21J (Delta)": 309,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 371
+                "others": 371
               },
               "stand_total_cases": 701,
               "total_sequences": 34,
@@ -39963,7 +39963,7 @@
                 "21J (Delta)": 3793,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 1062
+                "others": 1062
               },
               "stand_total_cases": 4855,
               "total_sequences": 32,
@@ -39981,7 +39981,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 15082
+                "others": 15082
               },
               "stand_total_cases": 15082,
               "total_sequences": 3,
@@ -39999,7 +39999,7 @@
                 "21J (Delta)": 10241,
                 "21K (Omicron)": 186,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 10613,
               "total_sequences": 57,
@@ -40017,7 +40017,7 @@
                 "21J (Delta)": 5743,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 5743,
               "total_sequences": 3,
@@ -40035,7 +40035,7 @@
                 "21J (Delta)": 2932,
                 "21K (Omicron)": 382,
                 "21L (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 3315,
               "total_sequences": 52,
@@ -40053,7 +40053,7 @@
                 "21J (Delta)": 979,
                 "21K (Omicron)": 703,
                 "21L (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 1682,
               "total_sequences": 79,
@@ -40071,7 +40071,7 @@
                 "21J (Delta)": 225,
                 "21K (Omicron)": 577,
                 "21L (Omicron)": 68,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 870,
               "total_sequences": 89,
@@ -40089,7 +40089,7 @@
                 "21J (Delta)": 1573,
                 "21K (Omicron)": 25615,
                 "21L (Omicron)": 7640,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 34828,
               "total_sequences": 155,
@@ -40107,7 +40107,7 @@
                 "21J (Delta)": 456,
                 "21K (Omicron)": 10263,
                 "21L (Omicron)": 16421,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 27140,
               "total_sequences": 119,
@@ -40125,7 +40125,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 4057,
                 "21L (Omicron)": 12170,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 16227,
               "total_sequences": 36,
@@ -40143,7 +40143,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 2681,
                 "21L (Omicron)": 15193,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 17874,
               "total_sequences": 20,
@@ -40161,7 +40161,7 @@
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
                 "21L (Omicron)": 13966,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 13966,
               "total_sequences": 10,
@@ -40181,7 +40181,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 4,
               "total_sequences": 13,
@@ -40196,7 +40196,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 2,
               "total_sequences": 12,
@@ -40211,7 +40211,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 0,
               "total_sequences": 8,
@@ -40226,7 +40226,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 4
+                "others": 4
               },
               "stand_total_cases": 4,
               "total_sequences": 1,
@@ -40241,7 +40241,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 8
+                "others": 8
               },
               "stand_total_cases": 8,
               "total_sequences": 17,
@@ -40256,7 +40256,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 14
+                "others": 14
               },
               "stand_total_cases": 14,
               "total_sequences": 3,
@@ -40271,7 +40271,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 162
+                "others": 162
               },
               "stand_total_cases": 162,
               "total_sequences": 220,
@@ -40286,7 +40286,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 552
+                "others": 552
               },
               "stand_total_cases": 552,
               "total_sequences": 25,
@@ -40301,7 +40301,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 478
+                "others": 478
               },
               "stand_total_cases": 478,
               "total_sequences": 26,
@@ -40316,7 +40316,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 177
+                "others": 177
               },
               "stand_total_cases": 177,
               "total_sequences": 20,
@@ -40331,7 +40331,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 65
+                "others": 65
               },
               "stand_total_cases": 65,
               "total_sequences": 3,
@@ -40346,7 +40346,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 25
+                "others": 25
               },
               "stand_total_cases": 25,
               "total_sequences": 4,
@@ -40361,7 +40361,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 11
+                "others": 11
               },
               "stand_total_cases": 11,
               "total_sequences": 1,
@@ -40376,7 +40376,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 14
+                "others": 14
               },
               "stand_total_cases": 28,
               "total_sequences": 2,
@@ -40391,7 +40391,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 31
+                "others": 31
               },
               "stand_total_cases": 46,
               "total_sequences": 6,
@@ -40406,7 +40406,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 106
+                "others": 106
               },
               "stand_total_cases": 106,
               "total_sequences": 9,
@@ -40421,7 +40421,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 127
+                "others": 127
               },
               "stand_total_cases": 127,
               "total_sequences": 6,
@@ -40436,7 +40436,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 21
+                "others": 21
               },
               "stand_total_cases": 82,
               "total_sequences": 20,
@@ -40451,7 +40451,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 45
+                "others": 45
               },
               "stand_total_cases": 199,
               "total_sequences": 44,
@@ -40466,7 +40466,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 11
+                "others": 11
               },
               "stand_total_cases": 100,
               "total_sequences": 19,
@@ -40481,7 +40481,7 @@
                 "21I (Delta)": 25,
                 "21J (Delta)": 25,
                 "21K (Omicron)": 0,
-                "Unknown": 11
+                "others": 11
               },
               "stand_total_cases": 86,
               "total_sequences": 7,
@@ -40496,7 +40496,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 24
+                "others": 24
               },
               "stand_total_cases": 72,
               "total_sequences": 6,
@@ -40511,7 +40511,7 @@
                 "21I (Delta)": 8,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": -1
+                "others": -1
               },
               "stand_total_cases": 15,
               "total_sequences": 2,
@@ -40526,7 +40526,7 @@
                 "21I (Delta)": 13,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 7
+                "others": 7
               },
               "stand_total_cases": 20,
               "total_sequences": 6,
@@ -40541,7 +40541,7 @@
                 "21I (Delta)": 7,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 7,
               "total_sequences": 2,
@@ -40556,7 +40556,7 @@
                 "21I (Delta)": 24,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 24,
               "total_sequences": 4,
@@ -40571,7 +40571,7 @@
                 "21I (Delta)": 66,
                 "21J (Delta)": 14,
                 "21K (Omicron)": 0,
-                "Unknown": 2
+                "others": 2
               },
               "stand_total_cases": 85,
               "total_sequences": 49,
@@ -40586,7 +40586,7 @@
                 "21I (Delta)": 226,
                 "21J (Delta)": 196,
                 "21K (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 422,
               "total_sequences": 43,
@@ -40601,7 +40601,7 @@
                 "21I (Delta)": 137,
                 "21J (Delta)": 355,
                 "21K (Omicron)": 0,
-                "Unknown": 7
+                "others": 7
               },
               "stand_total_cases": 510,
               "total_sequences": 138,
@@ -40616,7 +40616,7 @@
                 "21I (Delta)": 56,
                 "21J (Delta)": 269,
                 "21K (Omicron)": 0,
-                "Unknown": 5
+                "others": 5
               },
               "stand_total_cases": 336,
               "total_sequences": 60,
@@ -40631,7 +40631,7 @@
                 "21I (Delta)": 7,
                 "21J (Delta)": 110,
                 "21K (Omicron)": 0,
-                "Unknown": 1
+                "others": 1
               },
               "stand_total_cases": 119,
               "total_sequences": 82,
@@ -40646,7 +40646,7 @@
                 "21I (Delta)": 4,
                 "21J (Delta)": 57,
                 "21K (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 61,
               "total_sequences": 15,
@@ -40661,7 +40661,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 18,
                 "21K (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 18,
               "total_sequences": 11,
@@ -40676,7 +40676,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 4,
                 "21K (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 4,
               "total_sequences": 2,
@@ -40691,7 +40691,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 7,
                 "21K (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 7,
               "total_sequences": 2,
@@ -40706,7 +40706,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 18,
                 "21K (Omicron)": 0,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 18,
               "total_sequences": 3,
@@ -40721,7 +40721,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 5,
                 "21K (Omicron)": 16,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 21,
               "total_sequences": 4,
@@ -40736,7 +40736,7 @@
                 "21I (Delta)": 0,
                 "21J (Delta)": 0,
                 "21K (Omicron)": 283,
-                "Unknown": 0
+                "others": 0
               },
               "stand_total_cases": 283,
               "total_sequences": 45,

--- a/web/src/components/Cases/CasesPlot.tsx
+++ b/web/src/components/Cases/CasesPlot.tsx
@@ -8,7 +8,7 @@ import ReactResizeDetector from 'react-resize-detector'
 
 import type { PerCountryCasesDistributionDatum } from 'src/io/getPerCountryCasesData'
 import { ticks, timeDomain } from 'src/io/getParams'
-import { getClusterColor } from 'src/io/getClusters'
+import { CLUSTER_NAME_OTHERS, getClusterColor } from 'src/io/getClusters'
 import { formatDateHumanely } from 'src/helpers/format'
 import { adjustTicks } from 'src/helpers/adjustTicks'
 import { PlotPlaceholder } from 'src/components/Common/PlotPlaceholder'
@@ -89,6 +89,16 @@ export function CasesPlotComponent({ cluster_names, distribution }: CasesPlotPro
                       isAnimationActive={false}
                     />
                   ))}
+
+                  <Area
+                    type="monotone"
+                    dataKey={CLUSTER_NAME_OTHERS}
+                    stackId="1"
+                    stroke="none"
+                    fill={theme.clusters.color.others}
+                    fillOpacity={1}
+                    isAnimationActive={false}
+                  />
 
                   <CartesianGrid stroke={theme.plot.cartesianGrid.stroke} />
 


### PR DESCRIPTION
Adding a new category, currently called `Unknown`, to cases data which contains all remaining case counts that are not covered by known clades.