### PR TITLE
fix(web): fetch urls relative to root, rhather than current page

### DIFF
--- a/web/src/io/getPerClusterData.ts
+++ b/web/src/io/getPerClusterData.ts
@@ -36,11 +36,11 @@ export interface PerClusterData {
 }
 
 export function usePerClusterDataRaw(options?: UseAxiosQueryOptions<PerClusterDataRaw>): PerClusterDataRaw {
-  return useAxiosQuery<PerClusterDataRaw>('data/perClusterData.json', options)
+  return useAxiosQuery<PerClusterDataRaw>('/data/perClusterData.json', options)
 }
 
 export function fetchPerClusterDataRaw() {
-  return FETCHER.fetch<PerClusterDataRaw>('data/perClusterData.json')
+  return FETCHER.fetch<PerClusterDataRaw>('/data/perClusterData.json')
 }
 
 export function usePerClusterData(): PerClusterData & { setClusters: SetterOrUpdater<Cluster[]> } {

--- a/web/src/io/getPerCountryData.ts
+++ b/web/src/io/getPerCountryData.ts
@@ -41,11 +41,11 @@ export interface PerCountryData {
 }
 
 export function usePerCountryDataRaw(options?: UseAxiosQueryOptions<PerCountryDataRaw>) {
-  return useAxiosQuery<PerCountryDataRaw>('data/perCountryData.json', options)
+  return useAxiosQuery<PerCountryDataRaw>('/data/perCountryData.json', options)
 }
 
 export function fetchPerCountryDataRaw() {
-  return FETCHER.fetch<PerCountryDataRaw>('data/perCountryData.json')
+  return FETCHER.fetch<PerCountryDataRaw>('/data/perCountryData.json')
 }
 
 export function usePerCountryData(region: string): PerCountryData & { setClusters: SetterOrUpdater<Cluster[]> } {


### PR DESCRIPTION
This resolves 404 errors when fetching dynamic data from non-root pages. The fetches should always be done relative to the root `/` and not relative to the current page

