### PR TITLE
feat: add "others" as a variant

### DIFF
--- a/scripts/clusters.py
+++ b/scripts/clusters.py
@@ -1030,7 +1030,7 @@ clusters = {
     },
 
     "22D": {  #BA.2.75
-       "snps": [3927, 26275, 3796], #TGT = C3927T, A26275G, C3796T 
+       "snps": [3927, 26275, 3796], #TGT = C3927T, A26275G, C3796T
        "snps_with_base": ["3927T", "26275G", "3796T"],
        "cluster_data": [],
        "nextstrain_build": True,
@@ -1362,7 +1362,7 @@ clusters = {
         },
     },
 
-    # C.37 
+    # C.37
     "21GLambda": {
         "snps": [7424, 23031, 24138],  # ORF1a 2387 (7424G)  #S 490 (23031C) 859 (24138A)
         "snps_with_base": ["7424G", "23031C", "24138A"],
@@ -2509,4 +2509,16 @@ clusters = {
     # "ORFTEN30": {'snps': [29644], 'exclude_snps': [22226], 'cluster_data': [], "build_name": "ORF10.V30", "display_name": "ORF10:V30"}
     # "N220re": {'snps': [28931,29644], 'exclude_snps': [22226], 'cluster_data': [], "build_name": "N.A220Vre", "display_name": "N:A220Vre"}
     # "B1139" {'snps': [28486,28867], 'exclude_snps': [], 'cluster_data': [], "build_name": "B1139", "display_name": "B1139"}
+
+    "others": {
+        "build_name": "others",
+        "cluster_data": [],
+        "col": "#222222",
+        "snps": [],
+        "display_name": "others",
+        "graphing": False,
+        "important": False,
+        "nextstrain_build": False,
+        "type": "variant"
+    }
 }

--- a/web/data/clusters.json
+++ b/web/data/clusters.json
@@ -8592,6 +8592,18 @@
         23277
       ],
       "type": "do_not_display"
+    },
+    {
+      "build_name": "others",
+      "cluster_data": [],
+      "snps": [],
+      "col": "#222222",
+      "country_info": [],
+      "display_name": "others",
+      "graphing": false,
+      "important": false,
+      "nextstrain_build": false,
+      "type": "variant"
     }
   ]
 }

--- a/web/data/perCountryDataCaseCounts.json
+++ b/web/data/perCountryDataCaseCounts.json
@@ -30,7 +30,8 @@
         "22C (Omicron)",
         "22D (Omicron)",
         "S:677H.Robin1",
-        "S:677P.Pelican"
+        "S:677P.Pelican",
+        "others"
       ],
       "distributions": [
         {

--- a/web/src/components/Cases/CasesPlot.tsx
+++ b/web/src/components/Cases/CasesPlot.tsx
@@ -8,7 +8,7 @@ import ReactResizeDetector from 'react-resize-detector'
 
 import type { PerCountryCasesDistributionDatum } from 'src/io/getPerCountryCasesData'
 import { ticks, timeDomain } from 'src/io/getParams'
-import { CLUSTER_NAME_OTHERS, getClusterColor } from 'src/io/getClusters'
+import { getClusterColor } from 'src/io/getClusters'
 import { formatDateHumanely } from 'src/helpers/format'
 import { adjustTicks } from 'src/helpers/adjustTicks'
 import { PlotPlaceholder } from 'src/components/Common/PlotPlaceholder'
@@ -89,16 +89,6 @@ export function CasesPlotComponent({ cluster_names, distribution }: CasesPlotPro
                       isAnimationActive={false}
                     />
                   ))}
-
-                  <Area
-                    type="monotone"
-                    dataKey={CLUSTER_NAME_OTHERS}
-                    stackId="1"
-                    stroke="none"
-                    fill={theme.clusters.color.others}
-                    fillOpacity={1}
-                    isAnimationActive={false}
-                  />
 
                   <CartesianGrid stroke={theme.plot.cartesianGrid.stroke} />
 


### PR DESCRIPTION
Resolves https://github.com/hodcroftlab/covariants/issues/316

Treating "others" as a variant allows:
 -  to remove unnecessary computation from web app - the data for "others" is immutable, should be precomputed in advance and be stored along with other variant data
 - to have a checkbox which allows toggling it on the plots

