### PR TITLE
Use intersection observer to render visible charts

### DIFF
--- a/web/config/next/next.config.ts
+++ b/web/config/next/next.config.ts
@@ -89,6 +89,10 @@ const nextConfig: NextConfig = {
   },
   env: clientEnv,
   poweredByHeader: false,
+  webpack(config) {
+    config.experiments.topLevelAwait = true
+    return config
+  },
 }
 
 const withMDX = getWithMDX({

--- a/web/package.json
+++ b/web/package.json
@@ -73,6 +73,7 @@
     "fast-copy": "2.1.3",
     "history": "5.3.0",
     "immutable": "4.0.0",
+    "intersection-observer": "0.12.2",
     "is-absolute-url": "3.0.3",
     "iso-3166-1-alpha-2": "1.0.0",
     "lodash": "4.17.21",

--- a/web/package.json
+++ b/web/package.json
@@ -93,6 +93,7 @@
     "react-gif-player": "0.4.2",
     "react-helmet": "6.1.0",
     "react-icons": "4.3.1",
+    "react-intersection-observer": "9.4.0",
     "react-loader-spinner": "5.1.4",
     "react-query": "3.38.0",
     "react-reactstrap-pagination": "2.0.3",

--- a/web/src/components/Cases/CasesPlot.tsx
+++ b/web/src/components/Cases/CasesPlot.tsx
@@ -2,9 +2,8 @@
 import React, { CSSProperties, useMemo, useRef } from 'react'
 
 import dynamic from 'next/dynamic'
-import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Label } from 'recharts'
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, Label } from 'recharts'
 import { DateTime } from 'luxon'
-import ReactResizeDetector from 'react-resize-detector'
 
 import type { PerCountryCasesDistributionDatum } from 'src/io/getPerCountryCasesData'
 import { ticks, timeDomain } from 'src/io/getParams'
@@ -12,7 +11,7 @@ import { CLUSTER_NAME_OTHERS, getClusterColor } from 'src/io/getClusters'
 import { formatDateHumanely } from 'src/helpers/format'
 import { adjustTicks } from 'src/helpers/adjustTicks'
 import { PlotPlaceholder } from 'src/components/Common/PlotPlaceholder'
-import { ChartContainerOuter, ChartContainerInner } from 'src/components/Common/PlotLayout'
+import { ChartContainer } from 'src/components/Common/ChartContainer'
 import { useTheme } from 'styled-components'
 import { CasesPlotTooltip } from './CasesPlotTooltip'
 
