### PR TITLE
Add tooltip sorting to cases, cluster distribution and country distribution page

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -39,6 +39,7 @@
     "@tanstack/query-core": "^5.60.6",
     "@tanstack/react-query": "^5.60.6",
     "@tanstack/react-query-devtools": "^5.60.6",
+    "@tanstack/react-table": "8.21.3",
     "animate.css": "^4.1.1",
     "autoprefixer": "^10.4.20",
     "axios": "^1.8.2",

--- a/web/package.json
+++ b/web/package.json
@@ -40,6 +40,7 @@
     "@tanstack/react-query": "^5.60.6",
     "@tanstack/react-query-devtools": "^5.60.6",
     "@tanstack/react-table": "8.21.3",
+    "@tanstack/table-core": "8.21.3",
     "animate.css": "^4.1.1",
     "autoprefixer": "^10.4.20",
     "axios": "^1.8.2",

--- a/web/src/components/Cases/Cases.tsx
+++ b/web/src/components/Cases/Cases.tsx
@@ -15,6 +15,8 @@ import { FetchError } from 'src/components/Error/FetchError'
 import { LOADING } from 'src/components/Loading/Loading'
 import { clusterSidebarCollapsedAtoms, countriesSidebarCollapsedAtoms } from 'src/state/DistributionSidebar'
 import { updateUrlOnMismatch } from 'src/state/Clusters'
