### PR TITLE
feat-612: fix column width of defining mutations table

### DIFF
--- a/web/src/components/Common/table/TableWithSearchPaginationFilter.tsx
+++ b/web/src/components/Common/table/TableWithSearchPaginationFilter.tsx
@@ -1,5 +1,5 @@
 import { Column, flexRender, Header, SortDirection } from '@tanstack/react-table'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import type { Table } from '@tanstack/table-core'
 import { Pagination } from 'src/components/Common/table/Pagination'
 
@@ -10,19 +10,36 @@ const removeAllDefaultStylesForButton = {
   cursor: 'pointer',
 } as const
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function TableWithSearchPaginationFilter({ table, pageSizes }: { table: Table<any>; pageSizes: number[] }) {
+export function TableWithSearchPaginationFilter({
+  table,
+  pageSizes,
+  equiWidthHeader,
+}: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  table: Table<any>
+  pageSizes: number[]
+  equiWidthHeader?: boolean
+}) {
+  const thStyle = useMemo(() => {
+    if (equiWidthHeader) {
+      return {
+        width: `${100 / table.getFlatHeaders().length}%`,
+      }
+    }
+    return undefined
+  }, [equiWidthHeader, table])
+
   return (
-    <div className="border border-2 rounded shadow-sm">
+    <div className="border border-2 rounded shadow-sm table-responsive">
       <table className={'table table-striped table-hover'}>
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (
             <React.Fragment key={headerGroup.id}>
               <tr key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
-                  <th key={header.id}>
+                  <th key={header.id} style={thStyle}>
                     <button onClick={header.column.getToggleSortingHandler()} style={removeAllDefaultStylesForButton}>
-                      <div className={'d-flex justify-content-between'}>
+                      <div className={'d-flex justify-content-between text-nowrap gap-2'}>
                         <HeaderText header={header} />
                         <SortingIndicator sorted={header.column.getIsSorted()} />
                       </div>

--- a/web/src/components/DefiningMutations/CodingMutationsTable.tsx
+++ b/web/src/components/DefiningMutations/CodingMutationsTable.tsx
@@ -41,7 +41,7 @@ export function CodingMutationsTable({ codingMutations }: { codingMutations: Cod
     },
   })
 
-  return <TableWithSearchPaginationFilter table={table} pageSizes={DEFAULT_PAGE_SIZES} />
+  return <TableWithSearchPaginationFilter table={table} pageSizes={DEFAULT_PAGE_SIZES} equiWidthHeader={true} />
 }
 
 function getAminoAcidMutationsColumn() {
@@ -52,7 +52,7 @@ function getAminoAcidMutationsColumn() {
     cell: ({ getValue }) => {
       const aminoAcidMutations = getValue()
       return (
-        <div className={'d-flex gap-2 align-items-center'}>
+        <div className={'d-flex gap-2 align-items-center flex-wrap'}>
           {aminoAcidMutations.map((aminoAcidMutation) => (
             <AminoacidMutationBadge
               key={formatMutation(aminoAcidMutation)}
@@ -78,7 +78,7 @@ function getNucleotideMutationsColumn() {
   const columnHelper = createColumnHelper<CodingMutation>()
 
   return columnHelper.accessor('nucMutations', {
-    header: () => <span>Nucleotide Mutations</span>,
+    header: () => <span>Nucleotide mutations</span>,
     cell: ({ getValue, row }) => {
       const nucMuts = getValue()
 

--- a/web/src/components/DefiningMutations/SilentMutationsTable.tsx
+++ b/web/src/components/DefiningMutations/SilentMutationsTable.tsx
@@ -43,7 +43,7 @@ function getNucleotideMutationColumn() {
   const columnHelper = createColumnHelper<SilentMutation>()
 
   return columnHelper.accessor('nucMutation', {
-    header: () => <span>Nucleotide Mutations</span>,
+    header: () => <span>Nucleotide mutations</span>,
     cell: ({ getValue, row }) => {
       const nucleotideMutation = getValue()
       return (


### PR DESCRIPTION
-  adds the option to specify for each table, that each of the columns has the same width.
- fixes minor spelling
- makes the table "responsive" meaning, that when the minimal width (length of the title) is reached, then there appears a scroll bar at the bottom

![grafik](https://github.com/user-attachments/assets/61064ce0-eff1-41a2-85e8-fdc38aba7e9b)