@@ -43,78 +42,72 @@ export function CasesPlotComponent({ cluster_names, distribution }: CasesPlotPro
   )
 
   return (
-    <ChartContainerOuter>
-      <ChartContainerInner>
-        <ReactResizeDetector handleWidth refreshRate={300} refreshMode="debounce">
-          {({ width }: { width?: number }) => {
-            const adjustedTicks = adjustTicks(ticks, width ?? 0, theme.plot.tickWidthMin).slice(1) // slice ensures first tick is not outside domain
-            return (
-              <ResponsiveContainer aspect={theme.plot.aspectRatio} debounce={0}>
-                <AreaChart margin={CHART_MARGIN} data={data} ref={chartRef}>
-                  <XAxis
-                    dataKey="week"
-                    type="number"
-                    tickFormatter={formatDateHumanely}
-                    domain={timeDomain}
-                    ticks={adjustedTicks}
-                    tick={theme.plot.tickStyle}
-                    tickMargin={theme.plot.tickMargin?.x}
-                    allowDataOverflow
-                  />
-                  <YAxis
-                    type="number"
-                    name="Cases per million"
-                    tick={theme.plot.tickStyle}
-                    tickMargin={theme.plot.tickMargin?.y}
-                    allowDataOverflow
-                  >
-                    <Label
-                      style={yAxisLabelStyle}
-                      position="insideLeft"
-                      offset={0}
-                      angle={270}
-                      value={'Cases per million people'}
-                    />
-                  </YAxis>
+    <ChartContainer>
+      {({ width, height }) => {
+        const adjustedTicks = adjustTicks(ticks, width ?? 0, theme.plot.tickWidthMin).slice(1) // slice ensures first tick is not outside domain
+        return (
+          <AreaChart width={width} height={height} margin={CHART_MARGIN} data={data} ref={chartRef}>
+            <XAxis
+              dataKey="week"
+              type="number"
+              tickFormatter={formatDateHumanely}
+              domain={timeDomain}
+              ticks={adjustedTicks}
+              tick={theme.plot.tickStyle}
+              tickMargin={theme.plot.tickMargin?.x}
+              allowDataOverflow
+            />
+            <YAxis
+              type="number"
+              name="Cases per million"
+              tick={theme.plot.tickStyle}
+              tickMargin={theme.plot.tickMargin?.y}
+              allowDataOverflow
+            >
+              <Label
+                style={yAxisLabelStyle}
+                position="insideLeft"
+                offset={0}
+                angle={270}
+                value={'Cases per million people'}
+              />
+            </YAxis>
 
-                  {cluster_names.map((cluster) => (
-                    <Area
-                      key={cluster}
-                      type="monotone"
-                      dataKey={cluster}
-                      stackId="1"
-                      stroke="none"
-                      fill={getClusterColor(cluster)}
-                      fillOpacity={1}
-                      isAnimationActive={false}
-                    />
-                  ))}
+            {cluster_names.map((cluster) => (
+              <Area
+                key={cluster}
+                type="monotone"
+                dataKey={cluster}
+                stackId="1"
+                stroke="none"
+                fill={getClusterColor(cluster)}
+                fillOpacity={1}
+                isAnimationActive={false}
+              />
+            ))}
 
-                  <Area
-                    type="monotone"
-                    dataKey={CLUSTER_NAME_OTHERS}
-                    stackId="1"
-                    stroke="none"
-                    fill={theme.clusters.color.others}
-                    fillOpacity={1}
-                    isAnimationActive={false}
-                  />
+            <Area
+              type="monotone"
+              dataKey={CLUSTER_NAME_OTHERS}
+              stackId="1"
+              stroke="none"
+              fill={theme.clusters.color.others}
+              fillOpacity={1}
+              isAnimationActive={false}
+            />
 
-                  <CartesianGrid stroke={theme.plot.cartesianGrid.stroke} />
+            <CartesianGrid stroke={theme.plot.cartesianGrid.stroke} />
 
-                  <Tooltip
-                    content={CasesPlotTooltip}
-                    isAnimationActive={false}
-                    allowEscapeViewBox={ALLOW_ESCAPE_VIEW_BOX}
-                    offset={50}
-                  />
-                </AreaChart>
-              </ResponsiveContainer>
-            )
-          }}
-        </ReactResizeDetector>
-      </ChartContainerInner>
-    </ChartContainerOuter>
+            <Tooltip
+              content={CasesPlotTooltip}
+              isAnimationActive={false}
+              allowEscapeViewBox={ALLOW_ESCAPE_VIEW_BOX}
+              offset={50}
+            />
+          </AreaChart>
+        )
+      }}
+    </ChartContainer>
   )
 }
 

--- a/web/src/components/ClusterDistribution/ClusterDistributionPlot.tsx
+++ b/web/src/components/ClusterDistribution/ClusterDistributionPlot.tsx
@@ -3,9 +3,8 @@ import React, { useMemo } from 'react'
 
 import { get } from 'lodash'
 import { DateTime } from 'luxon'
-import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+import { CartesianGrid, Line, LineChart, Tooltip, XAxis, YAxis } from 'recharts'
 import { useTheme } from 'styled-components'
-import { useResizeDetector } from 'react-resize-detector'
 
 import { ticks, timeDomain } from 'src/io/getParams'
 import { getCountryColor, getCountryStrokeDashArray } from 'src/io/getCountryColor'
@@ -13,7 +12,7 @@ import { formatDateHumanely, formatProportion } from 'src/helpers/format'
 import { adjustTicks } from 'src/helpers/adjustTicks'
 import type { ClusterDistributionDatum } from 'src/io/getPerClusterData'
 import { ClusterDistributionPlotTooltip } from 'src/components/ClusterDistribution/ClusterDistributionPlotTooltip'
