### PR TITLE
feat-505: make per plotting pages respond to pango switch

### DIFF
--- a/web/src/components/Cases/CasesPlotTooltip.tsx
+++ b/web/src/components/Cases/CasesPlotTooltip.tsx
@@ -8,46 +8,14 @@ import { useRecoilValue } from 'recoil'
 import { ColoredBox } from '../Common/ColoredBox'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { formatDateBiweekly, formatInteger, formatProportion } from 'src/helpers/format'
-import { getClusterColorsSelector } from 'src/state/Clusters'
-
-const EPSILON = 1e-2
-
-const Tooltip = styled.div`
-  display: flex;
-  flex-direction: column;
-
-  padding: 5px 10px;
-  background-color: ${(props) => props.theme.gray100};
-  box-shadow: ${(props) => props.theme.shadows.slight};
-  border-radius: 3px;
-`
-
-const TooltipTitle = styled.h1`
-  font-size: 1rem;
-  margin: 5px auto;
-  font-weight: 600;
-`
-
-const TooltipTable = styled.table`
-  padding: 30px 35px;
-  font-size: 0.9rem;
-  border: none;
-  min-width: 250px;
-
-  & > tbody > tr:nth-child(odd) {
-    background-color: ${(props) => props.theme.gray200};
-  }
-`
-
-const TooltipTableBody = styled.tbody``
-
-export const ClusterNameText = styled.span`
-  font-family: ${(props) => props.theme.font.monospace};
-`
+import { clusterPangoLineageMapSelector, getClusterColorsSelector } from 'src/state/Clusters'
+import { enablePangolinAtom } from 'src/state/Nomenclature'
 
 export function CasesPlotTooltip(props: DefaultTooltipContentProps<number, string>) {
   const { t } = useTranslationSafe()
   const getClusterColor = useRecoilValue(getClusterColorsSelector)
+  const enablePangolin = useRecoilValue(enablePangolinAtom)
+  const pangoLineageMap = useRecoilValue(clusterPangoLineageMapSelector)
 
   const { payload } = props
   if (!payload || payload.length === 0) {
@@ -84,7 +52,9 @@ export function CasesPlotTooltip(props: DefaultTooltipContentProps<number, strin
             <tr key={name}>
               <td className="px-2 text-left">
                 <ColoredBox $color={getClusterColor(name ?? '')} $size={10} $aspect={1.66} />
-                <ClusterNameText>{name}</ClusterNameText>
+                <ClusterNameText>
+                  {enablePangolin ? ((name && pangoLineageMap.get(name)) ?? name) : name}
+                </ClusterNameText>
               </td>
               <td className="px-2 text-right">{value !== undefined && value > EPSILON ? formatInteger(value) : '-'}</td>
               <td className="px-2 text-right">
@@ -107,3 +77,38 @@ export function CasesPlotTooltip(props: DefaultTooltipContentProps<number, strin
     </Tooltip>
   )
 }
+
+const EPSILON = 1e-2
+
+const Tooltip = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  padding: 5px 10px;
+  background-color: ${(props) => props.theme.gray100};
+  box-shadow: ${(props) => props.theme.shadows.slight};
+  border-radius: 3px;
+`
+
+const TooltipTitle = styled.h1`
+  font-size: 1rem;
+  margin: 5px auto;
+  font-weight: 600;
+`
+
+const TooltipTable = styled.table`
+  padding: 30px 35px;
+  font-size: 0.9rem;
+  border: none;
+  min-width: 250px;
+
+  & > tbody > tr:nth-child(odd) {
+    background-color: ${(props) => props.theme.gray200};
+  }
+`
+
+const TooltipTableBody = styled.tbody``
+
+export const ClusterNameText = styled.span`
+  font-family: ${(props) => props.theme.font.monospace};
+`

--- a/web/src/components/ClusterDistribution/ClusterDistributionPage.tsx
+++ b/web/src/components/ClusterDistribution/ClusterDistributionPage.tsx
@@ -20,83 +20,43 @@ import { ClusterDistributionComponents } from 'src/components/ClusterDistributio
 import { FetchError } from 'src/components/Error/FetchError'
 import { LOADING } from 'src/components/Loading/Loading'
 
-const Dropdown = styled(DropdownBase)`
-  min-width: 130px;
-`
+export function ClusterDistributionPage() {
+  const { t } = useTranslationSafe()
+
+  return (
+    <Layout wide>
+      <Row className={'gx-0'}>
+        <Col>
+          <PageHeading>{t('Overview of Variants/Mutations')}</PageHeading>
+        </Col>
+      </Row>
+
+      <Row className={'gx-0'}>
+        <Col>
+          <CenteredEditable githubUrl="blob/master/content/PerClusterIntro.md">
+            <MdxContent filepath="PerClusterIntro.md" />
+          </CenteredEditable>
+        </Col>
+      </Row>
+
+      <Row className={'gx-0'}>
+        <Col>
+          <SharingPanel />
+        </Col>
+      </Row>
+
+      <Row className={'gx-0'}>
+        <Col className="pb-10">
+          <Editable githubUrl="blob/master/scripts" text={t('View data generation scripts')}>
+            <ClusterDistributionPlotSection />
+          </Editable>
+        </Col>
+      </Row>
+    </Layout>
+  )
+}
 
 const enabledFilters = ['countries', 'clusters']
-
-const sortByOptions = Object.entries(TooltipSortCriterion).map(([key, value]) => ({ value, label: key }))
-
-export function SortByDropdown() {
-  const { t } = useTranslationSafe()
-
-  const [tooltipSort, setTooltipSort] = useRecoilState(tooltipSortAtom)
-  const sortBy = tooltipSort.criterion
-
-  const handleSortByChange = useCallback(
-    (value: string) => {
-      const setSortBy = (criterion: TooltipSortCriterion) => {
-        setTooltipSort((tooltipSort) => ({ ...tooltipSort, criterion }))
-      }
-      return setSortBy(TooltipSortCriterion[value as keyof typeof TooltipSortCriterion])
-    },
-    [setTooltipSort],
-  )
-
-  return (
-    <Col className={'d-flex flex-row align-items-center justify-between me-2'}>
-      <Label for="per-variant-sort-by" className={'mb-0 me-2'}>
-        {t('Tooltip sort by:')}
-      </Label>
-      <Dropdown
-        identifier="per-variant-sort-by"
-        options={sortByOptions}
-        value={stringToOption(sortBy)}
-        onValueChange={handleSortByChange}
-        isSearchable={false}
-      />
-    </Col>
-  )
-}
-
-export function SortReverseCheckbox() {
-  const { t } = useTranslationSafe()
-
-  const [tooltipSort, setTooltipSort] = useRecoilState(tooltipSortAtom)
-  const sortReversed = tooltipSort.reversed
-
-  const setSortReversed = useCallback(
-    (reversed: boolean) => {
-      setTooltipSort((tooltipSort) => ({ ...tooltipSort, reversed }))
-    },
-    [setTooltipSort],
-  )
-
-  const onChange = useCallback(() => setSortReversed(!sortReversed), [setSortReversed, sortReversed])
-
-  return (
-    <Col>
-      <Input
-        id="per-variant-sort-reverse"
-        type="checkbox"
-        checked={sortReversed}
-        onChange={onChange}
-        className={'me-1'}
-      />
-      <Label for="per-variant-sort-reverse" check>
-        {t('Reversed')}
-      </Label>
-    </Col>
-  )
-}
-
-const StickyRow = styled(Row)`
-  position: sticky;
-  top: 0;
-  z-index: 1;
-  align-self: flex-start;
-`
 
 function ClusterDistributionPlotSection() {
   const { t } = useTranslationSafe()
@@ -153,38 +113,78 @@ function ClusterDistributionPlotSection() {
   )
 }
 
-export function ClusterDistributionPage() {
+const sortByOptions = Object.entries(TooltipSortCriterion).map(([key, value]) => ({ value, label: key }))
+
+export function SortByDropdown() {
   const { t } = useTranslationSafe()
 
+  const [tooltipSort, setTooltipSort] = useRecoilState(tooltipSortAtom)
+  const sortBy = tooltipSort.criterion
+
+  const handleSortByChange = useCallback(
+    (value: string) => {
+      const setSortBy = (criterion: TooltipSortCriterion) => {
+        setTooltipSort((tooltipSort) => ({ ...tooltipSort, criterion }))
+      }
+      return setSortBy(TooltipSortCriterion[value as keyof typeof TooltipSortCriterion])
+    },
+    [setTooltipSort],
+  )
+
   return (
-    <Layout wide>
-      <Row className={'gx-0'}>
-        <Col>
-          <PageHeading>{t('Overview of Variants/Mutations')}</PageHeading>
-        </Col>
-      </Row>
-
-      <Row className={'gx-0'}>
-        <Col>
-          <CenteredEditable githubUrl="blob/master/content/PerClusterIntro.md">
-            <MdxContent filepath="PerClusterIntro.md" />
-          </CenteredEditable>
-        </Col>
-      </Row>
-
-      <Row className={'gx-0'}>
-        <Col>
-          <SharingPanel />
-        </Col>
-      </Row>
-
-      <Row className={'gx-0'}>
-        <Col className="pb-10">
-          <Editable githubUrl="blob/master/scripts" text={t('View data generation scripts')}>
-            <ClusterDistributionPlotSection />
-          </Editable>
-        </Col>
-      </Row>
-    </Layout>
+    <Col className={'d-flex flex-row align-items-center justify-between me-2'}>
+      <Label for="per-variant-sort-by" className={'mb-0 me-2'}>
+        {t('Tooltip sort by:')}
+      </Label>
+      <Dropdown
+        identifier="per-variant-sort-by"
+        options={sortByOptions}
+        value={stringToOption(sortBy)}
+        onValueChange={handleSortByChange}
+        isSearchable={false}
+      />
+    </Col>
   )
 }
+
+const Dropdown = styled(DropdownBase)`
+  min-width: 130px;
+`
+
+export function SortReverseCheckbox() {
+  const { t } = useTranslationSafe()
+
+  const [tooltipSort, setTooltipSort] = useRecoilState(tooltipSortAtom)
+  const sortReversed = tooltipSort.reversed
+
+  const setSortReversed = useCallback(
+    (reversed: boolean) => {
+      setTooltipSort((tooltipSort) => ({ ...tooltipSort, reversed }))
+    },
+    [setTooltipSort],
+  )
+
+  const onChange = useCallback(() => setSortReversed(!sortReversed), [setSortReversed, sortReversed])
+
+  return (
+    <Col>
+      <Input
+        id="per-variant-sort-reverse"
+        type="checkbox"
+        checked={sortReversed}
+        onChange={onChange}
+        className={'me-1'}
+      />
+      <Label for="per-variant-sort-reverse" check>
+        {t('Reversed')}
+      </Label>
+    </Col>
+  )
+}
+
+const StickyRow = styled(Row)`
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  align-self: flex-start;
+`

--- a/web/src/components/ClusterDistribution/ClusterDistributionPlotCard.tsx
+++ b/web/src/components/ClusterDistribution/ClusterDistributionPlotCard.tsx
@@ -4,10 +4,13 @@ import React from 'react'
 import { Card, CardBody, CardHeader, Col, Row } from 'reactstrap'
 import { styled } from 'styled-components'
 
+import { useRecoilValue } from 'recoil'
 import type { ClusterDistributionDatum } from 'src/io/getPerClusterData'
 import { Link } from 'src/components/Link/Link'
 import { PlotCardTitle } from 'src/components/Common/PlotCardTitle'
 import { ClusterDistributionPlot } from 'src/components/ClusterDistribution/ClusterDistributionPlot'
+import { clusterPangoLineageMapSelector } from 'src/state/Clusters'
+import { enablePangolinAtom } from 'src/state/Nomenclature'
 
 export interface ClusterDistributionPlotCardProps {
   clusterBuildName: string
@@ -27,12 +30,15 @@ export function ClusterDistributionPlotCard({
   country_names,
 }: ClusterDistributionPlotCardProps) {
   const url = `/variants/${clusterBuildName}`
+  const enablePangolin = useRecoilValue(enablePangolinAtom)
+  const pangoLineageMap = useRecoilValue(clusterPangoLineageMapSelector)
+  const pangoName = pangoLineageMap.get(clusterDisplayName) ?? clusterDisplayName
 
   return (
     <Card className="m-2">
       <CardHeader className="d-flex flex-sm-column">
         <PlotCardTitle>
-          <GreyLink href={url}>{clusterDisplayName}</GreyLink>
+          <GreyLink href={url}>{enablePangolin ? pangoName : clusterDisplayName}</GreyLink>
         </PlotCardTitle>
       </CardHeader>
 

--- a/web/src/components/CountryDistribution/CountryDistributionComponents.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionComponents.tsx
@@ -9,13 +9,6 @@ import { Country } from 'src/state/Places'
 import { Cluster } from 'src/state/Clusters'
 import { perCountryDataDistributionsSelector } from 'src/state/PerCountryData'
 
-export interface ClusterDistributionComponentsProps {
-  clusters: Cluster[]
-  countries: Country[]
-  region: string
-  iconComponent?: React.ComponentType<CountryFlagProps>
-}
-
 export function CountryDistributionComponents({
   countries,
   clusters,
@@ -47,4 +40,11 @@ export function CountryDistributionComponents({
   )
 
   return <Row className={'gx-0'}>{countryDistributionComponents}</Row>
+}
+
+export interface ClusterDistributionComponentsProps {
+  clusters: Cluster[]
+  countries: Country[]
+  region: string
+  iconComponent?: React.ComponentType<CountryFlagProps>
 }

--- a/web/src/components/CountryDistribution/CountryDistributionPage.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPage.tsx
@@ -24,6 +24,62 @@ import { CountryDistributionComponents } from 'src/components/CountryDistributio
 import { clustersForPerCountryDataAtom } from 'src/state/ClustersForPerCountryData'
 import { perCountryDataIntroContentFilenameSelector } from 'src/state/PerCountryData'
 
+export function CountryDistributionPage() {
+  const { t } = useTranslationSafe()
+
+  return (
+    <Layout wide>
+      <Row className={'gx-0'}>
+        <Col>
+          <PageHeading>{t('Overview of Variants in Countries')}</PageHeading>
+        </Col>
+      </Row>
+      <CountryDistributionPageBody />
+    </Layout>
+  )
+}
+
+function CountryDistributionPageBody() {
+  const { t } = useTranslationSafe()
+
+  const contentFilename = useRecoilValue(perCountryDataIntroContentFilenameSelector)
+  const IntroContent = useMemo(() => {
+    return <MdxContent filepath={`PerCountryIntro/${contentFilename}`} />
+  }, [contentFilename])
+
+  return (
+    <>
+      <Row className={'gx-0'}>
+        <Col>
+          <RegionSwitcher />
+        </Col>
+      </Row>
+
+      <Row className={'gx-0'}>
+        <Col>
+          <CenteredEditable githubUrl="tree/master/web/src/content/en/PerCountryIntro/">
+            {IntroContent}
+          </CenteredEditable>
+        </Col>
+      </Row>
+
+      <Row className={'gx-0'}>
+        <Col>
+          <SharingPanel />
+        </Col>
+      </Row>
+
+      <Row className={'gx-0'}>
+        <Col>
+          <Editable githubUrl="blob/master/scripts" text={t('View data generation scripts')}>
+            <CountryDistributionPlotSection />
+          </Editable>
+        </Col>
+      </Row>
+    </>
+  )
+}
+
 const enabledFilters = ['clusters', 'countriesWithIcons']
 
 function CountryDistributionPlotSection() {
@@ -74,61 +130,5 @@ function CountryDistributionPlotSection() {
         </Row>
       </MainFlex>
     </WrapperFlex>
-  )
-}
-
-function CountryDistributionPageBody() {
-  const { t } = useTranslationSafe()
-
-  const contentFilename = useRecoilValue(perCountryDataIntroContentFilenameSelector)
-  const IntroContent = useMemo(() => {
-    return <MdxContent filepath={`PerCountryIntro/${contentFilename}`} />
-  }, [contentFilename])
-
-  return (
-    <>
-      <Row className={'gx-0'}>
-        <Col>
-          <RegionSwitcher />
-        </Col>
-      </Row>
-
-      <Row className={'gx-0'}>
-        <Col>
-          <CenteredEditable githubUrl="tree/master/web/src/content/en/PerCountryIntro/">
-            {IntroContent}
-          </CenteredEditable>
-        </Col>
-      </Row>
-
-      <Row className={'gx-0'}>
-        <Col>
-          <SharingPanel />
-        </Col>
-      </Row>
-
-      <Row className={'gx-0'}>
-        <Col>
-          <Editable githubUrl="blob/master/scripts" text={t('View data generation scripts')}>
-            <CountryDistributionPlotSection />
-          </Editable>
-        </Col>
-      </Row>
-    </>
-  )
-}
-
-export function CountryDistributionPage() {
-  const { t } = useTranslationSafe()
-
-  return (
-    <Layout wide>
-      <Row className={'gx-0'}>
-        <Col>
-          <PageHeading>{t('Overview of Variants in Countries')}</PageHeading>
-        </Col>
-      </Row>
-      <CountryDistributionPageBody />
-    </Layout>
   )
 }

--- a/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
@@ -8,46 +8,14 @@ import { useRecoilValue } from 'recoil'
 import { ColoredBox } from '../Common/ColoredBox'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { formatDateBiweekly, formatInteger, formatProportion } from 'src/helpers/format'
-import { getClusterColorsSelector } from 'src/state/Clusters'
-
-const EPSILON = 1e-2
-
-const Tooltip = styled.div`
-  display: flex;
-  flex-direction: column;
-
-  padding: 5px 10px;
-  background-color: ${(props) => props.theme.gray100};
-  box-shadow: ${(props) => props.theme.shadows.slight};
-  border-radius: 3px;
-`
-
-const TooltipTitle = styled.h1`
-  font-size: 1rem;
-  margin: 5px auto;
-  font-weight: 600;
-`
-
-const TooltipTable = styled.table`
-  padding: 30px 35px;
-  font-size: 0.9rem;
-  border: none;
-  min-width: 250px;
-
-  & > tbody > tr:nth-child(odd) {
-    background-color: ${(props) => props.theme.gray200};
-  }
-`
-
-const TooltipTableBody = styled.tbody``
-
-export const ClusterNameText = styled.span`
-  font-family: ${(props) => props.theme.font.monospace};
-`
+import { clusterPangoLineageMapSelector, getClusterColorsSelector } from 'src/state/Clusters'
+import { enablePangolinAtom } from 'src/state/Nomenclature'
 
 export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps<number, string>) {
   const { t } = useTranslationSafe()
   const getClusterColor = useRecoilValue(getClusterColorsSelector)
+  const enablePangolin = useRecoilValue(enablePangolinAtom)
+  const pangoLineageMap = useRecoilValue(clusterPangoLineageMapSelector)
 
   const { payload } = props
   if (!payload || payload.length === 0) {
@@ -84,7 +52,9 @@ export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps
             <tr key={name}>
               <td className="px-2 text-left">
                 <ColoredBox $color={getClusterColor(name ?? '')} $size={10} $aspect={1.66} />
-                <ClusterNameText>{name}</ClusterNameText>
+                <ClusterNameText>
+                  {enablePangolin ? ((name && pangoLineageMap.get(name)) ?? name) : name}
+                </ClusterNameText>
               </td>
               <td className="px-2 text-right">{value !== undefined && value > EPSILON ? formatInteger(value) : '-'}</td>
               <td className="px-2 text-right">
@@ -107,3 +77,38 @@ export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps
     </Tooltip>
   )
 }
+
+const EPSILON = 1e-2
+
+const Tooltip = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  padding: 5px 10px;
+  background-color: ${(props) => props.theme.gray100};
+  box-shadow: ${(props) => props.theme.shadows.slight};
+  border-radius: 3px;
+`
+
+const TooltipTitle = styled.h1`
+  font-size: 1rem;
+  margin: 5px auto;
+  font-weight: 600;
+`
+
+const TooltipTable = styled.table`
+  padding: 30px 35px;
+  font-size: 0.9rem;
+  border: none;
+  min-width: 250px;
+
+  & > tbody > tr:nth-child(odd) {
+    background-color: ${(props) => props.theme.gray200};
+  }
+`
+
+const TooltipTableBody = styled.tbody``
+
+export const ClusterNameText = styled.span`
+  font-family: ${(props) => props.theme.font.monospace};
+`

--- a/web/src/components/DistributionSidebar/ClusterFilters.tsx
+++ b/web/src/components/DistributionSidebar/ClusterFilters.tsx
@@ -14,53 +14,11 @@ import {
 
 import { styled } from 'styled-components'
 import { useRecoilValue } from 'recoil'
-import { Cluster, getClusterColorsSelector } from 'src/state/Clusters'
+import { Cluster, clusterPangoLineageMapSelector, getClusterColorsSelector } from 'src/state/Clusters'
 import { ColoredBox } from 'src/components/Common/ColoredBox'
 import { CardCollapsible } from 'src/components/Common/CardCollapsible'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
-
-export const FormGroup = styled(FormGroupBase)`
-  flex: 1 0 320px;
-`
-
-export const Form = styled(FormBase)`
-  display: flex;
-  flex-wrap: wrap;
-`
-
-export const ClusterNameText = styled.span`
-  font-family: ${(props) => props.theme.font.monospace};
-`
-
-export interface ClusterFilterCheckboxProps {
-  cluster: string
-  enabled: boolean
-  onFilterChange(cluster: string): void
-}
-
-export function ClusterFilterCheckbox({ cluster, enabled, onFilterChange }: ClusterFilterCheckboxProps) {
-  const onChange = useCallback(() => onFilterChange(cluster), [onFilterChange, cluster])
-  const getClusterColor = useRecoilValue(getClusterColorsSelector)
-
-  return (
-    <FormGroup key={cluster} check>
-      <Label htmlFor={CSS.escape(cluster)} check>
-        <Input id={CSS.escape(cluster)} type="checkbox" checked={enabled} onChange={onChange} />
-        <ColoredBox $color={getClusterColor(cluster)} $size={14} $aspect={16 / 9} />
-        <ClusterNameText>{cluster}</ClusterNameText>
-      </Label>
-    </FormGroup>
-  )
-}
-
-export interface ClusterFiltersProps {
-  clusters: Cluster[]
-  collapsed: boolean
-  onFilterChange(cluster: string): void
-  onFilterSelectAll(): void
-  onFilterDeselectAll(): void
-  setCollapsed(collapsed: boolean): void
-}
+import { enablePangolinAtom } from 'src/state/Nomenclature'
 
 export function ClusterFilters({
   clusters,
@@ -108,3 +66,51 @@ export function ClusterFilters({
     </CardCollapsible>
   )
 }
+
+export interface ClusterFiltersProps {
+  clusters: Cluster[]
+  collapsed: boolean
+
+  onFilterChange(cluster: string): void
+  onFilterSelectAll(): void
+  onFilterDeselectAll(): void
+  setCollapsed(collapsed: boolean): void
+}
+
+export const FormGroup = styled(FormGroupBase)`
+  flex: 1 0 320px;
+`
+
+export const Form = styled(FormBase)`
+  display: flex;
+  flex-wrap: wrap;
+`
+
+export function ClusterFilterCheckbox({ cluster, enabled, onFilterChange }: ClusterFilterCheckboxProps) {
+  const onChange = useCallback(() => onFilterChange(cluster), [onFilterChange, cluster])
+  const getClusterColor = useRecoilValue(getClusterColorsSelector)
+  const enablePangolin = useRecoilValue(enablePangolinAtom)
+  const pangoLineageMap = useRecoilValue(clusterPangoLineageMapSelector)
+  const pangoName = pangoLineageMap.get(cluster) ?? cluster
+
+  return (
+    <FormGroup key={cluster} check>
+      <Label htmlFor={CSS.escape(cluster)} check>
+        <Input id={CSS.escape(cluster)} type="checkbox" checked={enabled} onChange={onChange} />
+        <ColoredBox $color={getClusterColor(cluster)} $size={14} $aspect={16 / 9} />
+        <ClusterNameText>{enablePangolin ? pangoName : cluster}</ClusterNameText>
+      </Label>
+    </FormGroup>
+  )
+}
+
+export interface ClusterFilterCheckboxProps {
+  cluster: string
+  enabled: boolean
+
+  onFilterChange(cluster: string): void
+}
+
+export const ClusterNameText = styled.span`
+  font-family: ${(props) => props.theme.font.monospace};
+`

--- a/web/src/components/DistributionSidebar/DistributionSidebar.tsx
+++ b/web/src/components/DistributionSidebar/DistributionSidebar.tsx
@@ -17,20 +17,6 @@ import {
 } from 'src/state/Places'
 import { sortClustersByClusterNames } from 'src/io/getClusters'
 
-export interface DistributionSidebarProps {
-  countries: Country[]
-  continents: Continent[]
-  clusters?: Cluster[]
-  setCountries: SetterOrUpdater<Country[]>
-  setContinents: SetterOrUpdater<Continent[]>
-  setClusters: SetterOrUpdater<Cluster[]>
-  regionsTitle: string
-  clustersCollapsedByDefault?: boolean
-  countriesCollapsedByDefault?: boolean
-  enabledFilters: string[]
-  Icon?: React.ComponentType<CountryFlagProps>
-}
-
 export function DistributionSidebar({
   countries,
   continents,
@@ -157,4 +143,18 @@ export function DistributionSidebar({
       <Col>{enabledFilters.map((filterName) => get(availableFilters, filterName))}</Col>
     </Row>
   )
+}
+
+export interface DistributionSidebarProps {
+  countries: Country[]
+  continents: Continent[]
+  clusters?: Cluster[]
+  setCountries: SetterOrUpdater<Country[]>
+  setContinents: SetterOrUpdater<Continent[]>
+  setClusters: SetterOrUpdater<Cluster[]>
+  regionsTitle: string
+  clustersCollapsedByDefault?: boolean
+  countriesCollapsedByDefault?: boolean
+  enabledFilters: string[]
+  Icon?: React.ComponentType<CountryFlagProps>
 }


### PR DESCRIPTION
Resolves #505 

Behavior on hitting the pango switch:

- Cases and per-country page:
  - Sidebar updates
  - Tooltip updates

- Per-variant page:
  - Sidebar updates
  - Plot card headers update

Also changed code style such that exported component is at the top of the file.

![output](https://github.com/user-attachments/assets/08002d9c-8e04-4eba-a723-2096e0cc5616)
