### PR TITLE
chore(ci): fix github ssh key error during checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  git-shallow-clone: guitarrapc/git-shallow-clone@2.3.0
+  git-shallow-clone: guitarrapc/git-shallow-clone@2.5.0
 
 major_branches_only: &major_branches_only
   filters:


### PR DESCRIPTION
After GitHub changed their keys[1], CircleCI builds fail [2]. Here I upgrade `guitarrapc/git-shallow-clone` orb (which does the checkout) to version 2.5.0. This version has the new GitHub keys [3].

[1] https://github.blog/2023-03-23-we-updated-our-rsa-ssh-host-key/
[2] https://app.circleci.com/pipelines/github/hodcroftlab/covariants/1068/workflows/58e60084-5e19-4053-9001-623f21377da4/jobs/700
[3] https://github.com/guitarrapc/git-shallow-clone-orb/pull/41

