### PR TITLE
fix(web): crash when accessing "mutations" pages on side bar

### DIFF
--- a/web/src/components/MutationCounts/MutationCountsSummaryCard.tsx
+++ b/web/src/components/MutationCounts/MutationCountsSummaryCard.tsx
@@ -106,13 +106,13 @@ export interface MutationCountsSummaryProps {
 export function MutationCountsSummaryCard({ currentCluster }: MutationCountsSummaryProps) {
   const { t } = useTranslationSafe()
 
-  const { data, isError, error, isLoading } = useMutationCounts(currentCluster.build_name)
+  const { data } = useMutationCounts(currentCluster.build_name)
 
-  if (!data) {
+  if (!data?.result) {
     return null
   }
 
-  const { S, others } = data
+  const { S, others } = data.result
 
   return (
     <Card>
@@ -135,18 +135,6 @@ export function MutationCountsSummaryCard({ currentCluster }: MutationCountsSumm
 
               <Col className="d-flex mx-1 my-1 mb-auto">
                 <MutationCountsSummarySubTable title={t('Other genes')} record={others} />
-              </Col>
-            </Row>
-
-            <Row noGutters>
-              <Col>
-                {isLoading && <div className="mx-auto">{'Loading...'}</div>}
-                {isError && (
-                  <div className="mx-auto">
-                    <div>{t('Mutation counts are not yet available')}</div>
-                    <div className="text-danger">{process.env.NODE_ENV === 'development' && formatError(error)}</div>
-                  </div>
-                )}
               </Col>
             </Row>
           </Col>

--- a/web/src/io/getMutationCounts.ts
+++ b/web/src/io/getMutationCounts.ts
@@ -47,8 +47,13 @@ export function parseMutationCounts(data: MutationCountsJsonGeneRecord) {
   return { ...data, counts }
 }
 
-export async function getMutationCounts(clusterBuildName: string): Promise<MutationCountsData> {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,unicorn/no-await-expression-member
-  const data = (await import(`../../public/data/mutationCounts/${clusterBuildName}.json`)).default as MutationCountsJson
-  return mapValues(data, (datum) => parseMutationCounts(datum))
+export async function getMutationCounts(clusterBuildName: string): Promise<{ result: MutationCountsData | undefined }> {
+  try {
+    const data = (await import(`../../public/data/mutationCounts/${clusterBuildName}.json`)) // eslint-disable-line @typescript-eslint/no-unsafe-member-access
+      .default as MutationCountsJson // eslint-disable-line unicorn/no-await-expression-member
+    const result = mapValues(data, (datum) => parseMutationCounts(datum))
+    return { result }
+  } catch {
+    return { result: undefined }
+  }
 }


### PR DESCRIPTION
This was due to the mutations counts missing for these pages. It used to be displaying a placeholder, but at some point I migrated to async data fetching and it was throwing an exception which isn't handled correctly.

I am now explicitly ignoring the error if the mutation counts json is missing for a variant - and in this case nothing is shown on the page where the mutation counts widget should be.

