### PR TITLE
472 fix country filters

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -213,6 +213,7 @@
     "map.prototype.tojson": "^0.1.3",
     "markdown-loader": "^8.0.0",
     "msw": "2.6.9",
+    "next-router-mock": "0.9.13",
     "next-transpile-modules": "^10.0.1",
     "nodemon": "^3.1.7",
     "npm-run-all": "^4.1.5",

--- a/web/src/components/CountryDistribution/CountryDistributionPage.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPage.tsx
@@ -23,7 +23,7 @@ import { LOADING } from 'src/components/Loading/Loading'
 import { CountryDistributionComponents } from 'src/components/CountryDistribution/CountryDistributionComponents'
 import { clustersForPerCountryDataAtom } from 'src/state/ClustersForPerCountryData'
 import { perCountryDataIntroContentFilenameSelector } from 'src/state/PerCountryData'
-import { UNITED_STATES_REGION, WHOLE_WORLD_REGION } from 'src/state/Places'
+import { REGIONS } from 'src/state/Places'
 
 const enabledFilters = ['clusters', 'countriesWithIcons']
 
@@ -33,11 +33,11 @@ function CountryDistributionPlotSection() {
   const [countries, setCountries] = useRecoilState(perCountryCountriesAtom(region))
   const [continents, setContinents] = useRecoilState(perCountryContinentsAtom)
   const [clusters, setClusters] = useRecoilState(clustersForPerCountryDataAtom(region))
-  const regionsTitle = useMemo(() => (region === WHOLE_WORLD_REGION ? t('Countries') : t('Regions')), [region, t])
+  const regionsTitle = useMemo(() => (region === REGIONS.WORLD ? t('Countries') : t('Regions')), [region, t])
 
   const iconComponent = useMemo(() => {
-    if (region === WHOLE_WORLD_REGION) return CountryFlag
-    if (region === UNITED_STATES_REGION) return USStateCode
+    if (region === REGIONS.WORLD) return CountryFlag
+    if (region === REGIONS.UNITED_STATES) return USStateCode
     return undefined
   }, [region])
 

--- a/web/src/components/CountryDistribution/CountryDistributionPage.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPage.tsx
@@ -23,6 +23,7 @@ import { LOADING } from 'src/components/Loading/Loading'
 import { CountryDistributionComponents } from 'src/components/CountryDistribution/CountryDistributionComponents'
 import { clustersForPerCountryDataAtom } from 'src/state/ClustersForPerCountryData'
 import { perCountryDataIntroContentFilenameSelector } from 'src/state/PerCountryData'
+import { UNITED_STATES_REGION, WHOLE_WORLD_REGION } from 'src/state/Places'
 
 const enabledFilters = ['clusters', 'countriesWithIcons']
 
@@ -32,11 +33,11 @@ function CountryDistributionPlotSection() {
   const [countries, setCountries] = useRecoilState(perCountryCountriesAtom(region))
   const [continents, setContinents] = useRecoilState(perCountryContinentsAtom)
   const [clusters, setClusters] = useRecoilState(clustersForPerCountryDataAtom(region))
-  const regionsTitle = useMemo(() => (region === 'World' ? t('Countries') : t('Regions')), [region, t])
+  const regionsTitle = useMemo(() => (region === WHOLE_WORLD_REGION ? t('Countries') : t('Regions')), [region, t])
 
   const iconComponent = useMemo(() => {
-    if (region === 'World') return CountryFlag
-    if (region === 'United States') return USStateCode
+    if (region === WHOLE_WORLD_REGION) return CountryFlag
+    if (region === UNITED_STATES_REGION) return USStateCode
     return undefined
   }, [region])
 

--- a/web/src/components/SharedMutations/__tests__/mockRequests.ts
+++ b/web/src/components/SharedMutations/__tests__/mockRequests.ts
@@ -114,6 +114,27 @@ const mockPerCountryData = {
       per_country_intro_content: 'World.md',
       region: 'World',
     },
+    {
+      cluster_names: ['20I (Alpha, V1)'],
+      distributions: [
+        {
+          country: 'Region 4',
+          distribution: [
+            {
+              cluster_counts: {
+                '20I (Alpha, V1)': 0.0,
+              },
+              total_sequences: 2,
+              week: '2024-07-15',
+            },
+          ],
+        },
+      ],
+      max_date: '2024-12-30',
+      min_date: '2020-04-27',
+      per_country_intro_content: 'Switzerland.md',
+      region: 'Switzerland',
+    },
   ],
 }
 

