### PR TITLE
fix: avoid duplicate keys for different recoil atoms

### DIFF
--- a/web/src/state/ClustersForCaseData.ts
+++ b/web/src/state/ClustersForCaseData.ts
@@ -34,7 +34,7 @@ export function urlQueryToClustersCases(query: ParsedUrlQuery) {
  * Represents a list of currently enabled clusters (variants)
  */
 export const clustersCasesAtom = atom<Cluster[]>({
-  key: 'clusters',
+  key: 'clustersCases',
   default: getAllClusters(),
   effects: [
     ({ onSet }) => {


### PR DESCRIPTION
This fixes a copy-paste mistake, where 2 Recoil atoms ended up having the same key. I renamed the key for one of the atoms.

Duplicate keys could have caused app to misbehave or crash.
