### PR TITLE
feat-606: add download button to defining mutations page

### DIFF
--- a/web/src/components/DefiningMutations/DefiningMutationsContent.tsx
+++ b/web/src/components/DefiningMutations/DefiningMutationsContent.tsx
@@ -3,6 +3,7 @@ import { DefiningMutationCluster } from 'src/io/getDefiningMutationsClusters'
 import { SelectReferenceDropdown } from 'src/components/DefiningMutations/SelectReferenceDropdown'
 import { DefiningMutationsTables } from 'src/components/DefiningMutations/DefiningMutationsTables'
 import { DefiningMutationsDescription } from 'src/components/DefiningMutations/DefiningMutationsDescription'
+import { DownloadDefiningMutationsButton } from 'src/components/DefiningMutations/DownloadDefiningMutationsButton'
 
 export function DefiningMutationsContent({ cluster }: { cluster: DefiningMutationCluster | undefined }) {
   return (
@@ -24,12 +25,13 @@ function DefiningMutationsTableCard({ cluster }: { cluster: DefiningMutationClus
 
   return (
     <div className={'card'}>
-      <div className="card-header d-flex justify-content-end">
+      <div className="card-header d-flex justify-content-end align-items-center gap-2">
         <SelectReferenceDropdown
           referenceSequences={referenceSequences}
           selectedSequence={selectedReference}
           setSelectedReference={setSelectedReference}
         />
+        <DownloadDefiningMutationsButton cluster={cluster} />
       </div>
       <div className="card-body">
         <DefiningMutationsTables currentCluster={cluster} referenceSequenceName={selectedReference} />

--- a/web/src/components/DefiningMutations/DownloadDefiningMutationsButton.tsx
+++ b/web/src/components/DefiningMutations/DownloadDefiningMutationsButton.tsx
@@ -1,0 +1,28 @@
+import React, { useCallback, useMemo } from 'react'
+import { DefiningMutationCluster } from 'src/io/getDefiningMutationsClusters'
+
+export function DownloadDefiningMutationsButton({ cluster }: { cluster: DefiningMutationCluster }) {
+  const download = useCallback(() => {
+    const content = JSON.stringify(cluster)
+    const blob = new Blob([content], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `defining_mutations_${cluster.lineage}.json`
+    document.body.append(a)
+    a.click()
+    setTimeout(() => URL.revokeObjectURL(url), 100)
+    a.remove()
+  }, [cluster])
+
+  const title = useMemo(() => {
+    return `Download defining mutation for ${cluster.lineage}`
+  }, [cluster.lineage])
+
+  return (
+    <button className={'btn btn-light'} onClick={download} title={title}>
+      <div className="bi bi-download"></div>
+      <div className="visually-hidden">{title}</div>
+    </button>
+  )
+}


### PR DESCRIPTION
Adds a download button to the defining mutations page. Clicking on it, will download the available data of the selected defining mutation.

![grafik](https://github.com/user-attachments/assets/06f120ec-efb6-4959-a683-1c134eef5406)
