### PR TITLE
Use either pango or snps for cluster assignment, not both

### DIFF
--- a/scripts/cluster_analysis.py
+++ b/scripts/cluster_analysis.py
@@ -278,7 +278,7 @@ clus_to_run_breakdown = {key: {"official_clus": [], "unofficial_clus": [], "rest
 for clus in clus_to_run:
     for key in snps_categories:
         if key in clusters[clus] and clusters[clus][key]:
-            if clusters[clus]["display_name"] in Nextstrain_clades or "meta_cluster" in clusters[clus] and clusters[clus]["meta_cluster"]:
+            if (clusters[clus]["display_name"] in Nextstrain_clades) or ("meta_cluster" in clusters[clus] and clusters[clus]["meta_cluster"]) or ("use_pango" in clusters[clus] and clusters[clus]["use_pango"]):
                 clus_to_run_breakdown[key]["official_clus"].append(clus)
             elif clusters[clus]["type"] == "variant" and clusters[clus]["graphing"]:
                 clus_to_run_breakdown[key]["unofficial_clus"].append(clus)


### PR DESCRIPTION
For a given cluster, it is currently possible that both pango lineages and snps could be used to assign sequences to it. With this change, only one of these methods will be used for each cluster:
- Does this cluster have a `display_name` that is found in the metadata "Nextstrain_clade" column? -> use Nextstrain_clade
if not:
- Does this cluster have `use_pango=True` enabled? -> use pango lineages
if not:
- Does this cluster have a non-empty `snps` entry? -> use snps
if not:
- No sequence will be assigned to this cluster

Thoughts:
- Currently, no warning is printed if none of these methods are possible. Should we print a warning if this is the case or will this never happen anyway?
- The script currently only checks if `use_pango=True`, but not if the pango_lineages given in `clusters[clus]["pango_lineages"]` are real. This would include a separate pass over the metadata to collect all possible pango_lineages in order to compare them. (This is currently already done to find all "legal" Nextstrain_clades). Would this be desired?