--- a/web/src/helpers/__tests__/providers.tsx
+++ b/web/src/helpers/__tests__/providers.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { render } from '@testing-library/react'
+import React, { ReactNode, Suspense } from 'react'
+import { render, renderHook } from '@testing-library/react'
 import { ThemeProvider } from 'styled-components'
 import { I18nextProvider } from 'react-i18next'
 import { QueryClientProvider } from '@tanstack/react-query'
@@ -36,4 +36,28 @@ export const renderWithQueryClientAndRecoilRoot = (component: React.JSX.Element)
       </QueryClientProvider>
     </RecoilRoot>,
   )
+}
+
+export const RecoilRootAndQueryClientWrapper = (content: { children: ReactNode }) => {
+  return (
+    <RecoilRoot>
+      <QueryClientProvider client={FETCHER.getQueryClient()}>
+        <Suspense>{content.children}</Suspense>
+      </QueryClientProvider>
+    </RecoilRoot>
+  )
+}
+
+export async function renderHookWithTimeout<T>(
+  useMyCustomHook: () => T,
+  wrapper: (content: { children: React.ReactNode }) => React.JSX.Element,
+  timeout = 100,
+) {
+  const { result } = renderHook(() => useMyCustomHook(), {
+    wrapper: wrapper,
+  })
+  await new Promise((resolve) => {
+    setTimeout(resolve, timeout)
+  })
+  return result.current
 }

--- a/web/src/state/Places.ts
+++ b/web/src/state/Places.ts
@@ -2,9 +2,11 @@ import { z } from 'zod'
 import { FETCHER } from 'src/hooks/useAxiosQuery'
 import { atomAsync } from 'src/state/utils/atomAsync'
 
