### PR TITLE
fix(web): enable all 'counties' in non-'World' region

### DIFF
--- a/web/src/state/PlacesForPerCountryData.ts
+++ b/web/src/state/PlacesForPerCountryData.ts
@@ -69,10 +69,7 @@ const countriesAtom = atomFamilyAsync<Country[], string>({
     if (!data) {
       throw new Error(`Unable to find countries in region '${region}'`)
     }
-    const countries = data.distributions.map(({ country }) => ({
-      country,
-      enabled: region === DEFAULT_REGION ? shouldPlotCountry(country) : true,
-    }))
+    const countries = data.distributions.map(({ country }) => ({ country, enabled: true }))
 
     const enabledCountries = convertToArrayMaybe(get(query, 'country'))
     if (enabledCountries) {

--- a/web/src/state/PlacesForPerCountryData.ts
+++ b/web/src/state/PlacesForPerCountryData.ts
@@ -69,7 +69,10 @@ const countriesAtom = atomFamilyAsync<Country[], string>({
     if (!data) {
       throw new Error(`Unable to find countries in region '${region}'`)
     }
-    const countries = data.distributions.map(({ country }) => ({ country, enabled: shouldPlotCountry(country) }))
+    const countries = data.distributions.map(({ country }) => ({
+      country,
+      enabled: region === DEFAULT_REGION ? shouldPlotCountry(country) : true,
+    }))
 
     const enabledCountries = convertToArrayMaybe(get(query, 'country'))
     if (enabledCountries) {

--- a/web/src/state/PlacesForPerCountryData.ts
+++ b/web/src/state/PlacesForPerCountryData.ts
@@ -2,7 +2,6 @@ import { get } from 'lodash'
 import Router from 'next/router'
 import { selectorFamily, useRecoilState } from 'recoil'
 import { convertToArrayMaybe, includesCaseInsensitive } from 'src/helpers/array'
-import { shouldPlotCountry } from 'src/io/getCountryColor'
 import {
   DEFAULT_REGION,
   getAllContinents,


### PR DESCRIPTION
The list of `countriesToPlot.json` was mistakenly applied to regions that are not "World", this led to most of the locations not being selected for plotting by default on `/per-country` page in regions that are not "World",.

This PR fixes it by only applying the list to the "World" region only.

