### PR TITLE
feat-409: add zooming to plots

### DIFF
--- a/web/src/components/Cases/CasesPlot.tsx
+++ b/web/src/components/Cases/CasesPlot.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable camelcase */
-import React, { CSSProperties, useMemo, useRef } from 'react'
+import React, { CSSProperties, useMemo } from 'react'
 
 import dynamic from 'next/dynamic'
-import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, Label } from 'recharts'
+import { Area, CartesianGrid, Label, Tooltip, XAxis, YAxis } from 'recharts'
 import { DateTime } from 'luxon'
 
 import { useTheme } from 'styled-components'
@@ -18,6 +18,8 @@ import { ChartContainer } from 'src/components/Common/ChartContainer'
 import { ticksSelector, timeDomainSelector } from 'src/state/Params'
 import { getClusterColorsSelector } from 'src/state/Clusters'
 
+import { ChartWithZoom } from 'src/components/Common/ChartWithZoom'
+
 const CHART_MARGIN = { left: 10, top: 12, bottom: 6, right: 12 }
 const ALLOW_ESCAPE_VIEW_BOX = { x: false, y: true }
 
@@ -26,14 +28,15 @@ export interface CasesPlotProps {
   distribution: PerCountryCasesDistributionDatum[]
 }
 
+const ZOOM_ATOM_ID = 'cases'
+
 export function CasesPlotComponent({ cluster_names, distribution }: CasesPlotProps) {
   const { t } = useTranslationSafe()
   const theme = useTheme()
-  const chartRef = useRef(null)
   const getClusterColor = useRecoilValue(getClusterColorsSelector)
 
-  const ticks = useRecoilValue(ticksSelector)
-  const timeDomain = useRecoilValue(timeDomainSelector)
+  const ticks = useRecoilValue(ticksSelector(ZOOM_ATOM_ID))
+  const timeDomain = useRecoilValue(timeDomainSelector(ZOOM_ATOM_ID))
 
   const data = distribution.map(({ week, stand_total_cases, stand_estimated_cases }) => {
     const weekSec = DateTime.fromFormat(week, 'yyyy-MM-dd').toSeconds()
@@ -54,7 +57,7 @@ export function CasesPlotComponent({ cluster_names, distribution }: CasesPlotPro
       {({ width, height }) => {
         const adjustedTicks = adjustTicks(ticks, width ?? 0, theme.plot.tickWidthMin).slice(1) // slice ensures first tick is not outside domain
         return (
-          <AreaChart width={width} height={height} margin={CHART_MARGIN} data={data} ref={chartRef}>
+          <ChartWithZoom type="area" zoomAtomId="cases" width={width} height={height} margin={CHART_MARGIN} data={data}>
             <XAxis
               dataKey="week"
               type="number"
@@ -112,7 +115,7 @@ export function CasesPlotComponent({ cluster_names, distribution }: CasesPlotPro
               allowEscapeViewBox={ALLOW_ESCAPE_VIEW_BOX}
               offset={50}
             />
-          </AreaChart>
+          </ChartWithZoom>
         )
       }}
     </ChartContainer>

--- a/web/src/components/ClusterDistribution/ClusterDistributionPlot.tsx
+++ b/web/src/components/ClusterDistribution/ClusterDistributionPlot.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react'
 
 import get from 'lodash/get'
 import { DateTime } from 'luxon'
-import { CartesianGrid, Line, LineChart, Tooltip, XAxis, YAxis } from 'recharts'
+import { CartesianGrid, Line, Tooltip, XAxis, YAxis } from 'recharts'
 import { useTheme } from 'styled-components'
 
 import { useRecoilValue } from 'recoil'
@@ -14,6 +14,8 @@ import { ClusterDistributionPlotTooltip } from 'src/components/ClusterDistributi
 import { ChartContainer } from 'src/components/Common/ChartContainer'
 import { ticksSelector, timeDomainSelector } from 'src/state/Params'
 import { getCountryStylesSelector } from 'src/state/CountryStyles'
+
+import { ChartWithZoom } from 'src/components/Common/ChartWithZoom'
 
 const getValueOrig = (country: string) => (value: ClusterDistributionDatum) => {
   const orig = get(value.orig, country, false)
@@ -42,12 +44,14 @@ interface LinePlotProps {
   distribution: ClusterDistributionDatum[]
 }
 
+const ZOOM_ATOM_ID = 'perVariant'
+
 function LinePlot({ width, height, country_names, distribution }: LinePlotProps) {
   const theme = useTheme()
   const getCountryStyle = useRecoilValue(getCountryStylesSelector)
 
-  const ticks = useRecoilValue(ticksSelector)
-  const timeDomain = useRecoilValue(timeDomainSelector)
+  const ticks = useRecoilValue(ticksSelector(ZOOM_ATOM_ID))
+  const timeDomain = useRecoilValue(timeDomainSelector(ZOOM_ATOM_ID))
 
   const data = useMemo(
     () =>
@@ -98,7 +102,15 @@ function LinePlot({ width, height, country_names, distribution }: LinePlotProps)
   }, [country_names, getCountryStyle])
 
   return (
-    <LineChart width={width} height={height} margin={theme.plot.margin} data={data}>
+    <ChartWithZoom
+      type="line"
+      zoomAtomId="perVariant"
+      width={width}
+      height={height}
+      margin={theme.plot.margin}
+      data={data}
+      zoomWindowColor={theme.gray500}
+    >
       <XAxis
         dataKey="week"
         type="number"
@@ -124,10 +136,10 @@ function LinePlot({ width, height, country_names, distribution }: LinePlotProps)
         offset={50}
       />
 
-      <CartesianGrid stroke="#2222" />
+      <CartesianGrid stroke={theme.plot.cartesianGrid.stroke} />
 
       {lines}
-    </LineChart>
+    </ChartWithZoom>
   )
 }
 

--- a/web/src/components/Common/ChartWithZoom.tsx
+++ b/web/src/components/Common/ChartWithZoom.tsx
@@ -1,0 +1,101 @@
+import React, { PropsWithChildren, useCallback, useState } from 'react'
+import { CategoricalChartProps } from 'recharts/types/chart/generateCategoricalChart'
+import { AreaChart, LineChart, ReferenceArea } from 'recharts'
+import { useRecoilState } from 'recoil'
+import { CategoricalChartState } from 'recharts/types/chart/types'
+import { zoomWindowAtom } from 'src/state/Params'
+import { theme } from 'src/theme'
+
+interface ZoomWindow {
+  left: number | undefined
+  right: number | undefined
+}
+
+const resetZoomButtonStyle = {
+  top: 16,
+  right: 16,
+}
+
+export function ChartWithZoom({
+  type,
+  zoomAtomId,
+  children,
+  zoomWindowColor,
+  ...rest
+}: PropsWithChildren<
+  {
+    type: 'line' | 'area'
+    zoomAtomId: string
+    zoomWindowColor?: string
+  } & CategoricalChartProps
+>) {
+  const ChartComponent = type === 'line' ? LineChart : AreaChart
+
+  const [zoomWindow, setZoomWindow] = useRecoilState(zoomWindowAtom(zoomAtomId))
+  const [selectedZoomWindow, setSelectedZoomWindow] = useState<ZoomWindow>({ left: undefined, right: undefined })
+
+  const onMouseDown = useCallback((e: CategoricalChartState) => {
+    if (e.activeLabel === undefined) {
+      return
+    }
+    setSelectedZoomWindow((prevState) => ({
+      ...prevState,
+      left: Number(e.activeLabel),
+    }))
+  }, [])
+
+  const onMouseMove = useCallback(
+    (e: CategoricalChartState) => {
+      if (selectedZoomWindow.left !== undefined && e.activeLabel !== undefined) {
+        setSelectedZoomWindow((prevState) => ({
+          ...prevState,
+          right: Number(e.activeLabel),
+        }))
+      }
+    },
+    [selectedZoomWindow.left],
+  )
+
+  const onMouseUp = useCallback(() => {
+    if (selectedZoomWindow.left !== undefined && selectedZoomWindow.right !== undefined) {
+      const min = Math.min(selectedZoomWindow.left, selectedZoomWindow.right)
+      const max = Math.max(selectedZoomWindow.left, selectedZoomWindow.right)
+
+      setZoomWindow({ min, max })
+    }
+    setSelectedZoomWindow({ left: undefined, right: undefined })
+  }, [selectedZoomWindow.left, selectedZoomWindow.right, setZoomWindow])
+
+  const onResetZoomButtonClick = useCallback(() => {
+    setZoomWindow(undefined)
+  }, [setZoomWindow])
+
+  return (
+    <div className={'position-absolute'}>
+      <ChartComponent onMouseDown={onMouseDown} onMouseMove={onMouseMove} onMouseUp={onMouseUp} {...rest}>
+        {children}
+        {selectedZoomWindow.left !== undefined && selectedZoomWindow.right !== undefined ? (
+          <ReferenceArea
+            x1={selectedZoomWindow.left}
+            x2={selectedZoomWindow.right}
+            fill={zoomWindowColor ?? theme.gray500}
+            fillOpacity={0.5}
+            isFront={true}
+            ifOverflow={'visible'}
+          />
+        ) : null}
+      </ChartComponent>
+      {zoomWindow && (
+        <button
+          className={'position-absolute btn btn-sm btn-light'}
+          style={resetZoomButtonStyle}
+          onClick={onResetZoomButtonClick}
+          title={'Reset zoom'}
+        >
+          <div className="bi bi-arrow-clockwise"></div>
+          <div className="visually-hidden">Reset zoom</div>
+        </button>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/CountryDistribution/CountryDistributionPlot.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlot.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import React, { useMemo } from 'react'
 
-import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts'
+import { Area, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts'
 import { DateTime } from 'luxon'
 
 import { useRecoilValue } from 'recoil'
@@ -14,6 +14,7 @@ import { adjustTicks } from 'src/helpers/adjustTicks'
 import { ChartContainer } from 'src/components/Common/ChartContainer'
 import { ticksSelector, timeDomainSelector } from 'src/state/Params'
 import { getClusterColorsSelector } from 'src/state/Clusters'
+import { ChartWithZoom } from 'src/components/Common/ChartWithZoom'
 
 const allowEscapeViewBox = { x: false, y: true }
 
@@ -24,10 +25,12 @@ export interface AreaPlotProps {
   distribution: CountryDistributionDatum[]
 }
 
+const ZOOM_ATOM_ID = 'perCountry'
+
 function AreaPlot({ width, height, cluster_names, distribution }: AreaPlotProps) {
   const getClusterColor = useRecoilValue(getClusterColorsSelector)
-  const ticks = useRecoilValue(ticksSelector)
-  const timeDomain = useRecoilValue(timeDomainSelector)
+  const ticks = useRecoilValue(ticksSelector(ZOOM_ATOM_ID))
+  const timeDomain = useRecoilValue(timeDomainSelector(ZOOM_ATOM_ID))
 
   const data = useMemo(
     () =>
@@ -45,12 +48,22 @@ function AreaPlot({ width, height, cluster_names, distribution }: AreaPlotProps)
   const { adjustedTicks, domainX, domainY } = useMemo(() => {
     const adjustedTicks = adjustTicks(ticks, width ?? 0, theme.plot.tickWidthMin).slice(1) // slice ensures first tick is not outside domain
     const domainX = [timeDomain[0], timeDomain[1]]
+
     const domainY = [0, 1]
     return { adjustedTicks, domainX, domainY }
-  }, [width, ticks, timeDomain])
+  }, [ticks, width, timeDomain])
 
   return (
-    <AreaChart margin={theme.plot.margin} data={data} stackOffset="expand" width={width} height={height}>
+    <ChartWithZoom
+      type="area"
+      zoomAtomId={ZOOM_ATOM_ID}
+      margin={theme.plot.margin}
+      data={data}
+      stackOffset="expand"
+      width={width}
+      height={height}
+      zoomWindowColor={theme.white}
+    >
       <XAxis
         dataKey="week"
         type="number"
@@ -101,7 +114,7 @@ function AreaPlot({ width, height, cluster_names, distribution }: AreaPlotProps)
         allowEscapeViewBox={allowEscapeViewBox}
         offset={50}
       />
-    </AreaChart>
+    </ChartWithZoom>
   )
 }
 

--- a/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
@@ -47,7 +47,7 @@ export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps
             <th className="px-2 text-right">{t('Freq')}</th>
           </tr>
         </thead>
-        <TooltipTableBody>
+        <tbody>
           {payloadNonZero.map(({ name, value }) => (
             <tr key={name}>
               <td className="px-2 text-left">
@@ -72,7 +72,7 @@ export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps
             <td className="px-2 text-right">{total}</td>
             <td className="px-2 text-right">{'1.00'}</td>
           </tr>
-        </TooltipTableBody>
+        </tbody>
       </TooltipTable>
     </Tooltip>
   )
@@ -106,8 +106,6 @@ const TooltipTable = styled.table`
     background-color: ${(props) => props.theme.gray200};
   }
 `
-
-const TooltipTableBody = styled.tbody``
 
 export const ClusterNameText = styled.span`
   font-family: ${(props) => props.theme.font.monospace};

--- a/web/src/state/Params.ts
+++ b/web/src/state/Params.ts
@@ -1,4 +1,4 @@
-import { atom, selector } from 'recoil'
+import { atom, atomFamily, selector, selectorFamily } from 'recoil'
 import { DateTime, Interval } from 'luxon'
 import { fetchParams, GlobalParams } from 'src/io/getParams'
 import { dateStringToSeconds } from 'src/helpers/format'
@@ -18,37 +18,48 @@ const INVALID_PARAMS = 'Invalid date params in params.json or invalid split poin
 type Ticks = number[]
 type TimeDomain = [number, number]
 
-export const timeDomainSelector = selector<TimeDomain>({
+export const timeDomainSelector = selectorFamily<TimeDomain, string>({
   key: 'timeDomain',
-  get: ({ get }) => {
-    const params = get(paramsAtom)
+  get:
+    (param) =>
+    ({ get }) => {
+      const params = get(paramsAtom)
+      const zoomWindow = get(zoomWindowAtom(param))
 
-    const minDate = dateStringToSeconds(params.min_date)
-    const maxDate = dateStringToSeconds(params.max_date)
-    if (Number.isNaN(minDate) || Number.isNaN(maxDate)) {
-      throw new TypeError(INVALID_PARAMS)
-    }
-    return [minDate, maxDate]
-  },
+      const minDate = dateStringToSeconds(params.min_date)
+      const maxDate = dateStringToSeconds(params.max_date)
+      if (Number.isNaN(minDate) || Number.isNaN(maxDate)) {
+        throw new TypeError(INVALID_PARAMS)
+      }
+
+      return [zoomWindow?.min ?? minDate, zoomWindow?.max ?? maxDate]
+    },
 })
 
-export const ticksSelector = selector<Ticks>({
+export const zoomWindowAtom = atomFamily<{ min: number; max: number } | undefined, string>({
+  key: 'zoomWindow',
+  default: undefined,
+})
+
+export const ticksSelector = selectorFamily<Ticks, string>({
   key: 'ticks',
-  get: ({ get }) => {
-    const timeDomain = get(timeDomainSelector)
-    const start = DateTime.fromSeconds(timeDomain[0])
-    const end = DateTime.fromSeconds(timeDomain[1])
-    const interval = Interval.fromDateTimes(start.startOf('month'), end.endOf('month'))
-    if (!interval.isValid) {
-      throw new Error(INVALID_PARAMS)
-    }
+  get:
+    (param) =>
+    ({ get }) => {
+      const timeDomain = get(timeDomainSelector(param))
+      const start = DateTime.fromSeconds(timeDomain[0])
+      const end = DateTime.fromSeconds(timeDomain[1])
+      const interval = Interval.fromDateTimes(start.startOf('month'), end.endOf('month'))
+      if (!interval.isValid) {
+        throw new Error(INVALID_PARAMS)
+      }
 
-    const months = interval.splitBy({ months: 1 })
-    if (months.length === 0 || months.some((i) => !i.isValid)) {
-      throw new Error(INVALID_PARAMS)
-    }
-    const validMonths = months as Interval<true>[]
+      const months = interval.splitBy({ months: 1 })
+      if (months.length === 0 || months.some((i) => !i.isValid)) {
+        throw new Error(INVALID_PARAMS)
+      }
+      const validMonths = months as Interval<true>[]
 
-    return validMonths.map((d) => d.start.toSeconds())
-  },
+      return validMonths.map((d) => d.start.toSeconds())
+    },
 })


### PR DESCRIPTION
Resolves: #409

Adds zooming to the plots on the perVariant, perCounrty and cases pages. The zooming window is stored between page changes. It is applied to all plots on the respective pages.

![grafik](https://github.com/user-attachments/assets/01978fc5-6009-4ae6-a5e8-644cdc51ebdf)