-export const WHOLE_WORLD_REGION = 'World'
-export const UNITED_STATES_REGION = 'United States'
-export const DEFAULT_REGION = WHOLE_WORLD_REGION
+export const REGIONS = {
+  WORLD: 'World' as const,
+  UNITED_STATES: 'United States' as const,
+}
+export const DEFAULT_REGION = REGIONS.WORLD
 
 export interface Country {
   country: string
@@ -35,7 +37,7 @@ export const regionCountryAtom = atomAsync<RegionCountry>({
 })
 
 export const getAllContinents = (region?: string, regionCountry?: RegionCountry) => {
-  if (region === WHOLE_WORLD_REGION && regionCountry !== undefined) {
+  if (region === REGIONS.WORLD && regionCountry !== undefined) {
     return Object.keys(regionCountry).map((continent) => ({ continent, enabled: true }))
   }
   return [{ continent: region ?? '', enabled: true }]
@@ -73,7 +75,7 @@ export const toggleCountriesFromContinents = (
  */
 export const getContinentsFromCountries = (countries: Country[], region?: string, regionCountry?: RegionCountry) => {
   // Continents are only relevant for the 'World' region
-  if (region === WHOLE_WORLD_REGION && regionCountry !== undefined) {
+  if (region === REGIONS.WORLD && regionCountry !== undefined) {
     return Object.entries(regionCountry).map(([continent, continentCountries]) => {
       // A continent is enabled if every country of this continent is enabled
       const enabled = continentCountries.every((continentCountry) => {

--- a/web/src/state/Places.ts
+++ b/web/src/state/Places.ts
@@ -5,6 +5,7 @@ import { atomAsync } from 'src/state/utils/atomAsync'
 export const REGIONS = {
   WORLD: 'World' as const,
   UNITED_STATES: 'United States' as const,
+  SWITZERLAND: 'Switzerland' as const,
 }
 export const DEFAULT_REGION = REGIONS.WORLD
 

--- a/web/src/state/Places.ts
+++ b/web/src/state/Places.ts
@@ -3,6 +3,7 @@ import { FETCHER } from 'src/hooks/useAxiosQuery'
 import { atomAsync } from 'src/state/utils/atomAsync'
 
 export const WHOLE_WORLD_REGION = 'World'
+export const UNITED_STATES_REGION = 'United States'
 export const DEFAULT_REGION = WHOLE_WORLD_REGION
 
 export interface Country {

--- a/web/src/state/PlacesForCaseData.ts
+++ b/web/src/state/PlacesForCaseData.ts
@@ -6,8 +6,8 @@ import {
   getAllContinents,
   getContinentsFromCountries,
   regionCountryAtom,
+  REGIONS,
   toggleCountriesFromContinents,
-  WHOLE_WORLD_REGION,
 } from 'src/state/Places'
 import { updateUrlQuery } from 'src/helpers/urlQuery'
 import { isDefaultValue } from 'src/state/utils/isDefaultValue'
@@ -51,13 +51,13 @@ export const continentsCasesAtom = selector<Continent[]>({
   get: ({ get }) => {
     const countries = get(countriesCasesAtom)
     const regionCountry = get(regionCountryAtom)
-    return getContinentsFromCountries(countries, WHOLE_WORLD_REGION, regionCountry)
+    return getContinentsFromCountries(countries, REGIONS.WORLD, regionCountry)
   },
   set: ({ set, get }, continentsOrDefault) => {
     const countriesOld = get(countriesCasesAtom)
     const regionCountry = get(regionCountryAtom)
     const continents = isDefaultValue(continentsOrDefault)
-      ? getAllContinents(WHOLE_WORLD_REGION, regionCountry)
+      ? getAllContinents(REGIONS.WORLD, regionCountry)
       : continentsOrDefault
     const countries = toggleCountriesFromContinents(countriesOld, continents, regionCountry)
     set(countriesCasesAtom, countries)

--- a/web/src/state/PlacesForPerCountryData.ts
+++ b/web/src/state/PlacesForPerCountryData.ts
@@ -53,9 +53,7 @@ export const perCountryCountriesAtom = atomFamilyDefault<Country[], string>({
     const countries = distributions.map(({ country }) => ({ country, enabled: true }))
     const regionFromUrl = getLodash(query, 'region')
     const enabledCountriesFromUrl = convertToArrayMaybe(getLodash(query, 'country'))
-    // we have to check that the regions are the same here, otherwise the query can spill from one region to another
-    // because the atom effect that updates the query (setRegionAtom) is run *after* all dependent atoms are updated
-    // see issue https://github.com/hodcroftlab/covariants/issues/472
+
     if (enabledCountriesFromUrl && regionFromUrl === region) {
       return countries.map((country) => ({
         ...country,

--- a/web/src/state/PlacesForPerCountryData.ts
+++ b/web/src/state/PlacesForPerCountryData.ts
@@ -51,12 +51,15 @@ export const perCountryCountriesAtom = atomFamilyDefault<Country[], string>({
     const { query } = parseUrl(Router.asPath)
     const distributions = get(perCountryDataDistributionsSelector(region))
     const countries = distributions.map(({ country }) => ({ country, enabled: true }))
-
-    const enabledCountries = convertToArrayMaybe(getLodash(query, 'country'))
-    if (enabledCountries) {
+    const regionFromUrl = getLodash(query, 'region')
+    const enabledCountriesFromUrl = convertToArrayMaybe(getLodash(query, 'country'))
+    // we have to check that the regions are the same here, otherwise the query can spill from one region to another
+    // because the atom effect that updates the query (setRegionAtom) is run *after* all dependent atoms are updated
+    // see issue https://github.com/hodcroftlab/covariants/issues/472
+    if (enabledCountriesFromUrl && regionFromUrl === region) {
       return countries.map((country) => ({
         ...country,
-        enabled: includesCaseInsensitive(enabledCountries, country.country),
+        enabled: includesCaseInsensitive(enabledCountriesFromUrl, country.country),
       }))
     }
     return countries

--- a/web/src/state/__tests__/Clusters.test.tsx
+++ b/web/src/state/__tests__/Clusters.test.tsx
@@ -1,0 +1,30 @@
+/* eslint-disable unicorn/consistent-function-scoping */
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest'
+import { useRecoilValue } from 'recoil'
+import nextRouterMock from 'next-router-mock'
+import { server } from 'src/components/SharedMutations/__tests__/mockRequests'
+import { FETCHER } from 'src/hooks/useAxiosQuery'
+import { clustersAtom } from 'src/state/Clusters'
+import { RecoilRootAndQueryClientWrapper, renderHookWithTimeout } from 'src/helpers/__tests__/providers'
+
+vi.mock('next/router', () => nextRouterMock)
+
+describe('clustersAtom', () => {
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+
+  afterAll(() => server.close())
+
+  afterEach(() => {
+    server.resetHandlers()
+    FETCHER.getQueryClient().clear()
+    vi.clearAllMocks()
+  })
+  test('Fetches clusters data', async () => {
+    const useTestHook = () => {
+      return useRecoilValue(clustersAtom)
+    }
+    const result = await renderHookWithTimeout(useTestHook, RecoilRootAndQueryClientWrapper)
+
+    expect(result[0].build_name).toEqual('20I.Alpha.V1')
+  })
+})

--- a/web/tests/home.spec.ts
+++ b/web/tests/home.spec.ts
@@ -12,6 +12,6 @@ test.describe('The Home page', () => {
   test('navbar link', async ({ page }) => {
     await page.getByRole('link', { name: 'FAQ' }).click()
 
-    await expect(page.getByRole('heading', { name: 'Frequently asked questions' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Frequently asked questions' })).toBeVisible({ timeout: 10_000 })
   })
 })

--- a/web/tests/perCountry.spec.ts
+++ b/web/tests/perCountry.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('The per-country page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/per-country')
+    await expect(page.getByText('Overview of Variants in Countries')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('lists the correct countries after using country filters and switching regions', async ({ page }) => {
+    const countriesMentions = await page.getByText('Countries').all()
+    await countriesMentions[2].click()
+    const africaButtons = await page.getByText('Africa').all()
+    await africaButtons[0].click()
+    const usaMentions = await page.getByText('United States').all()
+    await usaMentions[0].click()
+    const california = await page.getByText('California').all()
+    await expect(california[1]).toBeVisible()
+  })
+})

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -10653,6 +10653,11 @@ next-compose-plugins@^2.2.1:
   resolved "https://registry.yarnpkg.com/next-compose-plugins/-/next-compose-plugins-2.2.1.tgz#020fc53f275a7e719d62521bef4300fbb6fde5ab"
   integrity sha512-OjJ+fV15FXO2uQXQagLD4C0abYErBjyjE0I0FHpOEIB8upw0hg1ldFP6cqHTJBH1cZqy96OeR3u1dJ+Ez2D4Bg==
 
+next-router-mock@0.9.13:
+  version "0.9.13"
+  resolved "https://registry.yarnpkg.com/next-router-mock/-/next-router-mock-0.9.13.tgz#bdee2011ea6c09e490121c354ef917f339767f72"
+  integrity sha512-906n2RRaE6Y28PfYJbaz5XZeJ6Tw8Xz1S6E31GGwZ0sXB6/XjldD1/2azn1ZmBmRk5PQRkzjg+n+RHZe5xQzWA==
+
 next-transpile-modules@^10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/next-transpile-modules/-/next-transpile-modules-10.0.1.tgz#1ca2b735b14781f4792f6214f808b600574e0348"


### PR DESCRIPTION
Visiting /per-country, using the country filters and then switching to a different region would leave the "country" filter for that region almost empty (see #472). 

The reason was that the default state of a country filter is taken from the url query if one is present. Using the filter in one region adds a query to the url. Switching regions updates the query but only *after* the filter state has been updated because the filter state depends directly on the selected region state. Consequently, the filter state for e.g. "Switzerland" would be taken from the previous query of e.g. "World", leaving no regions selected.

This PR fixes the bug by only setting the filter state from the url if it includes the correct region.

Bug:

[Screencast from 11.03.2025 11:47:41.webm](https://github.com/user-attachments/assets/cd50de30-9bf5-4090-8de0-e07a6367f58d)

Fixed:

[Screencast from 11.03.2025 11:48:51.webm](https://github.com/user-attachments/assets/d04fe6f3-b2ec-423c-ad78-1f43990c2306)


