### PR TITLE
fix: ensure url parameters correctly apply for 'Cases' page

### DIFF
--- a/web/src/components/Cases/CasesPage.tsx
+++ b/web/src/components/Cases/CasesPage.tsx
@@ -8,10 +8,10 @@ import { Layout } from 'src/components/Layout/Layout'
 import { MainFlex, SidebarFlex, WrapperFlex } from 'src/components/Common/PlotLayout'
 
 import { getPerCountryCasesData, filterClusters, filterCountries } from 'src/io/getPerCountryCasesData'
-import { clustersAtom, disableAllClusters, enableAllClusters, toggleCluster } from 'src/state/ClustersForCaseData'
+import { clustersCasesAtom, disableAllClusters, enableAllClusters, toggleCluster } from 'src/state/ClustersForCaseData'
 import {
-  continentsAtom,
-  countriesAtom,
+  continentsCasesAtom,
+  countriesCasesAtom,
   disableAllCountries,
   enableAllCountries,
   toggleContinent,
@@ -28,9 +28,9 @@ import IntroContent from '../../../../content/PerCountryCasesIntro.md'
 const enabledFilters = ['clusters', 'countriesWithIcons']
 
 export function CasesPage() {
-  const [countries, setCountries] = useRecoilState(countriesAtom)
-  const [continents, setContinents] = useRecoilState(continentsAtom)
-  const [clusters, setClusters] = useRecoilState(clustersAtom)
+  const [countries, setCountries] = useRecoilState(countriesCasesAtom)
+  const [continents, setContinents] = useRecoilState(continentsCasesAtom)
+  const [clusters, setClusters] = useRecoilState(clustersCasesAtom)
 
   const { perCountryCasesDistributions } = useMemo(() => getPerCountryCasesData(), [])
 

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -12,7 +12,9 @@ import { ReactQueryDevtools } from 'react-query/devtools'
 import type { AppProps } from 'next/app'
 import { parseUrl } from 'src/helpers/parseUrl'
 import { clustersAtom, ClustersDataFlavor, urlQueryToClusters } from 'src/state/Clusters'
+import { clustersCasesAtom, urlQueryToClustersCases } from 'src/state/ClustersForCaseData'
 import { continentsAtom, countriesAtom, regionAtom, urlQueryToPlaces } from 'src/state/Places'
+import { continentsCasesAtom, countriesCasesAtom, urlQueryToPlacesCases } from 'src/state/PlacesForCaseData'
 import { ThemeProvider } from 'styled-components'
 import { MDXProvider } from '@mdx-js/react'
 
@@ -33,25 +35,46 @@ function MyApp({ Component, pageProps, router }: AppProps) {
 
   const initializeState = useCallback(
     ({ set }: MutableSnapshot) => {
-      // Extract state of places from the URL query params
-      const { region, continents, countries } = urlQueryToPlaces(query)
-
       // Set initial state
-      if (pathname === '/per-country') {
-        set(regionAtom, region)
-        set(continentsAtom(region), continents)
-        set(countriesAtom(region), countries)
+      switch (pathname) {
+        case '/per-country': {
+          const { region, continents, countries } = urlQueryToPlaces(query)
 
-        const params = { dataFlavor: ClustersDataFlavor.PerCountry, region }
-        const clusters = urlQueryToClusters(query, params)
-        set(clustersAtom(params), clusters)
-      } else if (pathname === '/per-variant') {
-        set(continentsAtom(undefined), continents)
-        set(countriesAtom(undefined), countries)
+          set(regionAtom, region)
+          set(continentsAtom(region), continents)
+          set(countriesAtom(region), countries)
 
-        const params = { dataFlavor: ClustersDataFlavor.PerCluster, region }
-        const clusters = urlQueryToClusters(query, params)
-        set(clustersAtom(params), clusters)
+          const params = { dataFlavor: ClustersDataFlavor.PerCountry, region }
+          const clusters = urlQueryToClusters(query, params)
+          set(clustersAtom(params), clusters)
+
+          break
+        }
+        case '/per-variant': {
+          const { region, continents, countries } = urlQueryToPlaces(query)
+
+          set(continentsAtom(undefined), continents)
+          set(countriesAtom(undefined), countries)
+
+          const params = { dataFlavor: ClustersDataFlavor.PerCluster, region }
+          const clusters = urlQueryToClusters(query, params)
+          set(clustersAtom(params), clusters)
+
+          break
+        }
+        case '/cases': {
+          const { continents, countries } = urlQueryToPlacesCases(query)
+
+          set(continentsCasesAtom, continents)
+          set(countriesCasesAtom, countries)
+
+          const clusters = urlQueryToClustersCases(query)
+          set(clustersCasesAtom, clusters)
+
+          break
+        }
+        default:
+          break
       }
     },
     [pathname, query],

--- a/web/src/state/ClustersForCaseData.ts
+++ b/web/src/state/ClustersForCaseData.ts
@@ -1,21 +1,39 @@
+import { get } from 'lodash'
+import { ParsedUrlQuery } from 'querystring'
 import { atom } from 'recoil'
+import { convertToArrayMaybe, includesCaseInsensitive } from 'src/helpers/array'
 
 import { updateUrlQuery } from 'src/helpers/urlQuery'
 import { getPerCountryCasesData } from 'src/io/getPerCountryCasesData'
-
-export interface Cluster {
-  cluster: string
-  enabled: boolean
-}
+import type { Cluster } from './Clusters'
 
 function getAllClusters(): Cluster[] {
   return getPerCountryCasesData().clusters
 }
 
 /**
+ * Converts values incoming from URL query into clusters.
+ * To be used during app startup.
+ */
+export function urlQueryToClustersCases(query: ParsedUrlQuery) {
+  const enabledClusters = convertToArrayMaybe(get(query, 'variant'))
+
+  // Take all clusters and set only the clusters present in the query as `enabled`
+  let clusters = getAllClusters()
+  if (enabledClusters) {
+    clusters = clusters.map((cluster) => ({
+      ...cluster,
+      enabled: includesCaseInsensitive(enabledClusters, cluster.cluster),
+    }))
+  }
+
+  return clusters
+}
+
+/**
  * Represents a list of currently enabled clusters (variants)
  */
-export const clustersAtom = atom<Cluster[]>({
+export const clustersCasesAtom = atom<Cluster[]>({
   key: 'clusters',
   default: getAllClusters(),
   effects: [


### PR DESCRIPTION
Resolves #299 

The URL parameters were not applied on app initialization to the recoil atoms which store the state for countries, continents and clusters specific to 'Cases' page.

This PR adds the logic that applies incoming parameters to the recoil state.