+import { TooltipConfig } from 'src/components/Common/tooltip/Tooltip'
+import { CasesPlotTooltipId } from 'src/components/Cases/CasesPlotTooltip'
 
 export function Cases() {
   const { t } = useTranslationSafe()
@@ -66,7 +68,11 @@ function CasesPlotSection() {
         />
       </SidebarFlex>
 
-      <MainFlex>
+      <MainFlex className={'d-flex flex-column gap-2'}>
+        <div className={'sticky-top'}>
+          <TooltipConfig columns={['cluster', 'estimatedCases', 'frequency']} tooltipId={CasesPlotTooltipId} />
+        </div>
+
         <ErrorBoundary FallbackComponent={FetchError}>
           <Suspense fallback={LOADING}>
             <CasesComponents countries={countries} clusters={clusters} />

--- a/web/src/components/Cases/Cases.tsx
+++ b/web/src/components/Cases/Cases.tsx
@@ -1,5 +1,4 @@
 import React, { Suspense, useMemo } from 'react'
-import { Col, Row } from 'reactstrap'
 import { useRecoilState } from 'recoil'
 import { ErrorBoundary } from 'react-error-boundary'
 import { CenteredEditable, Editable } from 'src/components/Common/Editable'
@@ -50,7 +49,7 @@ function CasesPlotSection() {
   }, [])
 
   return (
-    <WrapperFlex>
+    <WrapperFlex className={'gap-2'}>
       <SidebarFlex>
         <DistributionSidebar
           countries={countries}
@@ -68,15 +67,11 @@ function CasesPlotSection() {
       </SidebarFlex>
 
       <MainFlex>
-        <Row className={'gx-0'}>
-          <Col>
-            <ErrorBoundary FallbackComponent={FetchError}>
-              <Suspense fallback={LOADING}>
-                <CasesComponents countries={countries} clusters={clusters} />
-              </Suspense>
-            </ErrorBoundary>
-          </Col>
-        </Row>
+        <ErrorBoundary FallbackComponent={FetchError}>
+          <Suspense fallback={LOADING}>
+            <CasesComponents countries={countries} clusters={clusters} />
+          </Suspense>
+        </ErrorBoundary>
       </MainFlex>
     </WrapperFlex>
   )

--- a/web/src/components/Cases/Cases.tsx
+++ b/web/src/components/Cases/Cases.tsx
@@ -37,6 +37,7 @@ export function Cases() {
 }
 
 const enabledFilters = ['clusters', 'countriesWithIcons']
+const tooltipColumns = ['cluster', 'estimatedCases', 'frequency']
 
 function CasesPlotSection() {
   const { t } = useTranslationSafe()
@@ -70,7 +71,7 @@ function CasesPlotSection() {
 
       <MainFlex className={'d-flex flex-column gap-2'}>
         <div className={'sticky-top'}>
-          <TooltipConfig columns={['cluster', 'estimatedCases', 'frequency']} tooltipId={CasesPlotTooltipId} />
+          <TooltipConfig columns={tooltipColumns} tooltipId={CasesPlotTooltipId} />
         </div>
 
         <ErrorBoundary FallbackComponent={FetchError}>

--- a/web/src/components/Cases/CasesComponents.tsx
+++ b/web/src/components/Cases/CasesComponents.tsx
@@ -31,5 +31,5 @@ export function CasesComponents({ clusters, countries }: { clusters: Cluster[]; 
       )),
     [enabledClusters, withClustersFiltered],
   )
-  return <Row className={'gx-0'}>{casesComponents}</Row>
+  return <Row className={'g-2'}>{casesComponents}</Row>
 }

--- a/web/src/components/Cases/CasesPlotCard.tsx
+++ b/web/src/components/Cases/CasesPlotCard.tsx
@@ -25,7 +25,7 @@ export interface CasesPlotCardProps {
 
 export function CasesPlotCard({ country, distribution, cluster_names, Icon }: CasesPlotCardProps) {
   return (
-    <Card className="m-2">
+    <Card>
       <CardHeader className="d-flex flex-sm-column">
         <PlotCardTitle>
           <FlagAlignment>

--- a/web/src/components/Cases/CasesPlotTooltip.tsx
+++ b/web/src/components/Cases/CasesPlotTooltip.tsx
@@ -1,113 +1,177 @@
-import React from 'react'
-
-import { sortBy, reverse } from 'lodash'
+import React, { useMemo } from 'react'
 import { styled } from 'styled-components'
 import { Props as DefaultTooltipContentProps } from 'recharts/types/component/DefaultTooltipContent'
 
 import { useRecoilValue } from 'recoil'
+import { useReactTable } from '@tanstack/react-table'
+import { createColumnHelper, getCoreRowModel, getFilteredRowModel, getSortedRowModel } from '@tanstack/table-core'
 import { ColoredBox } from '../Common/ColoredBox'
-import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
-import { formatDateBiweekly, formatInteger, formatProportion } from 'src/helpers/format'
+import { formatProportion } from 'src/helpers/format'
 import { clusterDisplayNameToLineagesMapSelector, getClusterColorsSelector } from 'src/state/Clusters'
 import { enablePangolinAtom } from 'src/state/Nomenclature'
+import { tooltipSortAtomFamily } from 'src/state/TooltipSort'
+import { FREQUENCY_DISPLAY_THRESHOLD, getWeekFromPayload, Tooltip } from 'src/components/Common/tooltip/Tooltip'
+import { TooltipTable } from 'src/components/Common/tooltip/TooltipTable'
+
+export const CasesPlotTooltipId = 'cases'
+
+type Payload = { total: number; week: number } & Record<string, number>
 
 export function CasesPlotTooltip(props: DefaultTooltipContentProps<number, string>) {
-  const { t } = useTranslationSafe()
+  const data = props.payload?.[0]?.payload as Payload | undefined
+
+  if (!data) {
+    return null
+  }
+
+  return <TooltipInner rawData={data} />
+}
+
+function TooltipInner({ rawData }: { rawData: Payload }) {
   const getClusterColor = useRecoilValue(getClusterColorsSelector)
   const enablePangolin = useRecoilValue(enablePangolinAtom)
   const pangoLineagesMap = useRecoilValue(clusterDisplayNameToLineagesMapSelector)
 
-  const { payload } = props
-  if (!payload || payload.length === 0) {
-    return null
-  }
+  const data = useMemo(() => getRowDataFromPayload(rawData), [rawData])
+  const week = useMemo(() => getWeekFromPayload(rawData), [rawData])
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-argument
-  const week = formatDateBiweekly(payload[0]?.payload.week)
+  const { column: sortingColumn, sortDirection } = useRecoilValue(tooltipSortAtomFamily(CasesPlotTooltipId))
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-argument
-  const total: number = formatInteger(payload[0]?.payload.total ?? 0)
+  const sorting = useMemo(() => {
+    return {
+      id: sortingColumn,
+      desc: sortDirection === 'desc',
+    }
+  }, [sortDirection, sortingColumn])
 
-  const payloadSorted = reverse(sortBy(payload, 'value'))
-  const payloadNonZero = payloadSorted.filter((pld) => pld.value !== undefined && pld.value > EPSILON)
+  const table = useReactTable({
+    data,
+    columns: [
+      tooltipTableVariantColumn({
+        getClusterColor,
+        enablePangolin,
+        pangoLineagesMap,
+      }),
+      tooltipTableEstimatedCasesColumn(),
+      tooltipTableFrequencyColumn(),
+    ],
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    initialState: {
+      sorting: [sorting],
+      columnFilters: [
+        {
+          id: 'frequency',
+          value: FREQUENCY_DISPLAY_THRESHOLD,
+        },
+      ],
+    },
+  })
 
   return (
-    <Tooltip>
-      <TooltipTitle>{week}</TooltipTitle>
-
-      <TooltipTable>
-        <thead>
-          <tr className="w-100">
-            <th className="px-2 text-left">{t('Variant')}</th>
-            <th className="px-2 text-right">{t('Est. cases')}</th>
-            <th className="px-2 text-right">{t('Freq')}</th>
-          </tr>
-        </thead>
-        <TooltipTableBody>
-          {payloadNonZero.map(({ name, value }) => (
-            <tr key={name}>
-              <td className="px-2 text-left">
-                <ColoredBox $color={getClusterColor(name ?? '')} $size={10} $aspect={1.66} />
-                <ClusterNameText>
-                  {enablePangolin ? ((name && pangoLineagesMap.get(name)?.join(', ')) ?? name) : name}
-                </ClusterNameText>
-              </td>
-              <td className="px-2 text-right">{value !== undefined && value > EPSILON ? formatInteger(value) : '-'}</td>
-              <td className="px-2 text-right">
-                {value !== undefined && value > EPSILON ? formatProportion(value / total) : '-'}
-              </td>
-            </tr>
-          ))}
-
-          <tr>
-            <td className="px-2 text-left">
-              <span>
-                <b>{t('Total')}</b>
-              </span>
-            </td>
-            <td className="px-2 text-right">{total}</td>
-            <td className="px-2 text-right">{'1.00'}</td>
-          </tr>
-        </TooltipTableBody>
-      </TooltipTable>
+    <Tooltip title={week}>
+      <TooltipTable table={table} />
     </Tooltip>
   )
 }
 
-const EPSILON = 1e-2
+export interface CasesTooltipRow {
+  cluster: string
+  frequency: number | undefined
+  estimatedCases: number | undefined
+}
 
-const Tooltip = styled.div`
-  display: flex;
-  flex-direction: column;
+export function getRowDataFromPayload(payload: Payload) {
+  const keys = Object.keys(payload).filter((key) => key !== 'total' && key !== 'week')
+  return keys.map((key) => {
+    const estimatedCases = payload[key]
+    return {
+      cluster: key,
+      frequency: estimatedCases === undefined ? undefined : estimatedCases / payload.total,
+      estimatedCases: estimatedCases,
+    }
+  })
+}
 
-  padding: 5px 10px;
-  background-color: ${(props) => props.theme.gray100};
-  box-shadow: ${(props) => props.theme.shadows.slight};
-  border-radius: 3px;
-`
+export function tooltipTableFrequencyColumn() {
+  const columnHelper = createColumnHelper<CasesTooltipRow>()
 
-const TooltipTitle = styled.h1`
-  font-size: 1rem;
-  margin: 5px auto;
-  font-weight: 600;
-`
+  return columnHelper.accessor('frequency', {
+    header: 'Frequency',
+    cell: ({ getValue }) => {
+      const frequency = getValue()
+      return <span>{formatProportion(frequency ?? 0)}</span>
+    },
+    sortingFn: 'basic',
+    filterFn: (row, columnId, value) => {
+      const frequency = row.getValue(columnId)
+      return typeof frequency === 'number' && frequency > value
+    },
+    footer: '1',
+  })
+}
 
-const TooltipTable = styled.table`
-  padding: 30px 35px;
-  font-size: 0.9rem;
-  border: none;
-  min-width: 250px;
+export function tooltipTableVariantColumn({
+  getClusterColor,
+  enablePangolin,
+  pangoLineagesMap,
+}: {
+  getClusterColor: (clusterName: string) => string
+  enablePangolin: boolean
+  pangoLineagesMap: Map<string, string[]>
+}) {
+  const columnHelper = createColumnHelper<CasesTooltipRow>()
 
-  & > tbody > tr:nth-child(odd) {
-    background-color: ${(props) => props.theme.gray200};
-  }
-`
+  return columnHelper.accessor('cluster', {
+    header: 'Cluster',
+    cell: ({ getValue }) => {
+      const variant = getValue()
+      return (
+        <div className="text-left">
+          <ColoredBox $color={getClusterColor(variant ?? '')} $size={10} $aspect={1.66} />
+          <ClusterNameText>
+            {enablePangolin ? ((variant && pangoLineagesMap.get(variant)?.join(', ')) ?? variant) : variant}
+          </ClusterNameText>
+        </div>
+      )
+    },
+    sortingFn: (rowA, rowB) => {
+      const clusterA = String(rowA.original.cluster)
+      const clusterB = String(rowB.original.cluster)
 
-const TooltipTableBody = styled.tbody``
+      const aCluster = enablePangolin
+        ? ((clusterA && pangoLineagesMap.get(clusterA)?.join(', ')) ?? clusterA)
+        : clusterA
+      const bCluster = enablePangolin
+        ? ((clusterB && pangoLineagesMap.get(clusterB)?.join(', ')) ?? clusterB)
+        : clusterB
+
+      return aCluster.localeCompare(bCluster)
+    },
+    invertSorting: true, // Invert sorting to start with letter A on ascending sort
+    footer: 'Total',
+  })
+}
+
+export function tooltipTableEstimatedCasesColumn() {
+  const columnHelper = createColumnHelper<CasesTooltipRow>()
+
+  return columnHelper.accessor('estimatedCases', {
+    header: 'Estimated cases',
+    cell: ({ getValue }) => {
+      const cases = getValue()
+      return <span>{cases}</span>
+    },
+    sortingFn: 'basic',
+    footer: ({ table }) => {
+      return table.getFilteredRowModel().rows.reduce((sum, row) => {
+        const value = row.getValue('estimatedCases')
+        return sum + (typeof value === 'number' ? value : 0)
+      }, 0)
+    },
+  })
+}
 
 export const ClusterNameText = styled.span`
   font-family: ${(props) => props.theme.font.monospace};

--- a/web/src/components/Cases/CasesPlotTooltip.tsx
+++ b/web/src/components/Cases/CasesPlotTooltip.tsx
@@ -82,7 +82,7 @@ export interface CasesTooltipRow {
   estimatedCases: number | undefined
 }
 
-export function getRowDataFromPayload(payload: Payload) {
+function getRowDataFromPayload(payload: Payload) {
   const keys = Object.keys(payload).filter((key) => key !== 'total' && key !== 'week')
   return keys.map((key) => {
     const estimatedCases = payload[key]
@@ -94,7 +94,7 @@ export function getRowDataFromPayload(payload: Payload) {
   })
 }
 
-export function tooltipTableFrequencyColumn() {
+function tooltipTableFrequencyColumn() {
   const columnHelper = createColumnHelper<CasesTooltipRow>()
 
   return columnHelper.accessor('frequency', {
@@ -154,7 +154,7 @@ export function tooltipTableVariantColumn({
   })
 }
 
-export function tooltipTableEstimatedCasesColumn() {
+function tooltipTableEstimatedCasesColumn() {
   const columnHelper = createColumnHelper<CasesTooltipRow>()
 
   return columnHelper.accessor('estimatedCases', {

--- a/web/src/components/ClusterDistribution/ClusterDistribution.tsx
+++ b/web/src/components/ClusterDistribution/ClusterDistribution.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useCallback, useMemo } from 'react'
-import { Card, CardBody, Col, Form, Input, Label, Row } from 'reactstrap'
+import { Col, Input, Label } from 'reactstrap'
 import { useRecoilState } from 'recoil'
 import { styled } from 'styled-components'
 import { ErrorBoundary } from 'react-error-boundary'
@@ -53,7 +53,7 @@ function ClusterDistributionPlotSection() {
   }, [])
 
   return (
-    <WrapperFlex>
+    <WrapperFlex className={'gap-2'}>
       <SidebarFlex>
         <DistributionSidebar
           countries={countriesSelected}
@@ -69,36 +69,30 @@ function ClusterDistributionPlotSection() {
         />
       </SidebarFlex>
 
-      <MainFlex>
-        <StickyRow className={'gx-0'}>
-          <Col>
-            <Card className="m-2">
-              <CardBody className="px-3 py-2">
-                <Form>
-                  <Row className="row-cols-lg-auto gx-0 align-items-center">
-                    <SortByDropdown />
-                    <SortReverseCheckbox />
-                  </Row>
-                </Form>
-              </CardBody>
-            </Card>
-          </Col>
-        </StickyRow>
+      <MainFlex className={'d-flex flex-column gap-2'}>
+        <div className={'sticky-top'}>
+          <TooltipConfig />
+        </div>
 
-        <Row className={'gx-0'}>
-          <Col>
-            <ErrorBoundary FallbackComponent={FetchError}>
-              <Suspense fallback={LOADING}>
-                <ClusterDistributionComponents
-                  clustersSelected={clustersSelected}
-                  countriesSelected={countriesSelected}
-                />
-              </Suspense>
-            </ErrorBoundary>
-          </Col>
-        </Row>
+        <ErrorBoundary FallbackComponent={FetchError}>
+          <Suspense fallback={LOADING}>
+            <ClusterDistributionComponents clustersSelected={clustersSelected} countriesSelected={countriesSelected} />
+          </Suspense>
+        </ErrorBoundary>
       </MainFlex>
     </WrapperFlex>
+  )
+}
+
+export function TooltipConfig() {
+  return (
+    <div className="card">
+      <div className="card-header">Tooltip options</div>
+      <div className="card-body d-flex flex-column">
+        <SortByDropdown />
+        <SortReverseCheckbox />
+      </div>
+    </div>
   )
 }
 
@@ -121,7 +115,7 @@ export function SortByDropdown() {
   )
 
   return (
-    <Col className={'d-flex flex-row align-items-center justify-between me-2'}>
+    <div className={'d-flex flex-row align-items-center justify-between me-2'}>
       <Label for="per-variant-sort-by" className={'mb-0 me-2'}>
         {t('Tooltip sort by:')}
       </Label>
@@ -132,7 +126,7 @@ export function SortByDropdown() {
         onValueChange={handleSortByChange}
         isSearchable={false}
       />
-    </Col>
+    </div>
   )
 }
 
@@ -170,10 +164,3 @@ export function SortReverseCheckbox() {
     </Col>
   )
 }
-
-const StickyRow = styled(Row)`
-  position: sticky;
-  top: 0;
-  z-index: 1;
-  align-self: flex-start;
-`

--- a/web/src/components/ClusterDistribution/ClusterDistribution.tsx
+++ b/web/src/components/ClusterDistribution/ClusterDistribution.tsx
@@ -1,16 +1,11 @@
-import React, { Suspense, useCallback, useMemo } from 'react'
-import { Col, Input, Label } from 'reactstrap'
+import React, { Suspense, useMemo } from 'react'
 import { useRecoilState } from 'recoil'
-import { styled } from 'styled-components'
 import { ErrorBoundary } from 'react-error-boundary'
 import { SharingPanel } from 'src/components/Common/SharingPanel'
 import { clustersForPerClusterDataAtom } from 'src/state/ClustersForPerClusterData'
 import { perClusterContinentsAtom, perClusterCountriesAtom } from 'src/state/PlacesForPerClusterData'
-import { tooltipSortAtom, TooltipSortCriterion } from 'src/state/TooltipSort'
 import { MdxContent } from 'src/i18n/getMdxContent'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
-import { Dropdown as DropdownBase } from 'src/components/Common/Dropdown'
-import { stringToOption } from 'src/components/Common/DropdownOption'
 import { CenteredEditable, Editable } from 'src/components/Common/Editable'
 import { MainFlex, SidebarFlex, WrapperFlex } from 'src/components/Common/PlotLayout'
 import { DistributionSidebar } from 'src/components/DistributionSidebar/DistributionSidebar'
@@ -19,6 +14,8 @@ import { FetchError } from 'src/components/Error/FetchError'
 import { LOADING } from 'src/components/Loading/Loading'
 import { clusterSidebarCollapsedAtoms, countriesSidebarCollapsedAtoms } from 'src/state/DistributionSidebar'
 import { updateUrlOnMismatch } from 'src/state/Clusters'
+import { TooltipConfig } from 'src/components/Common/tooltip/Tooltip'
+import { ClusterDistributionPlotTooltipId } from 'src/components/ClusterDistribution/ClusterDistributionPlotTooltip'
 
 export function ClusterDistribution() {
   const { t } = useTranslationSafe()
@@ -39,6 +36,7 @@ export function ClusterDistribution() {
 }
 
 const enabledFilters = ['countries', 'clusters']
+const tooltipColumns = ['country', 'frequency']
 
 function ClusterDistributionPlotSection() {
   const { t } = useTranslationSafe()
@@ -71,7 +69,7 @@ function ClusterDistributionPlotSection() {
 
       <MainFlex className={'d-flex flex-column gap-2'}>
         <div className={'sticky-top'}>
-          <TooltipConfig />
+          <TooltipConfig columns={tooltipColumns} tooltipId={ClusterDistributionPlotTooltipId} />
         </div>
 
         <ErrorBoundary FallbackComponent={FetchError}>
@@ -81,86 +79,5 @@ function ClusterDistributionPlotSection() {
         </ErrorBoundary>
       </MainFlex>
     </WrapperFlex>
-  )
-}
-
-export function TooltipConfig() {
-  return (
-    <div className="card">
-      <div className="card-header">Tooltip options</div>
-      <div className="card-body d-flex flex-column">
-        <SortByDropdown />
-        <SortReverseCheckbox />
-      </div>
-    </div>
-  )
-}
-
-const sortByOptions = Object.entries(TooltipSortCriterion).map(([key, value]) => ({ value, label: key }))
-
-export function SortByDropdown() {
-  const { t } = useTranslationSafe()
-
-  const [tooltipSort, setTooltipSort] = useRecoilState(tooltipSortAtom)
-  const sortBy = tooltipSort.criterion
-
-  const handleSortByChange = useCallback(
-    (value: string) => {
-      const setSortBy = (criterion: TooltipSortCriterion) => {
-        setTooltipSort((tooltipSort) => ({ ...tooltipSort, criterion }))
-      }
-      return setSortBy(TooltipSortCriterion[value as keyof typeof TooltipSortCriterion])
-    },
-    [setTooltipSort],
-  )
-
-  return (
-    <div className={'d-flex flex-row align-items-center justify-between me-2'}>
-      <Label for="per-variant-sort-by" className={'mb-0 me-2'}>
-        {t('Tooltip sort by:')}
-      </Label>
-      <Dropdown
-        identifier="per-variant-sort-by"
-        options={sortByOptions}
-        value={stringToOption(sortBy)}
-        onValueChange={handleSortByChange}
-        isSearchable={false}
-      />
-    </div>
-  )
-}
-
-const Dropdown = styled(DropdownBase)`
-  min-width: 130px;
-`
-
-export function SortReverseCheckbox() {
-  const { t } = useTranslationSafe()
-
-  const [tooltipSort, setTooltipSort] = useRecoilState(tooltipSortAtom)
-  const sortReversed = tooltipSort.reversed
-
-  const setSortReversed = useCallback(
-    (reversed: boolean) => {
-      setTooltipSort((tooltipSort) => ({ ...tooltipSort, reversed }))
-    },
-    [setTooltipSort],
-  )
-
-  const onChange = useCallback(() => setSortReversed(!sortReversed), [setSortReversed, sortReversed])
-
-  return (
-    <Col>
-      <Input
-        id="per-variant-sort-reverse"
-        type="checkbox"
-        checked={sortReversed}
-        onChange={onChange}
-        className={'me-1'}
-      />
-      <Label for="per-variant-sort-reverse" check>
-        {t('Reversed')}
-      </Label>
-    </Col>
   )
 }

--- a/web/src/components/ClusterDistribution/ClusterDistributionComponents.tsx
+++ b/web/src/components/ClusterDistribution/ClusterDistributionComponents.tsx
@@ -42,5 +42,5 @@ export function ClusterDistributionComponents({
       )),
     [clusterBuildNames, enabledCountries, withCountriesFiltered],
   )
-  return <Row className={'gx-0'}>{clusterDistributionComponents}</Row>
+  return <Row className={'g-2'}>{clusterDistributionComponents}</Row>
 }

--- a/web/src/components/ClusterDistribution/ClusterDistributionPlotCard.tsx
+++ b/web/src/components/ClusterDistribution/ClusterDistributionPlotCard.tsx
@@ -34,7 +34,7 @@ export function ClusterDistributionPlotCard({
   const pangoName = useRecoilValue(clusterDisplayNameToJoinedLineagesSelector(clusterDisplayName)) ?? clusterDisplayName
 
   return (
-    <Card className="m-2">
+    <Card>
       <CardHeader className="d-flex flex-sm-column">
         <PlotCardTitle>
           <GreyLink href={url}>{enablePangolin ? pangoName : clusterDisplayName}</GreyLink>

--- a/web/src/components/Common/PlotLayout.tsx
+++ b/web/src/components/Common/PlotLayout.tsx
@@ -18,7 +18,6 @@ export const SidebarFlex = styled.aside`
 
 export const MainFlex = styled.section`
   flex: 1 0 350px;
-  margin-bottom: 300px;
 `
 
 export const ChartContainerOuter = styled.div`

--- a/web/src/components/Common/table/SortingIndicator.tsx
+++ b/web/src/components/Common/table/SortingIndicator.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { SortDirection } from '@tanstack/react-table'
+
+export function SortingIndicator({ sorted }: { sorted: false | SortDirection }) {
+  return <>{sorted ? sorted === 'desc' ? <SortedDescending /> : <SortedAscending /> : <NotSorted />}</>
+}
+
+export function SortedDescending() {
+  return <div aria-label="sorted descending" className="bi bi-sort-down"></div>
+}
+
+export function SortedAscending() {
+  return <div aria-label="sorted ascending" className="bi bi-sort-down-alt"></div>
+}
+
+export function NotSorted() {
+  return <div aria-label="not sorted" className="bi bi-filter"></div>
+}

--- a/web/src/components/Common/tooltip/Tooltip.tsx
+++ b/web/src/components/Common/tooltip/Tooltip.tsx
@@ -1,0 +1,59 @@
+import React, { PropsWithChildren, useCallback } from 'react'
+import { useRecoilState } from 'recoil'
+import { startCase } from 'lodash'
+import { tooltipSortAtomFamily } from 'src/state/TooltipSort'
+import { SortingIndicator } from 'src/components/Common/table/SortingIndicator'
+import { formatDateBiweekly } from 'src/helpers/format'
+import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
+
+export function Tooltip({ children, title }: PropsWithChildren<{ title: string }>) {
+  return (
+    <div className="d-flex flex-column p-2 shadow rounded-1 bg-white">
+      <div className="h5">{title}</div>
+      {children}
+    </div>
+  )
+}
+
+export function TooltipConfig({ columns, tooltipId }: { columns: string[]; tooltipId: string }) {
+  const { t } = useTranslationSafe()
+
+  return (
+    <div className="card">
+      <div className="card-header">{t('Tooltip sorting')}</div>
+      <div className="card-body d-flex flex-column">
+        <div className="d-flex gap-4">
+          {columns.map((column) => {
+            return <TooltipSortButton key={column} column={column} tooltipId={tooltipId} />
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function TooltipSortButton({ column, tooltipId }: { column: string; tooltipId: string }) {
+  const [clusterTooltipSort, setClusterTooltipSort] = useRecoilState(tooltipSortAtomFamily(tooltipId))
+
+  const isSorted = clusterTooltipSort.column === column
+
+  const onClick = useCallback(() => {
+    setClusterTooltipSort({
+      column,
+      sortDirection: isSorted ? (clusterTooltipSort.sortDirection === 'desc' ? 'asc' : 'desc') : 'desc',
+    })
+  }, [clusterTooltipSort.sortDirection, column, isSorted, setClusterTooltipSort])
+
+  return (
+    <button className="d-flex gap-2 btn btn-outline-primary align-items-center" onClick={onClick}>
+      <div>{startCase(column)}</div>
+      <SortingIndicator sorted={isSorted ? clusterTooltipSort.sortDirection : false} />
+    </button>
+  )
+}
+
+export function getWeekFromPayload(payload: { week: string | number }) {
+  return formatDateBiweekly(Number(payload.week))
+}
+
+export const FREQUENCY_DISPLAY_THRESHOLD = 1e-2

--- a/web/src/components/Common/tooltip/TooltipTable.tsx
+++ b/web/src/components/Common/tooltip/TooltipTable.tsx
@@ -1,0 +1,68 @@
+import { flexRender, Header } from '@tanstack/react-table'
+import React from 'react'
+import type { Table } from '@tanstack/table-core'
+import { SortingIndicator } from 'src/components/Common/table/SortingIndicator'
+
+export function TooltipTable({
+  table,
+  caption,
+}: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  table: Table<any>
+  caption?: string
+}) {
+  return (
+    <table className={'table table-striped table-sm small mb-0'}>
+      {caption && <caption>{caption}</caption>}
+      <thead>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <React.Fragment key={headerGroup.id}>
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <th key={header.id}>
+                  <div className={'d-flex justify-content-between text-nowrap gap-2'}>
+                    <HeaderText header={header} />
+                    <SortingIndicator sorted={header.column.getIsSorted()} />
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </React.Fragment>
+        ))}
+      </thead>
+      <tbody>
+        {table.getRowModel().rows.map((row) => (
+          <tr key={row.id}>
+            {row.getVisibleCells().map((cell) => (
+              <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
+            ))}
+          </tr>
+        ))}
+        {table.getRowModel().rows.length === 0 && (
+          <tr>
+            <td colSpan={table.getVisibleFlatColumns().length} className={'p-2 small'}>
+              No data
+            </td>
+          </tr>
+        )}
+      </tbody>
+      {table.getFooterGroups().length > 0 && (
+        <tfoot>
+          {table.getFooterGroups().map((footerGroup) => (
+            <tr key={footerGroup.id}>
+              {footerGroup.headers.map((header) => (
+                <th key={header.id}>
+                  {header.isPlaceholder ? null : flexRender(header.column.columnDef.footer, header.getContext())}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </tfoot>
+      )}
+    </table>
+  )
+}
+
+function HeaderText({ header }: { header: Header<unknown, unknown> }) {
+  return <>{header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}</>
+}

--- a/web/src/components/CountryDistribution/CountryDistribution.tsx
+++ b/web/src/components/CountryDistribution/CountryDistribution.tsx
@@ -1,5 +1,4 @@
 import React, { Suspense, useMemo } from 'react'
-import { Col, Row } from 'reactstrap'
 import { ErrorBoundary } from 'react-error-boundary'
 import { useRecoilState, useRecoilValue } from 'recoil'
 import { MdxContent } from 'src/i18n/getMdxContent'
@@ -24,6 +23,8 @@ import { perCountryDataIntroContentFilenameSelector } from 'src/state/PerCountry
 import { REGIONS } from 'src/state/Places'
 import { clusterSidebarCollapsedAtoms, countriesSidebarCollapsedAtoms } from 'src/state/DistributionSidebar'
 import { updateUrlOnMismatch } from 'src/state/Clusters'
+import { TooltipConfig } from 'src/components/Common/tooltip/Tooltip'
+import { CountryDistributionPlotTooltipId } from 'src/components/CountryDistribution/CountryDistributionPlotTooltip'
 
 export function CountryDistribution() {
   const { t } = useTranslationSafe()
@@ -49,6 +50,7 @@ export function CountryDistribution() {
 }
 
 const enabledFilters = ['clusters', 'countriesWithIcons']
+const tooltipColumns = ['cluster', 'estimatedCases', 'frequency']
 
 function CountryDistributionPlotSection() {
   const { t } = useTranslationSafe()
@@ -88,7 +90,10 @@ function CountryDistributionPlotSection() {
         />
       </SidebarFlex>
 
-      <MainFlex>
+      <MainFlex className={'d-flex flex-column gap-2'}>
+        <div className={'sticky-top'}>
+          <TooltipConfig columns={tooltipColumns} tooltipId={CountryDistributionPlotTooltipId} />
+        </div>
         <ErrorBoundary FallbackComponent={FetchError}>
           <Suspense fallback={LOADING}>
             <CountryDistributionComponents

--- a/web/src/components/CountryDistribution/CountryDistribution.tsx
+++ b/web/src/components/CountryDistribution/CountryDistribution.tsx
@@ -71,7 +71,7 @@ function CountryDistributionPlotSection() {
   }, [region])
 
   return (
-    <WrapperFlex>
+    <WrapperFlex className={'gap-2'}>
       <SidebarFlex>
         <DistributionSidebar
           countries={countries}
@@ -89,20 +89,16 @@ function CountryDistributionPlotSection() {
       </SidebarFlex>
 
       <MainFlex>
-        <Row className={'gx-0'}>
-          <Col>
-            <ErrorBoundary FallbackComponent={FetchError}>
-              <Suspense fallback={LOADING}>
-                <CountryDistributionComponents
-                  countries={countries}
-                  clusters={clusters}
-                  region={region}
-                  iconComponent={iconComponent}
-                />
-              </Suspense>
-            </ErrorBoundary>
-          </Col>
-        </Row>
+        <ErrorBoundary FallbackComponent={FetchError}>
+          <Suspense fallback={LOADING}>
+            <CountryDistributionComponents
+              countries={countries}
+              clusters={clusters}
+              region={region}
+              iconComponent={iconComponent}
+            />
+          </Suspense>
+        </ErrorBoundary>
       </MainFlex>
     </WrapperFlex>
   )

--- a/web/src/components/CountryDistribution/CountryDistribution.tsx
+++ b/web/src/components/CountryDistribution/CountryDistribution.tsx
@@ -50,7 +50,7 @@ export function CountryDistribution() {
 }
 
 const enabledFilters = ['clusters', 'countriesWithIcons']
-const tooltipColumns = ['cluster', 'estimatedCases', 'frequency']
+const tooltipColumns = ['cluster', 'sequences', 'frequency']
 
 function CountryDistributionPlotSection() {
   const { t } = useTranslationSafe()

--- a/web/src/components/CountryDistribution/CountryDistributionComponents.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionComponents.tsx
@@ -39,7 +39,7 @@ export function CountryDistributionComponents({
     [enabledClusters, withClustersFiltered, iconComponent],
   )
 
-  return <Row className={'gx-0'}>{countryDistributionComponents}</Row>
+  return <Row className={'g-2'}>{countryDistributionComponents}</Row>
 }
 
 export interface ClusterDistributionComponentsProps {

--- a/web/src/components/CountryDistribution/CountryDistributionPlotCard.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlotCard.tsx
@@ -36,7 +36,7 @@ export function CountryDistributionPlotCard({
   const { t } = useTranslationSafe()
 
   return (
-    <Card className="m-2">
+    <Card>
       <CardHeader className="d-flex flex-sm-column">
         <PlotCardTitle>
           <FlagAlignment>

--- a/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
@@ -3,18 +3,15 @@ import { Props as DefaultTooltipContentProps } from 'recharts/types/component/De
 
 import { useRecoilValue } from 'recoil'
 import { useReactTable } from '@tanstack/react-table'
-import { getCoreRowModel, getFilteredRowModel, getSortedRowModel } from '@tanstack/table-core'
-import {
-  getRowDataFromPayload,
-  tooltipTableEstimatedCasesColumn,
-  tooltipTableFrequencyColumn,
-  tooltipTableVariantColumn,
-} from '../Cases/CasesPlotTooltip'
+import { createColumnHelper, getCoreRowModel, getFilteredRowModel, getSortedRowModel } from '@tanstack/table-core'
 import { clusterDisplayNameToLineagesMapSelector, getClusterColorsSelector } from 'src/state/Clusters'
 import { enablePangolinAtom } from 'src/state/Nomenclature'
 import { FREQUENCY_DISPLAY_THRESHOLD, getWeekFromPayload, Tooltip } from 'src/components/Common/tooltip/Tooltip'
 import { tooltipSortAtomFamily } from 'src/state/TooltipSort'
 import { TooltipTable } from 'src/components/Common/tooltip/TooltipTable'
+import { formatProportion } from 'src/helpers/format'
+import { ColoredBox } from 'src/components/Common/ColoredBox'
+import { ClusterNameText } from 'src/components/Cases/CasesPlotTooltip'
 
 type Payload = { total: number; week: number } & Record<string, number>
 
@@ -57,7 +54,7 @@ function TooltipInner({ rawData }: { rawData: Payload }) {
         enablePangolin,
         pangoLineagesMap,
       }),
-      tooltipTableEstimatedCasesColumn(),
+      tooltipTableNumberOfSequencesColumn(),
       tooltipTableFrequencyColumn(),
     ],
     getCoreRowModel: getCoreRowModel(),
@@ -79,4 +76,101 @@ function TooltipInner({ rawData }: { rawData: Payload }) {
       <TooltipTable table={table} />
     </Tooltip>
   )
+}
+
+export interface CountryDistributionTooltipRow {
+  cluster: string
+  frequency: number | undefined
+  sequences: number | undefined
+}
+
+function getRowDataFromPayload(payload: Payload) {
+  const keys = Object.keys(payload).filter((key) => key !== 'total' && key !== 'week')
+  return keys.map((key) => {
+    const numberOfSequences = payload[key]
+    return {
+      cluster: key,
+      frequency: numberOfSequences === undefined ? undefined : numberOfSequences / payload.total,
+      sequences: numberOfSequences,
+    }
+  })
+}
+
+function tooltipTableFrequencyColumn() {
+  const columnHelper = createColumnHelper<CountryDistributionTooltipRow>()
+
+  return columnHelper.accessor('frequency', {
+    header: 'Frequency',
+    cell: ({ getValue }) => {
+      const frequency = getValue()
+      return <span>{formatProportion(frequency ?? 0)}</span>
+    },
+    sortingFn: 'basic',
+    filterFn: (row, columnId, value) => {
+      const frequency = row.getValue(columnId)
+      return typeof frequency === 'number' && frequency > value
+    },
+    footer: '1',
+  })
+}
+
+export function tooltipTableVariantColumn({
+  getClusterColor,
+  enablePangolin,
+  pangoLineagesMap,
+}: {
+  getClusterColor: (clusterName: string) => string
+  enablePangolin: boolean
+  pangoLineagesMap: Map<string, string[]>
+}) {
+  const columnHelper = createColumnHelper<CountryDistributionTooltipRow>()
+
+  return columnHelper.accessor('cluster', {
+    header: 'Cluster',
+    cell: ({ getValue }) => {
+      const variant = getValue()
+      return (
+        <div className="text-left">
+          <ColoredBox $color={getClusterColor(variant ?? '')} $size={10} $aspect={1.66} />
+          <ClusterNameText>
+            {enablePangolin ? ((variant && pangoLineagesMap.get(variant)?.join(', ')) ?? variant) : variant}
+          </ClusterNameText>
+        </div>
+      )
+    },
+    sortingFn: (rowA, rowB) => {
+      const clusterA = String(rowA.original.cluster)
+      const clusterB = String(rowB.original.cluster)
+
+      const aCluster = enablePangolin
+        ? ((clusterA && pangoLineagesMap.get(clusterA)?.join(', ')) ?? clusterA)
+        : clusterA
+      const bCluster = enablePangolin
+        ? ((clusterB && pangoLineagesMap.get(clusterB)?.join(', ')) ?? clusterB)
+        : clusterB
+
+      return aCluster.localeCompare(bCluster)
+    },
+    invertSorting: true, // Invert sorting to start with letter A on ascending sort
+    footer: 'Total',
+  })
+}
+
+export function tooltipTableNumberOfSequencesColumn() {
+  const columnHelper = createColumnHelper<CountryDistributionTooltipRow>()
+
+  return columnHelper.accessor('sequences', {
+    header: 'Sequences',
+    cell: ({ getValue }) => {
+      const nSequences = getValue()
+      return <span>{nSequences}</span>
+    },
+    sortingFn: 'basic',
+    footer: ({ table }) => {
+      return table.getFilteredRowModel().rows.reduce((sum, row) => {
+        const value = row.getValue('sequences')
+        return sum + (typeof value === 'number' ? value : 0)
+      }, 0)
+    },
+  })
 }

--- a/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
+++ b/web/src/components/CountryDistribution/CountryDistributionPlotTooltip.tsx
@@ -1,112 +1,82 @@
-import React from 'react'
-
-import { sortBy, reverse } from 'lodash'
-import { styled } from 'styled-components'
+import React, { useMemo } from 'react'
 import { Props as DefaultTooltipContentProps } from 'recharts/types/component/DefaultTooltipContent'
 
 import { useRecoilValue } from 'recoil'
-import { ColoredBox } from '../Common/ColoredBox'
-import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
-import { formatDateBiweekly, formatInteger, formatProportion } from 'src/helpers/format'
-import { clusterDisplayNameToLineageMapSelector, getClusterColorsSelector } from 'src/state/Clusters'
+import { useReactTable } from '@tanstack/react-table'
+import { getCoreRowModel, getFilteredRowModel, getSortedRowModel } from '@tanstack/table-core'
+import {
+  getRowDataFromPayload,
+  tooltipTableEstimatedCasesColumn,
+  tooltipTableFrequencyColumn,
+  tooltipTableVariantColumn,
+} from '../Cases/CasesPlotTooltip'
+import { clusterDisplayNameToLineagesMapSelector, getClusterColorsSelector } from 'src/state/Clusters'
 import { enablePangolinAtom } from 'src/state/Nomenclature'
+import { FREQUENCY_DISPLAY_THRESHOLD, getWeekFromPayload, Tooltip } from 'src/components/Common/tooltip/Tooltip'
+import { tooltipSortAtomFamily } from 'src/state/TooltipSort'
+import { TooltipTable } from 'src/components/Common/tooltip/TooltipTable'
+
+type Payload = { total: number; week: number } & Record<string, number>
+
+export const CountryDistributionPlotTooltipId = 'countryDistribution'
 
 export function CountryDistributionPlotTooltip(props: DefaultTooltipContentProps<number, string>) {
-  const { t } = useTranslationSafe()
-  const getClusterColor = useRecoilValue(getClusterColorsSelector)
-  const enablePangolin = useRecoilValue(enablePangolinAtom)
-  const pangoLineageMap = useRecoilValue(clusterDisplayNameToLineageMapSelector)
+  const data = props.payload?.[0]?.payload as Payload | undefined
 
-  const { payload } = props
-  if (!payload || payload.length === 0) {
+  if (!data) {
     return null
   }
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-argument
-  const week = formatDateBiweekly(payload[0]?.payload.week)
+  return <TooltipInner rawData={data} />
+}
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-argument
-  const total: number = formatInteger(payload[0]?.payload.total ?? 0)
+function TooltipInner({ rawData }: { rawData: Payload }) {
+  const getClusterColor = useRecoilValue(getClusterColorsSelector)
+  const enablePangolin = useRecoilValue(enablePangolinAtom)
+  const pangoLineagesMap = useRecoilValue(clusterDisplayNameToLineagesMapSelector)
 
-  const payloadSorted = reverse(sortBy(payload, 'value'))
-  const payloadNonZero = payloadSorted.filter((pld) => pld.value !== undefined && pld.value > EPSILON)
+  const data = useMemo(() => getRowDataFromPayload(rawData), [rawData])
+  const week = useMemo(() => getWeekFromPayload(rawData), [rawData])
+
+  const { column: sortingColumn, sortDirection } = useRecoilValue(
+    tooltipSortAtomFamily(CountryDistributionPlotTooltipId),
+  )
+
+  const sorting = useMemo(() => {
+    return {
+      id: sortingColumn,
+      desc: sortDirection === 'desc',
+    }
+  }, [sortDirection, sortingColumn])
+
+  const table = useReactTable({
+    data,
+    columns: [
+      tooltipTableVariantColumn({
+        getClusterColor,
+        enablePangolin,
+        pangoLineagesMap,
+      }),
+      tooltipTableEstimatedCasesColumn(),
+      tooltipTableFrequencyColumn(),
+    ],
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    initialState: {
+      sorting: [sorting],
+      columnFilters: [
+        {
+          id: 'frequency',
+          value: FREQUENCY_DISPLAY_THRESHOLD,
+        },
+      ],
+    },
+  })
 
   return (
-    <Tooltip>
-      <TooltipTitle>{week}</TooltipTitle>
-
-      <TooltipTable>
-        <thead>
-          <tr className="w-100">
-            <th className="px-2 text-left">{t('Variant')}</th>
-            <th className="px-2 text-right">{t('Num seq')}</th>
-            <th className="px-2 text-right">{t('Freq')}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {payloadNonZero.map(({ name, value }) => (
-            <tr key={name}>
-              <td className="px-2 text-left">
-                <ColoredBox $color={getClusterColor(name ?? '')} $size={10} $aspect={1.66} />
-                <ClusterNameText>
-                  {enablePangolin ? ((name && pangoLineageMap.get(name)) ?? name) : name}
-                </ClusterNameText>
-              </td>
-              <td className="px-2 text-right">{value !== undefined && value > EPSILON ? formatInteger(value) : '-'}</td>
-              <td className="px-2 text-right">
-                {value !== undefined && value > EPSILON ? formatProportion(value / total) : '-'}
-              </td>
-            </tr>
-          ))}
-
-          <tr>
-            <td className="px-2 text-left">
-              <span>
-                <b>{t('Total')}</b>
-              </span>
-            </td>
-            <td className="px-2 text-right">{total}</td>
-            <td className="px-2 text-right">{'1.00'}</td>
-          </tr>
-        </tbody>
-      </TooltipTable>
+    <Tooltip title={week}>
+      <TooltipTable table={table} />
     </Tooltip>
   )
 }
-
-const EPSILON = 1e-2
-
-const Tooltip = styled.div`
-  display: flex;
-  flex-direction: column;
-
-  padding: 5px 10px;
-  background-color: ${(props) => props.theme.gray100};
-  box-shadow: ${(props) => props.theme.shadows.slight};
-  border-radius: 3px;
-`
-
-const TooltipTitle = styled.h1`
-  font-size: 1rem;
-  margin: 5px auto;
-  font-weight: 600;
-`
-
-const TooltipTable = styled.table`
-  padding: 30px 35px;
-  font-size: 0.9rem;
-  border: none;
-  min-width: 250px;
-
-  & > tbody > tr:nth-child(odd) {
-    background-color: ${(props) => props.theme.gray200};
-  }
-`
-
-export const ClusterNameText = styled.span`
-  font-family: ${(props) => props.theme.font.monospace};
-`

--- a/web/src/components/DistributionSidebar/ClusterFilters.tsx
+++ b/web/src/components/DistributionSidebar/ClusterFilters.tsx
@@ -32,7 +32,7 @@ export function ClusterFilters({
   const [collapsed, setCollapsed] = useAtom(collapsedAtom)
 
   return (
-    <CardCollapsible className="m-2" title={t('Variants')} collapsed={collapsed} setCollapsed={setCollapsed}>
+    <CardCollapsible title={t('Variants')} collapsed={collapsed} setCollapsed={setCollapsed}>
       <CardBody>
         <Container fluid>
           <Row className={'gx-0'}>

--- a/web/src/components/DistributionSidebar/CountryFilters.tsx
+++ b/web/src/components/DistributionSidebar/CountryFilters.tsx
@@ -168,7 +168,7 @@ export function CountryFilters({
   )
 
   return (
-    <CardCollapsible className="m-2" title={regionsTitle} collapsed={collapsed} setCollapsed={setCollapsed}>
+    <CardCollapsible title={regionsTitle} collapsed={collapsed} setCollapsed={setCollapsed}>
       <CardBody>
         <Container fluid>
           <Row className={'gx-0'}>

--- a/web/src/components/DistributionSidebar/DistributionSidebar.tsx
+++ b/web/src/components/DistributionSidebar/DistributionSidebar.tsx
@@ -136,7 +136,9 @@ export function DistributionSidebar({
 
   return (
     <Row className={'gx-0'}>
-      <Col>{enabledFilters.map((filterName) => get(availableFilters, filterName))}</Col>
+      <Col className="gap-2 flex-column d-flex">
+        {enabledFilters.map((filterName) => get(availableFilters, filterName))}
+      </Col>
     </Row>
   )
 }

--- a/web/src/state/CountryStyles.ts
+++ b/web/src/state/CountryStyles.ts
@@ -4,7 +4,7 @@ import { atomAsync } from 'src/state/utils/atomAsync'
 import { fetchCountryStyles } from 'src/io/getCountryColor'
 import { lineStyleToStrokeDashArray } from 'src/helpers/lineStyleToStrokeDashArray'
 
-interface CountryStyle {
+export interface CountryStyle {
   color: string
   lineStyle: string
   strokeDashArray: string | undefined

--- a/web/src/state/TooltipSort.ts
+++ b/web/src/state/TooltipSort.ts
@@ -1,14 +1,10 @@
-import { atom } from 'recoil'
+import { atomFamily } from 'recoil'
+import { SortDirection } from '@tanstack/react-table'
 
-export enum TooltipSortCriterion {
-  country = 'country',
-  frequency = 'frequency',
-}
-
-export const tooltipSortAtom = atom({
-  key: 'TooltipSort',
+export const tooltipSortAtomFamily = atomFamily<{ column: string; sortDirection: SortDirection }, string>({
+  key: 'TooltipSortAtomFamily',
   default: {
-    criterion: TooltipSortCriterion.frequency,
-    reversed: false,
+    column: 'frequency',
+    sortDirection: 'desc',
   },
 })

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -4919,6 +4919,18 @@
   dependencies:
     "@tanstack/query-core" "5.62.0"
 
+"@tanstack/react-table@8.21.3":
+  version "8.21.3"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.21.3.tgz#2c38c747a5731c1a07174fda764b9c2b1fb5e91b"
+  integrity sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==
+  dependencies:
+    "@tanstack/table-core" "8.21.3"
+
+"@tanstack/table-core@8.21.3":
+  version "8.21.3"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.21.3.tgz#2977727d8fc8dfa079112d9f4d4c019110f1732c"
+  integrity sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==
+
 "@testing-library/dom@10.4.0", "@testing-library/dom@^10.0.0":
   version "10.4.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.0.tgz#82a9d9462f11d240ecadbf406607c6ceeeff43a8"
@@ -7314,12 +7326,7 @@ camelize@^1.0.0:
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.1.tgz#89b7e16884056331a35d6b5ad064332c91daa6c3"
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
-caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001669:
-  version "1.0.30001713"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz"
-  integrity sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==
-
-caniuse-lite@^1.0.30001688:
+caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001669, caniuse-lite@^1.0.30001688:
   version "1.0.30001713"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz"
   integrity sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==


### PR DESCRIPTION
Resolves #28, #367
- allows users to select the sorting direction above the plots
- uses tanstack table for sorting and filtering instead of custom solution
- slighly changes the design of the tooltip, so all three pages use the same design

![grafik](https://github.com/user-attachments/assets/65d23996-516f-4937-9fb6-468c6e2b2fd4)
