### PR TITLE
chore(ci): increase retry count of aws commands on ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
 
     environment:
       PROD_ENABLE_TYPE_CHECKS: 0
+      AWS_MAX_ATTEMPTS: 10
 
     steps:
       - git-shallow-clone/checkout:


### PR DESCRIPTION
This increases number of times AWS CLI will try the failed command again. This is especially useful for Cloudfront commands, which are (in)famous for increased failure rates.