-import { ChartContainerInner, ChartContainerOuter } from 'src/components/Common/PlotLayout'
+import { ChartContainer } from 'src/components/Common/ChartContainer'
 
 const getValueOrig = (country: string) => (value: ClusterDistributionDatum) => {
   const orig = get(value.orig, country, false)
@@ -36,12 +35,13 @@ const getValueInterp = (country: string) => (value: ClusterDistributionDatum) =>
 const allowEscapeViewBox = { x: false, y: true }
 
 interface LinePlotProps {
-  width?: number
+  width: number
+  height: number
   country_names: string[]
   distribution: ClusterDistributionDatum[]
 }
 
-function LinePlot({ width, country_names, distribution }: LinePlotProps) {
+function LinePlot({ width, height, country_names, distribution }: LinePlotProps) {
   const theme = useTheme()
 
   const data = useMemo(
@@ -93,38 +93,36 @@ function LinePlot({ width, country_names, distribution }: LinePlotProps) {
   }, [country_names])
 
   return (
-    <ResponsiveContainer aspect={theme.plot.aspectRatio}>
-      <LineChart margin={theme.plot.margin} data={data}>
-        <XAxis
-          dataKey="week"
-          type="number"
-          tickFormatter={formatDateHumanely}
-          domain={domainX}
-          ticks={adjustedTicks}
-          tick={theme.plot.tickStyle}
-          tickMargin={theme.plot.tickMargin?.x}
-          allowDataOverflow
-        />
-        <YAxis
-          type="number"
-          tickFormatter={formatProportion}
-          domain={domainY}
-          tick={theme.plot.tickStyle}
-          tickMargin={theme.plot.tickMargin?.y}
-          allowDataOverflow
-        />
-        <Tooltip
-          content={ClusterDistributionPlotTooltip}
-          isAnimationActive={false}
-          allowEscapeViewBox={allowEscapeViewBox}
-          offset={50}
-        />
+    <LineChart width={width} height={height} margin={theme.plot.margin} data={data}>
+      <XAxis
+        dataKey="week"
+        type="number"
+        tickFormatter={formatDateHumanely}
+        domain={domainX}
+        ticks={adjustedTicks}
+        tick={theme.plot.tickStyle}
+        tickMargin={theme.plot.tickMargin?.x}
+        allowDataOverflow
+      />
+      <YAxis
+        type="number"
+        tickFormatter={formatProportion}
+        domain={domainY}
+        tick={theme.plot.tickStyle}
+        tickMargin={theme.plot.tickMargin?.y}
+        allowDataOverflow
+      />
+      <Tooltip
+        content={ClusterDistributionPlotTooltip}
+        isAnimationActive={false}
+        allowEscapeViewBox={allowEscapeViewBox}
+        offset={50}
+      />
 
-        <CartesianGrid stroke="#2222" />
+      <CartesianGrid stroke="#2222" />
 
-        {lines}
-      </LineChart>
-    </ResponsiveContainer>
+      {lines}
+    </LineChart>
   )
 }
 
@@ -134,13 +132,11 @@ export interface ClusterDistributionPlotProps {
 }
 
 export function ClusterDistributionPlot({ country_names, distribution }: ClusterDistributionPlotProps) {
-  const { ref, width } = useResizeDetector({ handleWidth: true })
-
   return (
-    <ChartContainerOuter ref={ref}>
-      <ChartContainerInner>
-        <LinePlot width={width} country_names={country_names} distribution={distribution} />
-      </ChartContainerInner>
-    </ChartContainerOuter>
+    <ChartContainer>
+      {({ width, height }) => (
+        <LinePlot width={width} height={height} country_names={country_names} distribution={distribution} />
+      )}
+    </ChartContainer>
   )
 }

--- a/web/src/components/Common/ChartContainer.tsx
+++ b/web/src/components/Common/ChartContainer.tsx
@@ -1,43 +1,33 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { useResizeDetector } from 'react-resize-detector'
 import { Props as ResizeDetectorProps } from 'react-resize-detector/build/ResizeDetector'
 import { useInView } from 'react-intersection-observer'
 
 import { theme } from 'src/theme'
 import { ChartContainerInner, ChartContainerOuter } from './PlotLayout'
-import FadeIn from './FadeIn'
+import { FadeIn } from './FadeIn'
 
 type ChartContainerDimensions = {
   width: number
   height: number
 }
 
-type RenderChart = (dimensions: ChartContainerDimensions) => React.ReactNode
-
 export interface ChartContainerProps {
-  children: RenderChart
   resizeOptions?: ResizeDetectorProps
+  children: (dimensions: ChartContainerDimensions) => React.ReactNode
 }
 
 export function ChartContainer({ children, resizeOptions }: ChartContainerProps) {
   const { width = 0, ref: resizeRef } = useResizeDetector({ handleWidth: true, ...resizeOptions })
-  const { inView, ref: intersectionRef } = useInView({
-    fallbackInView: true,
-  })
-
-  const dimensions = React.useMemo(
-    () => ({
-      width,
-      height: width / theme.plot.aspectRatio,
-    }),
-    [width],
-  )
+  const { inView, ref: intersectionRef } = useInView({ fallbackInView: true })
+  const dimensions = useMemo(() => ({ width, height: width / theme.plot.aspectRatio }), [width])
+  const childrenWithDims = useMemo(() => children(dimensions), [children, dimensions])
 
   return (
     <ChartContainerOuter ref={resizeRef}>
       <ChartContainerInner>
         <div ref={intersectionRef} style={dimensions}>
-          {inView && <FadeIn>{children(dimensions)}</FadeIn>}
+          {inView && <FadeIn>{childrenWithDims}</FadeIn>}
         </div>
       </ChartContainerInner>
     </ChartContainerOuter>

--- a/web/src/components/Common/ChartContainer.tsx
+++ b/web/src/components/Common/ChartContainer.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { useResizeDetector } from 'react-resize-detector'
+import { Props as ResizeDetectorProps } from 'react-resize-detector/build/ResizeDetector'
+import { useInView } from 'react-intersection-observer'
+
+import { theme } from 'src/theme'
+import { ChartContainerInner, ChartContainerOuter } from './PlotLayout'
+import FadeIn from './FadeIn'
+
+type ChartContainerDimensions = {
+  width: number
+  height: number
+}
+
+type RenderChart = (dimensions: ChartContainerDimensions) => React.ReactNode
+
+export interface ChartContainerProps {
+  children: RenderChart
+  resizeOptions?: ResizeDetectorProps
+}
+
+export function ChartContainer({ children, resizeOptions }: ChartContainerProps) {
+  const { width = 0, ref: resizeRef } = useResizeDetector({ handleWidth: true, ...resizeOptions })
+  const { inView, ref: intersectionRef } = useInView({
+    fallbackInView: true,
+  })
+
+  const dimensions = React.useMemo(
+    () => ({
+      width,
+      height: width / theme.plot.aspectRatio,
+    }),
+    [width],
+  )
+
+  return (
+    <ChartContainerOuter ref={resizeRef}>
+      <ChartContainerInner>
+        <div ref={intersectionRef} style={dimensions}>
+          {inView && <FadeIn>{children(dimensions)}</FadeIn>}
+        </div>
+      </ChartContainerInner>
+    </ChartContainerOuter>
+  )
+}

--- a/web/src/components/Common/FadeIn.tsx
+++ b/web/src/components/Common/FadeIn.tsx
@@ -1,7 +1,20 @@
 // https://www.joshwcomeau.com/snippets/react-components/fade-in/
 
-import React from 'react'
+import React, { PropsWithChildren } from 'react'
 import styled, { keyframes } from 'styled-components'
+
+export interface FadeInProps {
+  duration?: number
+  delay?: number
+}
+
+export function FadeIn({ duration = 300, delay = 0, children }: PropsWithChildren<FadeInProps>) {
+  return (
+    <Wrapper $delay={delay} $duration={duration}>
+      {children}
+    </Wrapper>
+  )
+}
 
 const fadeIn = keyframes`
   from {
@@ -11,24 +24,12 @@ const fadeIn = keyframes`
     opacity: 1;
   }
 `
-function FadeIn({ duration = 300, delay = 0, children, ...delegated }) {
-  return (
-    <Wrapper
-      {...delegated}
-      style={{
-        ...delegated.style,
-        animationDuration: `${duration}ms`,
-        animationDelay: `${delay}ms`,
-      }}
-    >
-      {children}
-    </Wrapper>
-  )
-}
-const Wrapper = styled.div`
+
+const Wrapper = styled.div<{ $delay?: number; $duration?: number }>`
   @media (prefers-reduced-motion: no-preference) {
     animation-name: ${fadeIn};
     animation-fill-mode: backwards;
+    animation-delay: ${(props) => props.$delay};
+    animation-duration: ${(props) => props.$duration};
   }
 `
-export default FadeIn

--- a/web/src/components/Common/FadeIn.tsx
+++ b/web/src/components/Common/FadeIn.tsx
@@ -1,0 +1,34 @@
+// https://www.joshwcomeau.com/snippets/react-components/fade-in/
+
+import React from 'react'
+import styled, { keyframes } from 'styled-components'
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`
+function FadeIn({ duration = 300, delay = 0, children, ...delegated }) {
+  return (
+    <Wrapper
+      {...delegated}
+      style={{
+        ...delegated.style,
+        animationDuration: `${duration}ms`,
+        animationDelay: `${delay}ms`,
+      }}
+    >
+      {children}
+    </Wrapper>
+  )
+}
+const Wrapper = styled.div`
+  @media (prefers-reduced-motion: no-preference) {
+    animation-name: ${fadeIn};
+    animation-fill-mode: backwards;
+  }
+`
+export default FadeIn

--- a/web/src/components/Common/FadeIn.tsx
+++ b/web/src/components/Common/FadeIn.tsx
@@ -29,7 +29,7 @@ const Wrapper = styled.div<{ $delay?: number; $duration?: number }>`
   @media (prefers-reduced-motion: no-preference) {
     animation-name: ${fadeIn};
     animation-fill-mode: backwards;
-    animation-delay: ${(props) => props.$delay};
-    animation-duration: ${(props) => props.$duration};
+    animation-delay: ${(props) => props.$delay}ms;
+    animation-duration: ${(props) => props.$duration}ms;
   }
 `

--- a/web/src/components/CountryDistribution/CountryDistributionPlot.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlot.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import React, { useMemo } from 'react'
 
-import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts'
 import { DateTime } from 'luxon'
 import { useResizeDetector } from 'react-resize-detector'
 import { useInView } from 'react-intersection-observer'

--- a/web/src/components/CountryDistribution/CountryDistributionPlot.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlot.tsx
@@ -3,8 +3,6 @@ import React, { useMemo } from 'react'
 
 import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts'
 import { DateTime } from 'luxon'
-import { useResizeDetector } from 'react-resize-detector'
-import { useInView } from 'react-intersection-observer'
 
 import type { CountryDistributionDatum } from 'src/io/getPerCountryData'
 import { theme } from 'src/theme'
@@ -12,8 +10,7 @@ import { ticks, timeDomain } from 'src/io/getParams'
 import { CLUSTER_NAME_OTHERS, getClusterColor } from 'src/io/getClusters'
 import { formatDateHumanely, formatProportion } from 'src/helpers/format'
 import { adjustTicks } from 'src/helpers/adjustTicks'
-import { ChartContainerOuter, ChartContainerInner } from 'src/components/Common/PlotLayout'
-import FadeIn from 'src/components/Common/FadeIn'
+import { ChartContainer } from 'src/components/Common/ChartContainer'
 import { CountryDistributionPlotTooltip } from './CountryDistributionPlotTooltip'
 
 const allowEscapeViewBox = { x: false, y: true }
@@ -46,67 +43,59 @@ function AreaPlot({ width, height, cluster_names, distribution }: AreaPlotProps)
     return { adjustedTicks, domainX, domainY }
   }, [width])
 
-  const [ref, inView] = useInView()
-
   return (
-    <div ref={ref} style={{ width, height }}>
-      {inView && (
-        <FadeIn>
-          <AreaChart margin={theme.plot.margin} data={data} stackOffset="expand" width={width} height={height}>
-            <XAxis
-              dataKey="week"
-              type="number"
-              tickFormatter={formatDateHumanely}
-              domain={domainX}
-              ticks={adjustedTicks}
-              tick={theme.plot.tickStyle}
-              tickMargin={theme.plot.tickMargin?.x}
-              allowDataOverflow
-            />
-            <YAxis
-              type="number"
-              tickFormatter={formatProportion}
-              domain={domainY}
-              tick={theme.plot.tickStyle}
-              tickMargin={theme.plot.tickMargin?.y}
-              allowDataOverflow
-            />
+    <AreaChart margin={theme.plot.margin} data={data} stackOffset="expand" width={width} height={height}>
+      <XAxis
+        dataKey="week"
+        type="number"
+        tickFormatter={formatDateHumanely}
+        domain={domainX}
+        ticks={adjustedTicks}
+        tick={theme.plot.tickStyle}
+        tickMargin={theme.plot.tickMargin?.x}
+        allowDataOverflow
+      />
+      <YAxis
+        type="number"
+        tickFormatter={formatProportion}
+        domain={domainY}
+        tick={theme.plot.tickStyle}
+        tickMargin={theme.plot.tickMargin?.y}
+        allowDataOverflow
+      />
 
-            {cluster_names.map((cluster) => (
-              <Area
-                key={cluster}
-                type="monotone"
-                dataKey={cluster}
-                stackId="1"
-                stroke="none"
-                fill={getClusterColor(cluster)}
-                fillOpacity={1}
-                isAnimationActive={false}
-              />
-            ))}
+      {cluster_names.map((cluster) => (
+        <Area
+          key={cluster}
+          type="monotone"
+          dataKey={cluster}
+          stackId="1"
+          stroke="none"
+          fill={getClusterColor(cluster)}
+          fillOpacity={1}
+          isAnimationActive={false}
+        />
+      ))}
 
-            <Area
-              type="monotone"
-              dataKey={CLUSTER_NAME_OTHERS}
-              stackId="1"
-              stroke="none"
-              fill={theme.clusters.color.others}
-              fillOpacity={1}
-              isAnimationActive={false}
-            />
+      <Area
+        type="monotone"
+        dataKey={CLUSTER_NAME_OTHERS}
+        stackId="1"
+        stroke="none"
+        fill={theme.clusters.color.others}
+        fillOpacity={1}
+        isAnimationActive={false}
+      />
 
-            <CartesianGrid stroke={theme.plot.cartesianGrid.stroke} />
+      <CartesianGrid stroke={theme.plot.cartesianGrid.stroke} />
 
-            <Tooltip
-              content={CountryDistributionPlotTooltip}
-              isAnimationActive={false}
-              allowEscapeViewBox={allowEscapeViewBox}
-              offset={50}
-            />
-          </AreaChart>
-        </FadeIn>
-      )}
-    </div>
+      <Tooltip
+        content={CountryDistributionPlotTooltip}
+        isAnimationActive={false}
+        allowEscapeViewBox={allowEscapeViewBox}
+        offset={50}
+      />
+    </AreaChart>
   )
 }
 
@@ -116,18 +105,11 @@ export interface CountryDistributionPlotProps {
 }
 
 export function CountryDistributionPlot({ cluster_names, distribution }: CountryDistributionPlotProps) {
-  const { ref, width } = useResizeDetector({ handleWidth: true })
-
   return (
-    <ChartContainerOuter ref={ref}>
-      <ChartContainerInner>
-        <AreaPlot
-          width={width}
-          height={(width || 0) / theme.plot.aspectRatio}
-          cluster_names={cluster_names}
-          distribution={distribution}
-        />
-      </ChartContainerInner>
-    </ChartContainerOuter>
+    <ChartContainer>
+      {({ width, height }) => (
+        <AreaPlot width={width} height={height} cluster_names={cluster_names} distribution={distribution} />
+      )}
+    </ChartContainer>
   )
 }

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -27,6 +27,10 @@ import { getMdxComponents } from 'src/components/Common/MdxComponents'
 
 import 'src/styles/global.scss'
 
+if (typeof window.IntersectionObserver === 'undefined') {
+  await import('intersection-observer')
+}
+
 function MyApp({ Component, pageProps, router }: AppProps) {
   const queryClient = useMemo(() => new QueryClient(), [])
 

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -27,8 +27,6 @@ import { loadPolyfills } from 'src/polyfills'
 
 import 'src/styles/global.scss'
 
-await loadPolyfills()
-
 function MyApp({ Component, pageProps, router }: AppProps) {
   const queryClient = useMemo(() => new QueryClient(), [])
 
@@ -98,4 +96,9 @@ function MyApp({ Component, pageProps, router }: AppProps) {
   )
 }
 
-export default dynamic(() => Promise.resolve(MyApp), { ssr: false })
+async function run() {
+  await loadPolyfills()
+  return MyApp
+}
+
+export default dynamic(() => run(), { ssr: false })

--- a/web/src/pages/_app.tsx
+++ b/web/src/pages/_app.tsx
@@ -22,14 +22,12 @@ import { theme } from 'src/theme'
 import { DOMAIN_STRIPPED } from 'src/constants'
 import { Plausible } from 'src/components/Common/Plausible'
 import { SeoApp } from 'src/components/Common/SeoApp'
-
 import { getMdxComponents } from 'src/components/Common/MdxComponents'
+import { loadPolyfills } from 'src/polyfills'
 
 import 'src/styles/global.scss'
 
-if (typeof window.IntersectionObserver === 'undefined') {
-  await import('intersection-observer')
-}
+await loadPolyfills()
 
 function MyApp({ Component, pageProps, router }: AppProps) {
   const queryClient = useMemo(() => new QueryClient(), [])

--- a/web/src/polyfills.ts
+++ b/web/src/polyfills.ts
@@ -1,0 +1,8 @@
+export async function loadPolyfills() {
+  if (typeof window === 'undefined') {
+    return
+  }
+  if (typeof window.IntersectionObserver === 'undefined') {
+    await import('intersection-observer')
+  }
+}

--- a/web/src/types/intersection-observer.d.ts
+++ b/web/src/types/intersection-observer.d.ts
@@ -1,0 +1,1 @@
+declare module 'intersection-observer'

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -6205,6 +6205,11 @@ interpret@^2.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
+intersection-observer@0.12.2:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.12.2.tgz#4a45349cc0cd91916682b1f44c28d7ec737dc375"
+  integrity sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg==
+
 iota-array@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/iota-array/-/iota-array-1.0.0.tgz#81ef57fe5d05814cd58c2483632a99c30a0e8087"

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -8795,6 +8795,11 @@ react-icons@4.3.1:
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.3.1.tgz#2fa92aebbbc71f43d2db2ed1aed07361124e91ca"
   integrity sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==
 
+react-intersection-observer@9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-9.4.0.tgz#f6b6e616e625f9bf255857c5cba9dbf7b1825ec7"
+  integrity sha512-v0403CmomOVlzhqFXlzOxg0ziLcVq8mfbP0AwAcEQWgZmR2OulOT79Ikznw4UlB3N+jlUYqLMe4SDHUOyp0t2A==
+
 react-is@^16.10.2, react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
Hey folks,

I tried working with ECharts but I don't like it much. The scrolling issue we spoke about notwithstanding, the API is not great IMO and notice how the cursor line is not visible because reasons? I also noticed that it didn't improve performance when resizing the page and waiting for all the charts to update.

I noticed you've been trying out limiting the initial charts but I'd like to throw my hat in the ring with this. Think it's possible to extend the margin so that e.g. the chart you're about to scroll to is already rendered, but I've smoothed it out with fading anyway.

If you're keen to remove Recharts I think this would still be a useful approach. My variant chart changes are going well with Recharts though, so I can promise to implement the "brush" zooming we had on the Sanger dashboard for both 😇 

Look forward to your comments.