### PR TITLE
467 keep url synced with plot selection

### DIFF
--- a/web/src/components/Cases/Cases.tsx
+++ b/web/src/components/Cases/Cases.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react'
+import React, { Suspense, useMemo } from 'react'
 import { Col, Row } from 'reactstrap'
 import { useRecoilState } from 'recoil'
 import { ErrorBoundary } from 'react-error-boundary'
@@ -15,6 +15,7 @@ import { CasesComponents } from 'src/components/Cases/CasesComponents'
 import { FetchError } from 'src/components/Error/FetchError'
 import { LOADING } from 'src/components/Loading/Loading'
 import { clusterSidebarCollapsedAtoms, countriesSidebarCollapsedAtoms } from 'src/state/DistributionSidebar'
+import { updateUrlOnMismatch } from 'src/state/Clusters'
 
 export function Cases() {
   const { t } = useTranslationSafe()
@@ -41,6 +42,11 @@ function CasesPlotSection() {
   const [countries, setCountries] = useRecoilState(countriesCasesAtom)
   const [continents, setContinents] = useRecoilState(continentsCasesAtom)
   const [clusters, setClusters] = useRecoilState(clustersCasesAtom)
+
+  useMemo(() => {
+    updateUrlOnMismatch(countries, clusters)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     <WrapperFlex>

--- a/web/src/components/Cases/Cases.tsx
+++ b/web/src/components/Cases/Cases.tsx
@@ -45,6 +45,7 @@ function CasesPlotSection() {
 
   useMemo(() => {
     updateUrlOnMismatch(countries, clusters)
+    // Only on initial render to sync url when navigating, other url updates are done via the atoms
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/web/src/components/ClusterDistribution/ClusterDistribution.tsx
+++ b/web/src/components/ClusterDistribution/ClusterDistribution.tsx
@@ -48,6 +48,7 @@ function ClusterDistributionPlotSection() {
 
   useMemo(() => {
     updateUrlOnMismatch(countriesSelected, clustersSelected)
+    // Only on initial render to sync url when navigating, other url updates are done via the atoms
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/web/src/components/ClusterDistribution/ClusterDistribution.tsx
+++ b/web/src/components/ClusterDistribution/ClusterDistribution.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useCallback } from 'react'
+import React, { Suspense, useCallback, useMemo } from 'react'
 import { Card, CardBody, Col, Form, Input, Label, Row } from 'reactstrap'
 import { useRecoilState } from 'recoil'
 import { styled } from 'styled-components'
@@ -18,6 +18,7 @@ import { ClusterDistributionComponents } from 'src/components/ClusterDistributio
 import { FetchError } from 'src/components/Error/FetchError'
 import { LOADING } from 'src/components/Loading/Loading'
 import { clusterSidebarCollapsedAtoms, countriesSidebarCollapsedAtoms } from 'src/state/DistributionSidebar'
+import { updateUrlOnMismatch } from 'src/state/Clusters'
 
 export function ClusterDistribution() {
   const { t } = useTranslationSafe()
@@ -44,6 +45,11 @@ function ClusterDistributionPlotSection() {
   const [countriesSelected, setCountriesSelected] = useRecoilState(perClusterCountriesAtom)
   const [continentsSelected, setContinentsSelected] = useRecoilState(perClusterContinentsAtom)
   const [clustersSelected, setClustersSelected] = useRecoilState(clustersForPerClusterDataAtom)
+
+  useMemo(() => {
+    updateUrlOnMismatch(countriesSelected, clustersSelected)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     <WrapperFlex>

--- a/web/src/components/CountryDistribution/CountryDistribution.tsx
+++ b/web/src/components/CountryDistribution/CountryDistribution.tsx
@@ -23,6 +23,7 @@ import { clustersForPerCountryDataAtom } from 'src/state/ClustersForPerCountryDa
 import { perCountryDataIntroContentFilenameSelector } from 'src/state/PerCountryData'
 import { REGIONS } from 'src/state/Places'
 import { clusterSidebarCollapsedAtoms, countriesSidebarCollapsedAtoms } from 'src/state/DistributionSidebar'
+import { updateUrlOnMismatch } from 'src/state/Clusters'
 
 export function CountryDistribution() {
   const { t } = useTranslationSafe()
@@ -56,6 +57,12 @@ function CountryDistributionPlotSection() {
   const [continents, setContinents] = useRecoilState(perCountryContinentsAtom)
   const [clusters, setClusters] = useRecoilState(clustersForPerCountryDataAtom(region))
   const regionsTitle = useMemo(() => (region === REGIONS.WORLD ? t('Countries') : t('Regions')), [region, t])
+
+  useMemo(() => {
+    updateUrlOnMismatch(countries, clusters, region)
+    // Only on initial render to sync url when navigating, other url updates are done via the atoms
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const iconComponent = useMemo(() => {
     if (region === REGIONS.WORLD) return CountryFlag

--- a/web/src/state/Clusters.ts
+++ b/web/src/state/Clusters.ts
@@ -1,7 +1,7 @@
 import { selector, selectorFamily } from 'recoil'
 import Router from 'next/router'
 import { get as getLodash } from 'lodash'
-import { updateUrlQuery } from 'src/helpers/urlQuery'
+import { setUrlQuery, updateUrlQuery } from 'src/helpers/urlQuery'
 import type { AtomEffectParams } from 'src/state/utils/atomEffect'
 import { atomAsync } from 'src/state/utils/atomAsync'
 import { CLUSTER_NAME_OTHERS, ClusterDatum, fetchClusters } from 'src/io/getClusters'
@@ -10,6 +10,7 @@ import { notUndefinedOrNull } from 'src/helpers/notUndefined'
 import { enablePangolinAtom } from 'src/state/Nomenclature'
 import { parseUrl } from 'src/helpers/parseUrl'
 import { convertToArrayMaybe, includesCaseInsensitive } from 'src/helpers/array'
+import { Country } from 'src/state/Places'
 
 export interface Cluster {
   cluster: string
@@ -236,6 +237,36 @@ export function updateUrlOnClustersSet({ onSet, getPromise }: AtomEffectParams<C
         throw error
       })
   })
+}
+
+export function updateUrlOnMismatch(countries: Country[], clusters: Cluster[]) {
+  const { query } = parseUrl(Router.asPath)
+  const enabledCountriesInAtom = countries.flatMap((c) => (c.enabled ? [c.country] : []))
+  const enabledCountriesInUrl = convertToArrayMaybe(getLodash(query, 'country'))
+
+  const enabledClustersInAtom = clusters.flatMap((c) => (c.enabled ? [c.cluster] : []))
+  const enabledClustersInUrl = convertToArrayMaybe(getLodash(query, 'variant'))
+
+  const allCountriesEnabled = enabledCountriesInAtom.length === countries.length
+  const allClustersEnabled = enabledClustersInAtom.length === clusters.length
+
+  const countriesMismatch = enabledCountriesInAtom !== enabledCountriesInUrl
+  const clustersMismatch = enabledClustersInAtom !== enabledClustersInUrl
+
+  const updateCountries = countriesMismatch && !allCountriesEnabled
+  const updateClusters = clustersMismatch && !allClustersEnabled
+
+  const countriesQuery = updateCountries ? { country: enabledCountriesInAtom } : {}
+  const clustersQuery = updateClusters ? { cluster: enabledClustersInAtom } : {}
+
+  setUrlQuery({
+    ...countriesQuery,
+    ...clustersQuery,
+  })
+    .then(() => true)
+    .catch((error: Error) => {
+      throw error
+    })
 }
 
 export function extractEnabledClustersFromUrlQuery(clusters: Cluster[], lineagesMap: Map<string, string>) {

--- a/web/src/state/Clusters.ts
+++ b/web/src/state/Clusters.ts
@@ -239,7 +239,7 @@ export function updateUrlOnClustersSet({ onSet, getPromise }: AtomEffectParams<C
   })
 }
 
-export function updateUrlOnMismatch(countries: Country[], clusters: Cluster[]) {
+export function updateUrlOnMismatch(countries: Country[], clusters: Cluster[], region?: string) {
   const { query } = parseUrl(Router.asPath)
   const enabledCountriesInAtom = countries.flatMap((c) => (c.enabled ? [c.country] : []))
   const enabledCountriesInUrl = convertToArrayMaybe(getLodash(query, 'country'))
@@ -257,9 +257,11 @@ export function updateUrlOnMismatch(countries: Country[], clusters: Cluster[]) {
   const updateClusters = clustersMismatch && !allClustersEnabled
 
   const countriesQuery = updateCountries ? { country: enabledCountriesInAtom } : {}
-  const clustersQuery = updateClusters ? { cluster: enabledClustersInAtom } : {}
+  const clustersQuery = updateClusters ? { variant: enabledClustersInAtom } : {}
+  const regionQuery = region ? { region: region } : {}
 
   setUrlQuery({
+    ...regionQuery,
     ...countriesQuery,
     ...clustersQuery,
   })
@@ -269,11 +271,16 @@ export function updateUrlOnMismatch(countries: Country[], clusters: Cluster[]) {
     })
 }
 
-export function extractEnabledClustersFromUrlQuery(clusters: Cluster[], lineagesMap: Map<string, string>) {
+export function extractEnabledClustersFromUrlQuery(
+  clusters: Cluster[],
+  lineagesMap: Map<string, string>,
+  region?: string,
+) {
   const { query } = parseUrl(Router.asPath)
   const enabledClustersLineagesOrDisplayNames = convertToArrayMaybe(getLodash(query, 'variant'))
+  const regionFromUrl = getLodash(query, 'region')
 
-  if (enabledClustersLineagesOrDisplayNames) {
+  if (enabledClustersLineagesOrDisplayNames && region === regionFromUrl) {
     const enabledClustersDisplayNames = enabledClustersLineagesOrDisplayNames.map(
       (displayNameOrLineage) => lineagesMap.get(displayNameOrLineage) ?? displayNameOrLineage,
     )

--- a/web/src/state/ClustersForPerCountryData.ts
+++ b/web/src/state/ClustersForPerCountryData.ts
@@ -1,10 +1,10 @@
 import copy from 'fast-copy'
+import type { Cluster } from 'src/state/Clusters'
 import {
   clusterLineagesToDisplayNameMapSelector,
   extractEnabledClustersFromUrlQuery,
   updateUrlOnClustersSet,
 } from 'src/state/Clusters'
-import type { Cluster } from 'src/state/Clusters'
 import { fetchPerCountryDataRaw } from 'src/io/getPerCountryData'
 import { atomFamilyAsync } from 'src/state/utils/atomAsync'
 
@@ -20,7 +20,7 @@ export const clustersForPerCountryDataAtom = atomFamilyAsync<Cluster[], string>(
     const clusters = clusterNames.map((cluster) => ({ cluster, enabled: true }))
     const clusterPangoLineagesToDisplayNameMap = get(clusterLineagesToDisplayNameMapSelector)
 
-    return extractEnabledClustersFromUrlQuery(clusters, clusterPangoLineagesToDisplayNameMap)
+    return extractEnabledClustersFromUrlQuery(clusters, clusterPangoLineagesToDisplayNameMap, region)
   },
   effects: [updateUrlOnClustersSet],
 })


### PR DESCRIPTION
Resolves #467 

Fix: navigating on the page resets query url even though the state retains the query.

Fixed by updating url on first render of the plotting component. For the per-country page, an additional fix was needed when navigating between regions, as setting the region was scrubbing the url query.