### PR TITLE
Try to stop outputting files if not displayed or built

### DIFF
--- a/scripts/cluster_analysis.py
+++ b/scripts/cluster_analysis.py
@@ -692,19 +692,22 @@ if print_files:
             print(f"No summary written out for cluster {clus} (no sequences assigned to this cluster).")
             continue
 
-        clus_build_name = clus_data_all[clus]["build_name"]
-        table_file = f"{tables_path}{clus_build_name}_table.tsv"
-        ordered_country = pd.DataFrame.from_dict(clus_data_all[clus]["summary"], orient="index").sort_values(by=["first_seq", "last_seq"])
-        ordered_country = ordered_country[ordered_country["num_seqs"] != 0]
-        ordered_country["first_seq"] = ordered_country["first_seq"].dt.date
-        ordered_country["last_seq"] = ordered_country["last_seq"].dt.date
-        ordered_country.to_csv(table_file, sep="\t")
-        # only write if doing all clusters
-        if "all" in clus_answer:
-            display_cluster = clus_data_all[clus]["display_name"]
-            with open(overall_tables_file, "a") as fh:
-                fh.write(f"\n\n## {display_cluster}\n")
-            ordered_country.to_csv(overall_tables_file, sep="\t", mode="a")
+        nextstrain_run = clusters[clus]['nextstrain_build']
+        build_type = clusters[clus]['type']
+        if not (build_type == "do_not_display" and not nextstrain_run): #if do_not_display and no nextstrain build, we shouldn't output files anymore, so skip below
+            clus_build_name = clus_data_all[clus]["build_name"]
+            table_file = f"{tables_path}{clus_build_name}_table.tsv"
+            ordered_country = pd.DataFrame.from_dict(clus_data_all[clus]["summary"], orient="index").sort_values(by=["first_seq", "last_seq"])
+            ordered_country = ordered_country[ordered_country["num_seqs"] != 0]
+            ordered_country["first_seq"] = ordered_country["first_seq"].dt.date
+            ordered_country["last_seq"] = ordered_country["last_seq"].dt.date
+            ordered_country.to_csv(table_file, sep="\t")
+            # only write if doing all clusters
+            if "all" in clus_answer:
+                display_cluster = clus_data_all[clus]["display_name"]
+                with open(overall_tables_file, "a") as fh:
+                    fh.write(f"\n\n## {display_cluster}\n")
+                ordered_country.to_csv(overall_tables_file, sep="\t", mode="a")
 
 # only do this for 'all' runs as otherwise the main file won't be updated.
 if print_acks and "all" in clus_answer:
@@ -840,8 +843,9 @@ for clus in clus_to_run:
         countries_plotted[country] = "True"
 
     if print_files:
-        with open(tables_path + f"{clus_build_name}_data.json", "w") as fh:
-            json.dump(json_output[clus_build_name], fh)
+        if not (build_type == "do_not_display" and not nextstrain_run): #if do_not_display and no nextstrain build, we shouldn't output files anymore, so skip below
+            with open(tables_path + f"{clus_build_name}_data.json", "w") as fh:
+                json.dump(json_output[clus_build_name], fh)
 
 ## Write out plotting information - only if all clusters have run
 if print_files and "all" in clus_answer:


### PR DESCRIPTION
Continuing to output data files in `cluster_tables` for variants that were never displayed (`"type": "do_not_display"`) and that are no longer being built can cause confusion. As there's no straightforward way to monitor these variants (they aren't part of any graphs, and there's no longer a Nextstrain build), and as many of those that are `do_not_display` are often transient builds that I make to monitor something for a while, there's a chance that something can go wrong. Most obviously, the list of mutations that define these (many of these predate being able to use Pango, or are not monophyletic and so don't have a Pango) pops up in another cluster later, making it look like the variant is having a resurgence, even though it's a 'SNP bug'.

To avoid this type of confusion, we should stop outputting fresh counts for variants that aren't displayed (checkable in graphs) and no longer being built (checkable in the build).
This PR tries to do this without impacting other variants.

After merging, to make this fully functional, I should go through and edit the files for which these conditions apply, and cut off their 'counts' stop at the point they stopped being graphed... if I can (that might be too much editing).